### PR TITLE
Fix A Busted Reference Count In Eventer SSL Code

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -604,7 +604,6 @@ ssl_ctx_cache_set(ssl_ctx_cache_node *node) {
   pthread_mutex_lock(&ssl_ctx_cache_lock);
   if(mtev_hash_retrieve(&ssl_ctx_cache, node->key, strlen(node->key),
                         &vnode)) {
-    ssl_ctx_cache_node_free(node);
     node = vnode;
   }
   else {


### PR DESCRIPTION
We were double-decrementing a refcnt, which could lead to undocumented
behavior. Fix it to decrement properly.