### PR TITLE
always name mtev_console structure types.

### DIFF
--- a/src/mtev_console.h
+++ b/src/mtev_console.h
@@ -58,7 +58,7 @@ typedef char *(*console_prompt_func_t)(EditLine *);
 typedef void (*state_free_func_t)(struct _console_state *, struct __mtev_console_closure *);
 typedef void (*state_userdata_free_func_t)(void *);
 
-typedef struct {
+typedef struct _cmd_info_t {
   const char            *name;
   console_cmd_func_t     func;
   console_opt_func_t     autocomplete;
@@ -73,7 +73,7 @@ extern cmd_info_t console_command_crash;
 extern cmd_info_t console_command_shutdown;
 extern cmd_info_t console_command_restart;
 
-typedef struct {
+typedef struct _mtev_console_userdata_t {
   char                      *name;
   void                      *data;
   state_userdata_free_func_t freefunc;

--- a/src/mtev_console_telnet.h
+++ b/src/mtev_console_telnet.h
@@ -77,12 +77,12 @@
  * Structures of information for each special character function.
  */
 
-typedef struct {
+typedef struct _slcent {
 	unsigned char	flag;		/* the flags for this function */
 	unsigned char	val;		/* the value of the special character */
 } slcent, *Slcent;
 
-typedef struct {
+typedef struct _slcfun {
 	slcent		defset;		/* the default settings */
 	slcent		current;	/* the current settings */
 	unsigned char	*sptr;		/* a pointer to the char in */
@@ -154,7 +154,7 @@ struct clocks_t {
 	gotDM;			/* when did we last see a data mark */
 };
 
-typedef struct {
+typedef struct _mtev_console_telnet_closure_t {
   mtev_hash_table _env;
   unsigned char *_subbuffer;
   unsigned char *_subpointer;


### PR DESCRIPTION
This avoids a C++ warning, X has a field X::Y whose type uses the
anonymous namespace. In this case, we avoid the error by requiring
all structure types to have a name before the open-brace, but
signal to clients that these structure types should not be used
directly by prefixing the name with `_`.