### PR TITLE
Avoid -g flag to ctfconvert on later versions that no longer support it.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -53,6 +53,17 @@ MAPFLAGS=@MAPFLAGS@
 CTFCONVERT=@CTFCONVERT@
 CTFMERGE=@CTFMERGE@
 
+# Later versions of ctfconvert no longer have -g and by default do not strip,
+# so we get the same behavior as with -g on older versions.
+ifneq ($(wildcard $(CTFCONVERT)),)
+  HAS_G=$(shell $(CTFCONVERT) 2>&1 | grep -- -gis)
+  ifneq ($(HAS_G),)
+    CTFNOSTRIP=-g
+  else
+    CTFNOSTRIP=
+  endif
+endif
+
 WHOLE_ARCHIVE=@WHOLE_ARCHIVE@
 NOWHOLE_ARCHIVE=@NOWHOLE_ARCHIVE@
 
@@ -138,7 +149,7 @@ libmtev-objs/%.lo:	%.lo
 	$(Q)cp $(@:libmtev-objs/%.lo=%.lo) $@
 	$(Q)if test -x "$(CTFCONVERT)" ; then \
 		echo "- making CTF ($@)" ; \
-		$(CTFCONVERT) -g -i -l @VERSION@ $@ ; \
+		$(CTFCONVERT) $(CTFNOSTRIP) -i -l @VERSION@ $@ ; \
 	fi
 
 make-man:


### PR DESCRIPTION
This fixes the build on OmniOS r151014, which includes the updated CTF tools.

Reference: http://www.listbox.com/member/archive/182179/2015/02/sort/time_rev/page/1/entry/12:464/20150226142813:98EC219A-BDED-11E4-83DC-D39EC66174FC/