### PR TITLE
Undef "user2" If term.h Is Included

### DIFF
--- a/src/mtev_console_telnet.h
+++ b/src/mtev_console_telnet.h
@@ -316,4 +316,10 @@ int
                              const void *buf, int buflen);
 void ptyflush(struct __mtev_console_closure *ncct);
 
+/* term.h #defines user2, which can conflict with some libraries...
+ * notably, libxml/xterm.h. If we included term.h, undef user2 here */
+#ifdef HAVE_TERM_H
+#undef user2
+#endif
+
 #endif


### PR DESCRIPTION
term.h #defines "user2", which conflicts with some libraries (notably -
libxml and the libxml/xterm.h include file)... undefine it if we had to
include term.h.