### PR TITLE
Better Error Handling Before Aborts

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -225,8 +225,7 @@ generate_dh_params(eventer_t e, int mask, void *cl, struct timeval *now) {
     }
     break;
   default:
-    mtevL(mtev_error, "Unexpected DH parameter request: %d\n", bits);
-    abort();
+    MTEV_LOG_AND_ABORT(mtev_error, "Unexpected DH parameter request: %d\n", bits);
   }
   return 0;
 }
@@ -950,7 +949,7 @@ eventer_SSL_rw(int op, int fd, void *buffer, size_t len, int *mask,
       break;
 
     default:
-      abort();
+      MTEV_LOG_AND_ABORT(mtev_error, "error: unknown SSL operation (%d)\n", op);
   }
   /* This can't happen as we'd have already aborted... */
   if(!opstr) opstr = "none";

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -225,7 +225,7 @@ generate_dh_params(eventer_t e, int mask, void *cl, struct timeval *now) {
     }
     break;
   default:
-    MTEV_LOG_AND_ABORT(mtev_error, "Unexpected DH parameter request: %d\n", bits);
+    mtevFatal(mtev_error, "Unexpected DH parameter request: %d\n", bits);
   }
   return 0;
 }
@@ -949,7 +949,7 @@ eventer_SSL_rw(int op, int fd, void *buffer, size_t len, int *mask,
       break;
 
     default:
-      MTEV_LOG_AND_ABORT(mtev_error, "error: unknown SSL operation (%d)\n", op);
+      mtevFatal(mtev_error, "error: unknown SSL operation (%d)\n", op);
   }
   /* This can't happen as we'd have already aborted... */
   if(!opstr) opstr = "none";

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -179,13 +179,10 @@ static eventer_t eventer_epoll_impl_remove(eventer_t e) {
       removed = e;
       master_fds[e->fd].e = NULL;
       if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, e->fd, &_ev) != 0) {
+        mtevL(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
+              spec->epoll_fd, e->fd, strerror(errno));
         if(errno != ENOENT) {
-          mtevFatal(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
-                spec->epoll_fd, e->fd, strerror(errno));
-        }
-        else {
-          mtevL(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
-                spec->epoll_fd, e->fd, strerror(errno));
+          mtevFatal(mtev_error, "errno != ENOENT: %d (%s)\n", errno, strerror(errno));
         }
       }
     }
