### PR TITLE
add mtev_b<32|64>_<max_de|en>code_len functions and tests.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -5,7 +5,7 @@ ifeq ($(V),)
 	Q=@
 endif
 
-LIBMTEV_VERSION=0.0.5
+LIBMTEV_VERSION=0.0.6
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@

--- a/src/utils/mtev_b32.c
+++ b/src/utils/mtev_b32.c
@@ -97,13 +97,18 @@ mtev_b32_decode(const char *src, size_t src_len,
   return dcp - (unsigned char *)dest;
 }
 
+size_t
+mtev_b32_max_decode_len(size_t src_len) {
+  return (src_len / 8) * 5;
+}
+
 int
 mtev_b32_encode(const unsigned char *src, size_t src_len,
                 char *dest, size_t dest_len) {
   const unsigned char *bptr = src;
   char *eptr = dest;
   int len = src_len;
-  int i, n = (((src_len + 4) / 5) * 8) + 1;
+  int i, n = ((src_len + 4) / 5) * 8;
 
   if(dest_len < n) return 0;
 
@@ -151,8 +156,11 @@ mtev_b32_encode(const unsigned char *src, size_t src_len,
         }
       }
     }
-    *eptr++ = '=';
   }
   return (eptr - dest);
 }
 
+size_t
+mtev_b32_encode_len(size_t src_len) {
+  return ((src_len + 4) / 5) * 8;
+}

--- a/src/utils/mtev_b32.h
+++ b/src/utils/mtev_b32.h
@@ -53,6 +53,12 @@
     mtev_b32_decode decodes input until an the entire input is consumed or until an invalid base32 character is encountered.
  */
 API_EXPORT(int) mtev_b32_decode(const char *, size_t, unsigned char *, size_t);
+/*! \fn size_t mtev_b32_decode_len(size_t src_len)
+    \brief Calculate how large a buffer must be to contain a decoded base-32-encoded string of a given length.
+    \param src_len The size (in bytes) of the base-32-encoded string that might be decoded.
+    \return The size of the buffer that would be needed to decode the input string.
+ */
+API_EXPORT(size_t) mtev_b32_max_decode_len(size_t);
 /*! \fn int mtev_b32_encode(const unsigned char *src, size_t src_len, char *dest, size_t dest_len)
     \brief Encode raw data as base32 encoded output into the provided buffer.
     \param src The buffer containing the raw data.
@@ -62,5 +68,11 @@ API_EXPORT(int) mtev_b32_decode(const char *, size_t, unsigned char *, size_t);
     \return The size of the encoded output.  Returns zero is out_sz is too small.
  */
 API_EXPORT(int) mtev_b32_encode(const unsigned char *, size_t, char *, size_t);
+/*! \fn size_t mtev_b32_encode_len(size_t src_len)
+    \brief Calculate how large a buffer must be to contain the base-32 encoding for a given number of bytes.
+    \param src_len The size (in bytes) of the raw data buffer that might be encoded.
+    \return The size of the buffer that would be needed to store an encoded version of an input string.
+ */
+API_EXPORT(size_t) mtev_b32_encode_len(size_t);
 
 #endif

--- a/src/utils/mtev_b64.c
+++ b/src/utils/mtev_b64.c
@@ -80,6 +80,11 @@ mtev_b64_decode(const char *src, size_t src_len,
   return dcp - (unsigned char *)dest;
 }
 
