### PR TITLE
Implemented mtev_conf_check

### DIFF
--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -1063,7 +1063,72 @@ mtev_conf_load(const char *path) {
   XML2LOG(xml_debug);
   return rv;
 }
+static int mtev_conf_check_value(mtev_conf_description_t* description) {
+  int rv = 0;
+  switch (description->type) {
+  case MTEV_CONF_TYPE_BOOLEAN:
+    rv = mtev_conf_get_boolean(description->section, description->path,
+        &description->value.val_bool);
+    break;
+  case MTEV_CONF_TYPE_INT:
+    rv = mtev_conf_get_int(description->section, description->path,
+        &description->value.val_int);
+    break;
+  case MTEV_CONF_TYPE_INT64:
+    rv = mtev_conf_get_int64(description->section, description->path,
+        &description->value.val_int64);
+    break;
+  case MTEV_CONF_TYPE_FLOAT:
+    rv = mtev_conf_get_float(description->section, description->path,
+        &description->value.val_float);
+    break;
+  case MTEV_CONF_TYPE_DOUBLE:
+    rv = mtev_conf_get_double(description->section, description->path,
+        &description->value.val_double);
+    break;
+  case MTEV_CONF_TYPE_STRING:
+    rv = mtev_conf_get_string(description->section, description->path,
+        &description->value.val_string);
+    break;
+  case MTEV_CONF_TYPE_UUID:
+    rv = mtev_conf_get_uuid(description->section, description->path,
+        description->value.val_uuid);
+    break;
+  default:
+    rv = -1;
+  }
+  return rv;
+}
 
+mtev_hash_table*
+mtev_conf_check(mtev_conf_description_t* descriptions, int descriptions_cnt) {
+  mtev_hash_table* table = malloc(sizeof(mtev_hash_table));
+  mtev_hash_init_size(table, descriptions_cnt * 2);
+
+  for (int i = 0; i != descriptions_cnt; i++) {
+    if (mtev_conf_check_value(&descriptions[i]) == 0) {
+      mtevL(mtev_error,
+          "Path does not exist in config: '%s'. It should contain the following config: %s\n",
+          descriptions[i].path, descriptions[i].description);
+      free(table);
+      return NULL;
+    }
+    mtev_hash_store(table, descriptions[i].path, strlen(descriptions[i].path), &descriptions[i]);
+  }
+
+  return table;
+}
+
+mtev_hash_table*
+mtev_conf_load_desc(const char *path, mtev_conf_description_t* descriptions,
+    int descriptions_cnt) {
+  int rv = mtev_conf_load(path);
+
+  if (rv != -1) {
+    return mtev_conf_check(descriptions, descriptions_cnt);
+  }
+  return NULL;
+}
 char *
 mtev_conf_config_filename() {
   return strdup(master_config_file);

--- a/src/mtev_conf.h
+++ b/src/mtev_conf.h
@@ -52,6 +52,32 @@ typedef struct {
   char prompt[80];
 } mtev_conf_t_userdata_t;
 
+enum mtev_conf_type {
+  MTEV_CONF_TYPE_BOOLEAN,
+  MTEV_CONF_TYPE_INT,
+  MTEV_CONF_TYPE_INT64,
+  MTEV_CONF_TYPE_FLOAT,
+  MTEV_CONF_TYPE_DOUBLE,
+  MTEV_CONF_TYPE_STRING,
+  MTEV_CONF_TYPE_UUID
+};
+
+typedef struct mtev_conf_description_t {
+  mtev_conf_section_t section;
+  char* path;
+  enum mtev_conf_type type;
+  char* description;
+  union {
+    mtev_boolean val_bool;
+    int val_int;
+    int64_t val_int64;
+    float val_float;
+    double val_double;
+    char* val_string;
+    uuid_t val_uuid;
+  } value;
+} mtev_conf_description_t;
+
 /* seconds == 0 disable config journaling watchdog */
 API_EXPORT(void) mtev_conf_coalesce_changes(u_int32_t seconds);
 /* Start the watchdog */
@@ -69,6 +95,10 @@ API_EXPORT(void)
 API_EXPORT(void)
   mtev_override_console_stopword(int (*f)(const char *));
 API_EXPORT(int) mtev_conf_load(const char *path);
+API_EXPORT(mtev_hash_table*)
+  mtev_conf_check(mtev_conf_description_t* descriptions, int descriptions_cnt);
+API_EXPORT(mtev_hash_table*) mtev_conf_load_desc(const char *path,
+    mtev_conf_description_t* descriptions, int descriptions_cnt);
 API_EXPORT(int) mtev_conf_save(const char *path);
 API_EXPORT(char *) mtev_conf_config_filename();
 API_EXPORT(void) mtev_conf_write_section(mtev_conf_section_t node, int fd);


### PR DESCRIPTION
This allows you to check the existens of configs in a clean way. An example could look like following:

  struct mtev_conf_description_t descs[] = { {
  CONFIG_FQ_HOST, MTEV_CONF_TYPE_STRING,
      "Hostname of the fq broker data should be received from" },

  { CONFIG_FQ_PORT, MTEV_CONF_TYPE_INT, "Port number of the fq broker" },

  { CONFIG_FQ_USER, MTEV_CONF_TYPE_STRING,
      "User name used to connect to the fq broker" },

  { CONFIG_FQ_PASS, MTEV_CONF_TYPE_STRING,
      "Password used to connect to the fq broker" } };

  if (mtev_conf_load_desc(config_file, descs,
      sizeof(descs) / sizeof(struct mtev_conf_description_t)) != 0) {
    mtevL(mtev_error, "Cannot load config: '%s'\n", config_file);
    exit(2);
  }

If a config path isn't found this will print a message explaining which path is missing and what's the semantics of the corresponding value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/circonus-labs/libmtev/25)
<!-- Reviewable:end -->
