### PR TITLE
fix mtev_skiplist_destroy null pointer dereference.

### DIFF
--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -395,8 +395,10 @@ static void mtev_skiplisti_destroy(void *vsl) {
   free(vsl);
 }
 void mtev_skiplist_destroy(mtev_skiplist *sl, mtev_freefunc_t myfree) {
-  while(mtev_skiplist_pop(sl->index, mtev_skiplisti_destroy) != NULL);
-  free((void *) sl->index);
+  if(sl->index) {
+    while(mtev_skiplist_pop(sl->index, mtev_skiplisti_destroy) != NULL);
+    free((void *) sl->index);
+  }
   mtev_skiplist_remove_all(sl, myfree);
 }
 void *mtev_skiplist_pop(mtev_skiplist * a, mtev_freefunc_t myfree)


### PR DESCRIPTION
this program currently segv's:

```
#include <mtev_skiplist.h>

int foo(const void *ap, const void *bp)
{
  return mtev_compare_voidptr(ap, bp);
}

int main(int argc, char const *argv[])
{
  mtev_skiplist sl;
  mtev_skiplist_init(&sl);
  mtev_skiplist_set_compare(&sl, foo, foo);
  mtev_skiplist_add_index(&sl, mtev_compare_voidptr, mtev_compare_voidptr);
  mtev_skiplist_destroy(&sl, 0);
  return 0;
}
```

this patch addresses the issue.