### PR TITLE
Avoid SSL_SESSION_free

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -273,7 +273,7 @@ eventer_ssl_get_peer_certificate(eventer_ssl_ctx_t *ctx) {
 
 SSL_SESSION *
 eventer_ssl_get_session(eventer_ssl_ctx_t *ctx) {
-  return SSL_get1_session(ctx->ssl);
+  return SSL_get_session(ctx->ssl);
 }
 
 int


### PR DESCRIPTION
SSL_get1_session is supposed to increment the refcnt.  Other things can
negatively effect the SSL_SESSION itself making it dangerous to free even
the refcnt'd copy (crashes on OS X).  There is only one consumer of this
and we can avoid this by simply requiring that no one use it "later."

Expose a :release() method on the session in lua that null our reference
and make the GC null its reference.  Then change the return convention
to not increment the refcnt.