+size_t
+mtev_b64_max_decode_len(size_t src_len) {
+  return (src_len / 4) * 3;
+}
+
 int
 mtev_b64_encode(const unsigned char *src, size_t src_len,
                 char *dest, size_t dest_len) {
@@ -113,3 +118,7 @@ mtev_b64_encode(const unsigned char *src, size_t src_len,
   return n;
 }
 
+size_t
+mtev_b64_encode_len(size_t src_len) {
+  return 4 * ((src_len+2)/3);
+}

--- a/src/utils/mtev_b64.h
+++ b/src/utils/mtev_b64.h
@@ -53,6 +53,12 @@
     mtev_b64_decode decodes input until an the entire input is consumed or until an invalid base64 character is encountered.
  */
 API_EXPORT(int) mtev_b64_decode(const char *, size_t, unsigned char *, size_t);
+/*! \fn size_t mtev_b64_max_decode_len(size_t src_len)
+    \brief Calculate how large a buffer must be to contain a decoded base-64-encoded string of a given length.
+    \param src_len The size (in bytes) of the base-64-encoded string that might be decoded.
+    \return The size of the buffer that would be needed to decode the input string.
+ */
+API_EXPORT(size_t) mtev_b64_max_decode_len(size_t);
 /*! \fn int mtev_b64_encode(const unsigned char *src, size_t src_len, char *dest, size_t dest_len)
     \brief Encode raw data as base64 encoded output into the provided buffer.
     \param src The buffer containing the raw data.
@@ -64,5 +70,11 @@ API_EXPORT(int) mtev_b64_decode(const char *, size_t, unsigned char *, size_t);
     mtev_b64_encode encodes an input string into a base64 representation with no linefeeds.
  */
 API_EXPORT(int) mtev_b64_encode(const unsigned char *, size_t, char *, size_t);
+/*! \fn size_t mtev_b64_encode_len(size_t src_len)
+    \brief Calculate how large a buffer must be to contain the base-64 encoding for a given number of bytes.
+    \param src_len The size (in bytes) of the raw data buffer that might be encoded.
+    \return The size of the buffer that would be needed to store an encoded version of an input string.
+ */
+API_EXPORT(size_t) mtev_b64_encode_len(size_t);
 
 #endif

--- a/test/utils/b32_spec.lua
+++ b/test/utils/b32_spec.lua
@@ -1,6 +1,8 @@
 ffi.cdef([=[
   int mtev_b32_decode(const char *, size_t, unsigned char *, size_t);
   int mtev_b32_encode(const unsigned char *, size_t, char *, size_t);
+  size_t mtev_b32_max_decode_len(size_t);
+  size_t mtev_b32_encode_len(size_t);
 ]=])
 
 describe("mtev_b32", function()
@@ -15,10 +17,16 @@ describe("mtev_b32", function()
     local buf2 = charstar(1001)
     for i=1,1000 do
       str = str .. "x"
-     
-      local rv = mtev.mtev_b32_encode(str, string.len(str), buf, 1608)
+
+      local str_len = string.len(str)
+      local encode_len = mtev.mtev_b32_encode_len(str_len)
+      local rv = mtev.mtev_b32_encode(str, str_len, buf, encode_len)
       assert.is_true(rv > 0 and rv <= 1608)
-      local rv = mtev.mtev_b32_decode(buf, rv, buf2, 1001)
+      assert.are.equal(rv, encode_len)
+
+      local decode_len = mtev.mtev_b32_max_decode_len(encode_len)
+      assert.is_true(str_len <= decode_len)
+      local rv = mtev.mtev_b32_decode(buf, rv, buf2, decode_len)
       assert.are.equal(rv, i)
       assert.are.equal(str, ffi.string(buf2, rv))
     end
@@ -26,18 +34,21 @@ describe("mtev_b32", function()
 
   it("encode to short buffer", function()
     local str = "This is a string"
-    local buf_too_small = charstar(10)
-    local rv = mtev.mtev_b32_encode(str, string.len(str), buf_too_small, 10)
+    local encode_len = tonumber(mtev.mtev_b32_encode_len(string.len(str)))
+    local buf_too_small = charstar(encode_len)
+    local rv = mtev.mtev_b32_encode(str, string.len(str), buf_too_small, encode_len-1)
     assert.is_true(rv == 0)
   end)
 
   it("decode to short buffer", function()
-    local str = "KRUGS4ZANFZSAYJAON2HE2LOM4======="
+    local str = "KRUGS4ZANFZSAYJAON2HE2LOM4======"
     local buf = charstar(str)
-    local buf_too_small = charstar(20)
-    local rv = mtev.mtev_b32_decode(buf, string.len(str), buf_too_small, 19)
+    local decode_len = tonumber(mtev.mtev_b32_max_decode_len(string.len(str)))
+    assert.are.equal(decode_len, 20)
+    local buf_too_small = charstar(decode_len)
+    local rv = mtev.mtev_b32_decode(buf, string.len(str), buf_too_small, decode_len - 1)
     assert.is_true(rv == 0)
-    local rv = mtev.mtev_b32_decode(buf, string.len(str), buf_too_small, 20)
+    local rv = mtev.mtev_b32_decode(buf, string.len(str), buf_too_small, decode_len)
     assert.are.equal(rv, 16)
   end)
 end)

--- a/test/utils/b64_spec.lua
+++ b/test/utils/b64_spec.lua
@@ -1,6 +1,8 @@
 ffi.cdef([=[
   int mtev_b64_decode(const char *, size_t, unsigned char *, size_t);
   int mtev_b64_encode(const unsigned char *, size_t, char *, size_t);
+  size_t mtev_b64_encode_len(size_t);
+  size_t mtev_b64_max_decode_len(size_t);
 ]=])
 
 describe("mtev_b64", function()
@@ -10,10 +12,16 @@ describe("mtev_b64", function()
     local buf2 = charstar(1001)
     for i=1,1000 do
       str = str .. "x"
-     
-      local rv = mtev.mtev_b64_encode(str, string.len(str), buf, 1600)
+
+      local str_len = string.len(str)
+      local encode_len = mtev.mtev_b64_encode_len(str_len)
+      local rv = mtev.mtev_b64_encode(str, string.len(str), buf, encode_len)
       assert.is_true(rv > 0)
-      local rv = mtev.mtev_b64_decode(buf, rv, buf2, 1001)
+      assert.are.equal(rv, encode_len)
+
+      local decode_len = mtev.mtev_b64_max_decode_len(encode_len)
+      assert.is_true(str_len <= decode_len)
+      local rv = mtev.mtev_b64_decode(buf, rv, buf2, decode_len)
       assert.are.equal(rv, i)
       assert.are.equal(str, ffi.string(buf2, rv))
     end
@@ -21,15 +29,18 @@ describe("mtev_b64", function()
 
   it("encode to short buffer", function()
     local str = "This is a string"
-    local buf_too_small = charstar(10)
-    local rv = mtev.mtev_b64_encode(str, string.len(str), buf_too_small, 10)
+    local encode_len = tonumber(mtev.mtev_b64_encode_len(string.len(str)))
+    local buf_too_small = charstar(encode_len)
+    local rv = mtev.mtev_b64_encode(str, string.len(str), buf_too_small, encode_len-1)
     assert.is_true(rv == 0)
   end)
 
   it("decode to short buffer", function()
     local str = "VGhpcyBpcyBhIHN0cmluZw=="
     local buf = charstar(str)
-    local buf_too_small = charstar(20)
+    local decode_len = tonumber(mtev.mtev_b64_max_decode_len(string.len(str)))
+    assert.are.equal(decode_len,18)
+    local buf_too_small = charstar(decode_len)
     local rv = mtev.mtev_b64_decode(buf, string.len(str), buf_too_small, 15)
     assert.is_true(rv == 0)
     local rv = mtev.mtev_b64_decode(buf, string.len(str), buf_too_small, 16)


### PR DESCRIPTION
Also repair b32 encoding so that the encoded data length is always a
multiple of 8 bytes.
Bump library minor version number, because semver.