### PR TITLE
fix multiple definition error of eventer_err and _deb log streams.

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -31,13 +31,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#define _EVENTER_C_
 #include "eventer/eventer.h"
 #include "mtev_hash.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+
+eventer_impl_t __eventer;
+mtev_log_stream_t eventer_err;
+mtev_log_stream_t eventer_deb;
 
 eventer_t eventer_alloc() {
   eventer_t e;

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -141,13 +141,9 @@ typedef struct _eventer_impl {
   }                 *master_fds;
 } *eventer_impl_t;
 
-/* This is the "chosen one" */
-#ifndef _EVENTER_C
-extern
-#endif
-eventer_impl_t __eventer;
-mtev_log_stream_t eventer_err;
-mtev_log_stream_t eventer_deb;
+extern eventer_impl_t __eventer;
+extern mtev_log_stream_t eventer_err;
+extern mtev_log_stream_t eventer_deb;
 
 API_EXPORT(int) eventer_choose(const char *name);
 API_EXPORT(void) eventer_loop();


### PR DESCRIPTION
Get rid of _EVENTER_C conditional #define, just declare all global
variables from eventer.h as extern, and rely on a .c file to
actually define the values. The old scheme was not universally
applied to all globals exposed by the header file, resulting in
duplicate symbol errors in which these symbols could be multiply
defined.