### PR TITLE
Mtev skiplist node funcs

### DIFF
--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -229,6 +229,9 @@ void *mtev_skiplist_previous(mtev_skiplist *sl, mtev_skiplist_node **iter) {
   if(!(*iter)->prev) *iter = NULL;
   return (*iter)?((*iter)->data):NULL;
 }
+void *mtev_skiplist_data(mtev_skiplist_node *m) {
+  return m->data;
+}
 mtev_skiplist_node *mtev_skiplist_insert(mtev_skiplist *sl,
                                          const void *data) {
   if(!sl->compare) return 0;

--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -37,6 +37,8 @@ static int mtev_skiplisti_find_compare(mtev_skiplist *sl, const void *data,
                                        mtev_skiplist_node **prev,
                                        mtev_skiplist_node **next,
                                        mtev_skiplist_comparator_t comp);
+int mtev_skiplisti_remove(mtev_skiplist *sl, mtev_skiplist_node *m,
+                          mtev_freefunc_t myfree);
 
 int mtev_compare_voidptr(const void *a, const void *b) {
   if(a < b) return -1;
@@ -317,6 +319,12 @@ int mtev_skiplist_remove(mtev_skiplist *sl,
                          const void *data, mtev_freefunc_t myfree) {
   if(!sl->compare) return 0;
   return mtev_skiplist_remove_compare(sl, data, myfree, sl->comparek);
+}
+int mtev_skiplist_remove_node(mtev_skiplist *sl, mtev_skiplist_node *m,
+                              mtev_freefunc_t myfree) {
+  while(m->previndex) m = m->previndex;
+  assert(sl == m->sl);
+  return mtev_skiplisti_remove(sl, m, myfree);
 }
 int mtev_skiplisti_remove(mtev_skiplist *sl, mtev_skiplist_node *m, mtev_freefunc_t myfree) {
   mtev_skiplist_node *p;

--- a/src/utils/mtev_skiplist.h
+++ b/src/utils/mtev_skiplist.h
@@ -88,8 +88,8 @@ int mtev_skiplist_remove_compare(mtev_skiplist *sl, const void *data,
                                  mtev_skiplist_comparator_t comp);
 int mtev_skiplist_remove(mtev_skiplist *sl, const void *data,
                          mtev_freefunc_t myfree);
-int mtev_skiplisti_remove(mtev_skiplist *sl, mtev_skiplist_node *m,
-                          mtev_freefunc_t myfree);
+int mtev_skiplist_remove_node(mtev_skiplist *sl, mtev_skiplist_node *node,
+                              mtev_freefunc_t myfree);
 void mtev_skiplist_destroy(mtev_skiplist *sl, mtev_freefunc_t myfree);
 
 void *mtev_skiplist_pop(mtev_skiplist * a, mtev_freefunc_t myfree);

--- a/src/utils/mtev_skiplist.h
+++ b/src/utils/mtev_skiplist.h
@@ -78,6 +78,7 @@ void *mtev_skiplist_find_neighbors(mtev_skiplist *sl, const void *data,
                                    mtev_skiplist_node **next);
 void *mtev_skiplist_next(mtev_skiplist *sl, mtev_skiplist_node **);
 void *mtev_skiplist_previous(mtev_skiplist *sl, mtev_skiplist_node **);
+void *mtev_skiplist_data(mtev_skiplist_node *);
 
 mtev_skiplist_node *mtev_skiplist_insert_compare(mtev_skiplist *sl,
                                                  const void *data,


### PR DESCRIPTION
expose "blessed" interface to remove a node from a skiplist.
add `mtev_skiplist_data` accessor function.