### PR TITLE
Move curses.h Include To mtev_console_telnet.c

### DIFF
--- a/src/mtev_console_telnet.c
+++ b/src/mtev_console_telnet.c
@@ -48,6 +48,9 @@
 #include "mtev_console_telnet.h"
 #include "mtev_hash.h"
 
+#ifdef HAVE_CURSES_H
+#include <curses.h>
+#endif
 #ifdef HAVE_TERM_H
 #include <term.h>
 #endif

--- a/src/mtev_console_telnet.h
+++ b/src/mtev_console_telnet.h
@@ -50,9 +50,6 @@
 #ifdef HAVE_TERMIOS_H
 #include <termios.h>
 #endif
-#ifdef HAVE_CURSES_H
-#include <curses.h>
-#endif
 #ifdef HAVE_TERMIO_H
 #include <termio.h>
 #endif


### PR DESCRIPTION
Take curses.h out of mtev_console_telnet.h.... were getting conflicts
with the macro "move".