@@ -237,13 +234,10 @@ static eventer_t eventer_epoll_impl_remove_fd(int fd) {
     spec = eventer_get_spec_for_event(eiq);
     master_fds[fd].e = NULL;
     if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) != 0) {
+      mtevL(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
+            spec->epoll_fd, fd, strerror(errno));
       if(errno != ENOENT) {
-        mtevFatal(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
-              spec->epoll_fd, fd, strerror(errno));
-      }
-      else {
-        mtevL(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
-              spec->epoll_fd, fd, strerror(errno));
+        mtevFatal(mtev_error, "errno != ENOENT: %d (%s)\n", errno, strerror(errno));
       }
     }
     release_master_fd(fd, lockstate);

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -179,8 +179,6 @@ static eventer_t eventer_epoll_impl_remove(eventer_t e) {
       removed = e;
       master_fds[e->fd].e = NULL;
       if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, e->fd, &_ev) != 0) {
-        mtevL(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
-              spec->epoll_fd, e->fd, strerror(errno));
         if(errno != ENOENT) {
           mtevFatal(mtev_error, "epoll_ctl(%d, EPOLL_CTL_DEL, %d) -> %s\n",
                 spec->epoll_fd, e->fd, strerror(errno));

--- a/src/eventer/eventer_kqueue_impl.c
+++ b/src/eventer/eventer_kqueue_impl.c
@@ -122,7 +122,7 @@ static void *eventer_kqueue_spec_alloc() {
   spec = calloc(1, sizeof(*spec));
   spec->kqueue_fd = kqueue();
   if(spec->kqueue_fd == -1) {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eveter_kqueue_spec_alloc... spec->epoll_fd < 0 (%d)\n",
+    mtevFatal(mtev_error, "error in eveter_kqueue_spec_alloc... spec->epoll_fd < 0 (%d)\n",
             spec->epoll_fd);
   }
   kqs_init(spec);
@@ -192,7 +192,7 @@ static void eventer_kqueue_impl_add(eventer_t e) {
 static eventer_t eventer_kqueue_impl_remove(eventer_t e) {
   eventer_t removed = NULL;
   if(e->mask & EVENTER_ASYNCH) {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_kqueue_impl_remove: got unexpected EVENTER_ASYNCH mask\n");
+    mtevFatal(mtev_error, "error in eventer_kqueue_impl_remove: got unexpected EVENTER_ASYNCH mask\n");
   }
   if(e->mask & (EVENTER_READ | EVENTER_WRITE | EVENTER_EXCEPTION)) {
     ev_lock_state_t lockstate;
@@ -216,7 +216,7 @@ static eventer_t eventer_kqueue_impl_remove(eventer_t e) {
     removed = eventer_remove_recurrent(e);
   }
   else {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_kqueue_impl_remove: got unknown mask (0x%04x)\n",
+    mtevFatal(mtev_error, "error in eventer_kqueue_impl_remove: got unknown mask (0x%04x)\n",
             e->mask);
   }
   return removed;
@@ -389,7 +389,7 @@ static int eventer_kqueue_impl_loop() {
   KQUEUE_SETUP(NULL);
 
   if(eventer_kqueue_impl_register_wakeup(kqs) == -1) {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_kqueue_impl_loop: could not eventer_kqueue_impl_register_wakeup\n");
+    mtevFatal(mtev_error, "error in eventer_kqueue_impl_loop: could not eventer_kqueue_impl_register_wakeup\n");
   }
 
   while(1) {

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -69,7 +69,7 @@ static void *eventer_ports_spec_alloc() {
   spec = calloc(1, sizeof(*spec));
   spec->port_fd = port_create();
   if(spec->port_fd < 0) {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eveter_ports_spec_alloc... spec->port_fd < 0 (%d)\n",
+    mtevFatal(mtev_error, "error in eveter_ports_spec_alloc... spec->port_fd < 0 (%d)\n",
             spec->port_fd);
   }
   return spec;
@@ -170,7 +170,7 @@ static void eventer_ports_impl_add(eventer_t e) {
 static eventer_t eventer_ports_impl_remove(eventer_t e) {
   eventer_t removed = NULL;
   if(e->mask & EVENTER_ASYNCH) {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_ports_impl_remove: got unexpected EVENTER_ASYNCH mask\n");
+    mtevFatal(mtev_error, "error in eventer_ports_impl_remove: got unexpected EVENTER_ASYNCH mask\n");
   }
   if(e->mask & (EVENTER_READ | EVENTER_WRITE | EVENTER_EXCEPTION)) {
     ev_lock_state_t lockstate;
@@ -189,7 +189,7 @@ static eventer_t eventer_ports_impl_remove(eventer_t e) {
     removed = eventer_remove_recurrent(e);
   }
   else {
-    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_ports_impl_remove: got unknown mask (0x%04x)\n",
+    mtevFatal(mtev_error, "error in eventer_ports_impl_remove: got unknown mask (0x%04x)\n",
             e->mask);
   }
   return removed;

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -68,7 +68,10 @@ static void *eventer_ports_spec_alloc() {
   struct ports_spec *spec;
   spec = calloc(1, sizeof(*spec));
   spec->port_fd = port_create();
-  if(spec->port_fd < 0) abort();
+  if(spec->port_fd < 0) {
+    MTEV_LOG_AND_ABORT(mtev_error, "error in eveter_ports_spec_alloc... spec->port_fd < 0 (%d)\n",
+            spec->port_fd);
+  }
   return spec;
 }
 
@@ -167,7 +170,7 @@ static void eventer_ports_impl_add(eventer_t e) {
 static eventer_t eventer_ports_impl_remove(eventer_t e) {
   eventer_t removed = NULL;
   if(e->mask & EVENTER_ASYNCH) {
-    abort();
+    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_ports_impl_remove: got unexpected EVENTER_ASYNCH mask\n");
   }
   if(e->mask & (EVENTER_READ | EVENTER_WRITE | EVENTER_EXCEPTION)) {
     ev_lock_state_t lockstate;
@@ -186,7 +189,8 @@ static eventer_t eventer_ports_impl_remove(eventer_t e) {
     removed = eventer_remove_recurrent(e);
   }
   else {
-    abort();
+    MTEV_LOG_AND_ABORT(mtev_error, "error in eventer_ports_impl_remove: got unknown mask (0x%04x)\n",
+            e->mask);
   }
   return removed;
 }

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -134,12 +134,12 @@ inbuff_addlstring(struct nl_slcl *cl, const char *b, int l) {
   char *newbuf;
 
   if (cl->inbuff_len < 0 || l < 0) {
-    mtevL(nldeb, "Invalid Argument: An argument was negative");
-    abort();
+    MTEV_LOG_AND_ABORT(mtev_error, "Invalid Argument to inbuff_addlstring: An argument was negative (ci->inbuff_len: %d, l: %d)\n", 
+            cl->inbuff_len, l);
   }
   if (cl->inbuff_len + l < 0) {
-    mtevL(nldeb, "Error: Addition Overflow");
-    abort();
+    MTEV_LOG_AND_ABORT(mtev_error, "Error: Addition Overflow im inbuff_addlstring (ci->inbuff_len: %d, l: %d, sum: %d\n", 
+            cl->inbuff_len, l, cl->inbuff_len+l);
   }
 
   if(cl->inbuff_len + l > cl->inbuff_allocd)

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -134,11 +134,11 @@ inbuff_addlstring(struct nl_slcl *cl, const char *b, int l) {
   char *newbuf;
 
   if (cl->inbuff_len < 0 || l < 0) {
-    MTEV_LOG_AND_ABORT(mtev_error, "Invalid Argument to inbuff_addlstring: An argument was negative (ci->inbuff_len: %d, l: %d)\n", 
+    mtevFatal(mtev_error, "Invalid Argument to inbuff_addlstring: An argument was negative (ci->inbuff_len: %d, l: %d)\n", 
             cl->inbuff_len, l);
   }
   if (cl->inbuff_len + l < 0) {
-    MTEV_LOG_AND_ABORT(mtev_error, "Error: Addition Overflow im inbuff_addlstring (ci->inbuff_len: %d, l: %d, sum: %d\n", 
+    mtevFatal(mtev_error, "Error: Addition Overflow im inbuff_addlstring (ci->inbuff_len: %d, l: %d, sum: %d\n", 
             cl->inbuff_len, l, cl->inbuff_len+l);
   }
 

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -167,16 +167,14 @@ API_EXPORT(int)
     mtev_log(ls, NULL, __FILE__, __LINE__, args); \
   } \
 } while(0)
+#define mtevFatal(ls,args...) do {\
+  mtev_log_go_synch(); \
+  mtevL(ls, "[FATAL] " args); \
+  abort(); \
+} while(0)
 
 #define SETUP_LOG(a, b) do { if(!a##_log) a##_log = mtev_log_stream_find(#a); \
                              if(!a##_log) { b; } } while(0)
-
-#define MTEV_LOG_AND_ABORT(log,args...) \
-  do { \
-    mtev_log_go_synch(); \
-    mtevL(log, args); \
-    abort(); \
-  } while(0)
 
 MTEV_HOOK_PROTO(mtev_log_line,
                 (mtev_log_stream_t ls, struct timeval *whence,

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -172,9 +172,11 @@ API_EXPORT(int)
                              if(!a##_log) { b; } } while(0)
 
 #define MTEV_LOG_AND_ABORT(log,args...) \
-  mtev_log_go_synch(); \
-  mtevL(log, args); \
-  abort();
+  do { \
+    mtev_log_go_synch(); \
+    mtevL(log, args); \
+    abort(); \
+  } while(0)
 
 MTEV_HOOK_PROTO(mtev_log_line,
                 (mtev_log_stream_t ls, struct timeval *whence,

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -171,6 +171,11 @@ API_EXPORT(int)
 #define SETUP_LOG(a, b) do { if(!a##_log) a##_log = mtev_log_stream_find(#a); \
                              if(!a##_log) { b; } } while(0)
 
+#define MTEV_LOG_AND_ABORT(log,args...) \
+  mtev_log_go_synch(); \
+  mtevL(log, args); \
+  abort();
+
 MTEV_HOOK_PROTO(mtev_log_line,
                 (mtev_log_stream_t ls, struct timeval *whence,
                  const char *timebuf, int timebuflen,

--- a/src/utils/mtev_str.c
+++ b/src/utils/mtev_str.c
@@ -59,7 +59,7 @@ const char *strnstrn(const char *needle, int needle_len,
   int i=0, j=0, compiled[KMPPATSIZE];
 
   if(needle_len > KMPPATSIZE) {
-    MTEV_LOG_AND_ABORT(mtev_error, "errorin strnstrn: needle_len (%d) < KMPPATSIZE (%d)\n",
+    mtevFatal(mtev_error, "errorin strnstrn: needle_len (%d) < KMPPATSIZE (%d)\n",
             needle_len, KMPPATSIZE);
   }
   kmp_precompute(needle, needle_len, compiled);

--- a/src/utils/mtev_str.c
+++ b/src/utils/mtev_str.c
@@ -33,6 +33,7 @@
 
 #include "mtev_defines.h"
 #include "mtev_str.h"
+#include "mtev_log.h"
 
 #ifndef HAVE_STRNSTRN
 
@@ -57,8 +58,10 @@ const char *strnstrn(const char *needle, int needle_len,
                      const char *haystack, int haystack_len) {
   int i=0, j=0, compiled[KMPPATSIZE];
 
-  if(needle_len > KMPPATSIZE)
-    abort();
+  if(needle_len > KMPPATSIZE) {
+    MTEV_LOG_AND_ABORT(mtev_error, "errorin strnstrn: needle_len (%d) < KMPPATSIZE (%d)\n",
+            needle_len, KMPPATSIZE);
+  }
   kmp_precompute(needle, needle_len, compiled);
   while (j < haystack_len) {
     while (i > -1 && needle[i] != haystack[j])


### PR DESCRIPTION
When we abort, rather than just aborting, log what happens via the new
MTEV_LOG_AND_ABORT() function. This will set the log to synchronous, log
the message, then abort. This will avoid the issue where we queue
something to be written to a log but exit before it flushes.