### PR TITLE
Move Including #term.h Into mtev_console_telnet C File

### DIFF
--- a/src/mtev_console_telnet.c
+++ b/src/mtev_console_telnet.c
@@ -48,6 +48,10 @@
 #include "mtev_console_telnet.h"
 #include "mtev_hash.h"
 
+#ifdef HAVE_TERM_H
+#include <term.h>
+#endif
+
 /*
 RCSID("$Id: state.c,v 1.14.12.1 2004/06/21 08:21:58 lha Exp $");
 */

--- a/src/mtev_console_telnet.h
+++ b/src/mtev_console_telnet.h
@@ -56,9 +56,6 @@
 #ifdef HAVE_TERMIO_H
 #include <termio.h>
 #endif
-#ifdef HAVE_TERM_H
-#include <term.h>
-#endif
 
 #if !defined(__linux__) && !defined(__sun)
 /* At least _I_ can't get LINUMODE working on Linux */
@@ -315,11 +312,5 @@ int
   mtev_console_telnet_telrcv(struct __mtev_console_closure *ncct,
                              const void *buf, int buflen);
 void ptyflush(struct __mtev_console_closure *ncct);
-
-/* term.h #defines user2, which can conflict with some libraries...
- * notably, libxml/xterm.h. If we included term.h, undef user2 here */
-#ifdef HAVE_TERM_H
-#undef user2
-#endif
 
 #endif


### PR DESCRIPTION
Rather than doing an #undef for user2 (there are tons of bad defines in
term.h), just move term.h include into the C file itself.