### PR TITLE
Removes zipkin annotation.duration

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -505,7 +505,7 @@ begin_span(mtev_http_session_ctx *ctx) {
     mtev_zipkin_span_new(trace_id, parent_span_id, span_id,
                          req->uri_str, false, NULL, sampled);
   set_endpoint(ctx);
-  mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, ZIPKIN_SERVER_RECV, false, NULL);
+  mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, ZIPKIN_SERVER_RECV, false);
   mtev_zipkin_span_bannotate(ctx->zipkin_span, ZIPKIN_STRING,
                              zipkin_http_method, false,
                              req->method_str, strlen(req->method_str), false);
@@ -518,7 +518,6 @@ begin_span(mtev_http_session_ctx *ctx) {
 }
 static void
 end_span(mtev_http_session_ctx *ctx) {
-  uint32_t _duration, *duration = NULL;
   mtev_http_request *req = &ctx->req;
   mtev_http_response *res = &ctx->res;
   mtev_hrtime_t now;
@@ -542,7 +541,7 @@ end_span(mtev_http_session_ctx *ctx) {
                              zipkin_http_bytes_out, false,
                              &nbytesout, 8, false);
   
-  mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, zipkin_ss_done, false, NULL);
+  mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, zipkin_ss_done, false);
   mtev_zipkin_span_publish(ctx->zipkin_span);
   ctx->zipkin_span = NULL;
 }
@@ -1679,7 +1678,7 @@ _mtev_http_response_flush(mtev_http_session_ctx *ctx,
   if(ctx->res.output_started == mtev_false) {
     _http_construct_leader(ctx);
     ctx->res.output_started = mtev_true;
-    mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, ZIPKIN_SERVER_SEND, false, NULL);
+    mtev_zipkin_span_annotate(ctx->zipkin_span, NULL, ZIPKIN_SERVER_SEND, false);
   }
   /* encode output to output_raw */
   r = ctx->res.output_raw_last;

--- a/src/utils/mtev_zipkin.c
+++ b/src/utils/mtev_zipkin.c
@@ -204,12 +204,6 @@ ze_Zipkin_Annotation(byte *buffer, size_t len, Zipkin_Annotation *v) {
       ADV_SAFE(ze_field_end(buffer,len));
     }
 
-    if(v->duration) {
-      ADV_SAFE(ze_field_begin(buffer,len,"duration",ZE_I32,4));
-      ADV_SAFE(ze_i32(buffer,len,*v->duration));
-      ADV_SAFE(ze_field_end(buffer,len));
-    }
-
     ADV_SAFE(ze_field_stop(buffer,len));
   ADV_SAFE(ze_struct_end(buffer,len));
   return sofar;
@@ -520,7 +514,7 @@ mtev_zipkin_span_default_endpoint(Zipkin_Span *span, const char *service_name,
 
 Zipkin_Annotation *
 mtev_zipkin_span_annotate(Zipkin_Span *span, int64_t *timestamp,
-                          const char *value, bool value_copy, int32_t *duration) {
+                          const char *value, bool value_copy) {
   Zipkin_List_Zipkin_Annotation *node;
   Zipkin_Annotation *a;
   int64_t now;
@@ -541,11 +535,6 @@ mtev_zipkin_span_annotate(Zipkin_Span *span, int64_t *timestamp,
   a->value.needs_free = value_copy;
   a->value.value = value_copy ? strdup(value) : (char *)value;
   a->host = &span->_default_host;
-
-  if(duration) {
-    a->_duration = *duration;
-    a->duration = &a->_duration;
-  }
 
   node->next = span->annotations;
   span->annotations = node;

--- a/src/utils/mtev_zipkin.h
+++ b/src/utils/mtev_zipkin.h
@@ -96,8 +96,6 @@ typedef struct {
   Zipkin_String value;
   Zipkin_Endpoint *host;
   Zipkin_Endpoint _host;
-  int32_t *duration;
-  int32_t _duration;
 } Zipkin_Annotation;
 
 typedef struct {
@@ -206,13 +204,12 @@ API_EXPORT(void)
   mtev_zipkin_span_default_endpoint(Zipkin_Span *, const char *, bool,
                                     struct in_addr, unsigned short);
 
-/*! \fn Zipkin_Annotation * mtev_zipkin_span_annotate(Zipkin_Span *span, int64_t *timestamp, const char *value, bool value_copy, int32_t *duration)
+/*! \fn Zipkin_Annotation * mtev_zipkin_span_annotate(Zipkin_Span *span, int64_t *timestamp, const char *value, bool value_copy)
     \brief Annotate a span.
     \param span The span to annotate.
     \param timestamp A pointer the number of microseconds since epoch. NULL means now.
     \param value The annotation value itself.
     \param value_copy Whether value should be allocated (copied) within the span.
-    \param duration A pointer to the number of microseconds elapsed. NULL allowed (recommended).
     \return A new annotation.
 
     mtev_zipkin_span_annotate make an annotation on the provided span.  The returned resource is managed by the span and will be released with it.


### PR DESCRIPTION
This removes the troublesome annotation.duration field, which has also
be removed upstream in zipkin.

See https://github.com/openzipkin/zipkin/pull/717