### PR TITLE
added mtev_confstr_parse_time_gm routine.

### DIFF
--- a/src/utils/mtev_confstr.h
+++ b/src/utils/mtev_confstr.h
@@ -9,6 +9,11 @@
 
 typedef struct _mtev_duration_definition_t mtev_duration_definition_t;
 
+/* return codes from mtev_confstr_parse routines */
+#define MTEV_CONFSTR_PARSE_SUCCESS (0)
+#define MTEV_CONFSTR_PARSE_ERR_UNREPRESENTABLE (-1)
+#define MTEV_CONFSTR_PARSE_ERR_FORMAT (-2)
+
 API_EXPORT(const mtev_duration_definition_t *) mtev_get_durations_ns(void);
 API_EXPORT(const mtev_duration_definition_t *) mtev_get_durations_us(void);
 API_EXPORT(const mtev_duration_definition_t *) mtev_get_durations_ms(void);
@@ -19,6 +24,8 @@ API_EXPORT(int)
 API_EXPORT(int)
   mtev_confstr_parse_duration(const char *input, u_int64_t *output,
                               const mtev_duration_definition_t *durations);
+API_EXPORT(int)
+  mtev_confstr_parse_time_gm(const char *input, u_int64_t *output);
 
 #define mtev_confstr_parse_duration_ns(input, output) \
   mtev_confstr_parse_duration(input, output, mtev_get_durations_ns())

--- a/test/utils/confstr_spec.lua
+++ b/test/utils/confstr_spec.lua
@@ -13,37 +13,38 @@ ffi.cdef([=[
   int mtev_confstr_parse_boolean(const char *input, mtev_boolean *output);
   int mtev_confstr_parse_duration(const char *input, u_int64_t *output,
                                   const mtev_duration_definition_t *durations);
+  int mtev_confstr_parse_time_gm(const char *input, u_int64_t *output);
 ]=])
 
 describe("mtev_confstr_parse_boolean", function()
   it("decodes \"true\" strings", function()
     local result = ffi.new("mtev_boolean[1]")
-    assert.is_true(mtev.mtev_confstr_parse_boolean("true", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("true", result) == 0)
     assert.are.equal(mtev.mtev_true, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("TrUe", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("TrUe", result) == 0)
     assert.are.equal(mtev.mtev_true, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("yes", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("yes", result) == 0)
     assert.are.equal(mtev.mtev_true, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("on", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("on", result) == 0)
     assert.are.equal(mtev.mtev_true, result[0]);
   end)
   it("decodes \"false\" strings", function()
     local result = ffi.new("mtev_boolean[1]")
-    assert.is_true(mtev.mtev_confstr_parse_boolean("false", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("false", result) == 0)
     assert.are.equal(mtev.mtev_false, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("FaLsE", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("FaLsE", result) == 0)
     assert.are.equal(mtev.mtev_false, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("no", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("no", result) == 0)
     assert.are.equal(mtev.mtev_false, result[0]);
-    assert.is_true(mtev.mtev_confstr_parse_boolean("off", result) > 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("off", result) == 0)
     assert.are.equal(mtev.mtev_false, result[0]);
   end)
   it("fails to decode invalid strings", function()
     local result = ffi.new("mtev_boolean[1]")
-    assert.is_true(mtev.mtev_confstr_parse_boolean("WAT!", result) == 0)
-    assert.is_true(mtev.mtev_confstr_parse_boolean("", result) == 0)
-    assert.is_true(mtev.mtev_confstr_parse_boolean("tru", result) == 0)
-    assert.is_true(mtev.mtev_confstr_parse_boolean("truee", result) == 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("WAT!", result) ~= 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("", result) ~= 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("tru", result) ~= 0)
+    assert.is_true(mtev.mtev_confstr_parse_boolean("truee", result) ~= 0)
   end)
 end)
 
@@ -51,87 +52,115 @@ describe("mtev_confstr_parse_duration", function()
   it("fails to decode empty", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("", result,
-                                                    mtev.mtev_get_durations_ms()) == 0)
+                                                    mtev.mtev_get_durations_ms()) ~= 0)
   end)
   it("fails to decode unknown units", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1us", result,
-                                                    mtev.mtev_get_durations_ms()) == 0)
+                                                    mtev.mtev_get_durations_ms()) ~= 0)
   end)
   it("fails to decode when no number before unit", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("ms", result,
-                                                    mtev.mtev_get_durations_ms()) == 0)
+                                                    mtev.mtev_get_durations_ms()) ~= 0)
   end)
   it("decodes with ns units", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1ns", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1us", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(1000 * 1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1ms", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(1000 * 1000 * 1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1s", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(1000 * 1000 * 1000 * 1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1min", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(60 * 1000 * 1000 * 1000 * 1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1hr", result,
-                                                    mtev.mtev_get_durations_ns()) > 0)
+                                                    mtev.mtev_get_durations_ns()) == 0)
     assert.are.equal(60 * 60 * 1000 * 1000 * 1000 * 1, result[0])
   end)
   it("decodes with ms units", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1ms", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1s", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1min", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000 * 60, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1hr", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000 * 60 * 60, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1d", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000 * 60 * 60 * 24, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1w", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000 * 60 * 60 * 24 * 7, result[0])
   end)
   it("skips whitespace", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1ms", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration(" 1ms", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("1ms ", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration(" 1ms ", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1, result[0])
   end)
   it("sums duration elements", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1s 1ms", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(1000 + 1, result[0])
     assert.is_true(mtev.mtev_confstr_parse_duration("2s2ms", result,
-                                                    mtev.mtev_get_durations_ms()) > 0)
+                                                    mtev.mtev_get_durations_ms()) == 0)
     assert.are.equal(2000 + 2, result[0])
   end)
   it("fails to decode with extra data", function()
     local result = ffi.new("u_int64_t[1]")
     assert.is_true(mtev.mtev_confstr_parse_duration("1ms hello", result,
-                                                    mtev.mtev_get_durations_ms()) == 0)
+                                                    mtev.mtev_get_durations_ms()) ~= 0)
+  end)
+end)
+
+describe("mtev_confstr_parse_time_gm", function()
+  it("parses unix epoch in GMT", function()
+    local result = ffi.new("u_int64_t[1]")
+    assert.is_true(mtev.mtev_confstr_parse_time_gm("1970-01-01T00:00:00Z", result) == 0)
+    assert.are.equal(0, result[0])
+  end)
+  it("parses unix epoch with positive offset", function()
+    local result = ffi.new("u_int64_t[1]")
+    assert.is_true(mtev.mtev_confstr_parse_time_gm("1970-01-01T01:00:00+01:00", result) == 0)
+    assert.are.equal(0, result[0])
+  end)
+  it("parses unix epoch with negative offset", function()
+    local result = ffi.new("u_int64_t[1]")
+    assert.is_true(mtev.mtev_confstr_parse_time_gm("1969-12-31T23:00:00-01:00", result) == 0)
+    assert.are.equal(0, result[0])
+  end)
+  it("parses current time", function()
+    local now = os.time()
+    local date = os.date("!*t", now)
+    local timestr =
+      string.format("%04d-%02d-%02dT%02d:%02d:%02dZ",
+                    date.year, date.month, date.day, date.hour, date.min, date.sec)
+    local result = ffi.new("u_int64_t[1]")
+    assert.is_true(mtev.mtev_confstr_parse_time_gm(timestr, result) == 0)
+    assert.are.equal(now, result[0])
   end)
 end)


### PR DESCRIPTION
parses rfc3339 datespecs.

also, for consistency, changed existing mtev_confstr to return
MTEV_CONFSTR_PARSE result codes.