### PR TITLE
a timeout callback may be passed to socket:read used by HttpClient

### DIFF
--- a/src/modules/lua-support/mtev/HttpClient.lua
+++ b/src/modules/lua-support/mtev/HttpClient.lua
@@ -79,6 +79,13 @@ function HttpClient:connect(target, port, ssl, ssl_host, ssl_layer)
                                      ssl_host, ssl_layer)
 end
 
+function HttpClient:close()
+  if self.e ~= nil then
+    self.e:close()
+    self.e = nil
+  end
+end
+
 function HttpClient:ssl_ctx()
    return self.e:ssl_ctx()
 end
@@ -107,11 +114,43 @@ function HttpClient:do_request(method, uri, _headers, payload, http_version)
       sstr = sstr .. payload
     end
     self.e:write(sstr)
+
+    self.request_started_s, self.request_started_us = mtev.gettimeofday()
+end
+
+function HttpClient:read(delim)
+  local str
+  if self.on_timeout ~= nil then
+    local now_s, now_us = mtev.gettimeofday()
+    local passed_s = now_s - self.request_started_s
+    local passed_us = now_us - self.request_started_us
+    local timeout = self.timeout - passed_s - passed_us/1000000
+    if timeout < 0 then
+      self.on_timeout()
+      return nil
+    else
+      str = self.e:read(delim, 0, timeout, self.on_timeout)
+    end
+  else
+    str = self.e:read(delim)
+  end
+  return str
+end
+
+function HttpClient:set_timeout(timeout, timeout_callback)
+  if timeout == nil or timeout <= 0 then
+    self.timeout = nil
+    self.timeout_callback = nil
+  else
+    assert(timeout_callback)
+    self.timeout = timeout
+    self.on_timeout = timeout_callback
+  end
 end
 
 function HttpClient:get_headers()
     local lasthdr
-    local str = self.e:read("\n");
+    local str = self:read("\n");
     local cookie_count = 1;
     if str == nil then error("no response") end
     self.protocol, self.code = string.match(str, "^HTTP/(%d.%d)%s+(%d+)%s+")
@@ -120,7 +159,7 @@ function HttpClient:get_headers()
     self.headers = Headers()
     self.cookies = {}
     while true do
-        local str = self.e:read("\n")
+        local str = self:read("\n")
         if str == nil or str == "\r\n" or str == "\n" then break end
         str = string.gsub(str, '%s+$', '')
         local hdr, val = string.match(str, "^([%.-_%a%d]+):%s*(.*)$")
@@ -156,7 +195,7 @@ function te_close(self, content_enc_func)
     local len = 32678
     local str
     repeat
-        local str = self.e:read(len)
+        local str = self:read(len)
         if str ~= nil then
             self.raw_bytes = self.raw_bytes + string.len(str)
             local decoded = content_enc_func(str)
@@ -175,7 +214,7 @@ function te_length(self, content_enc_func, read_limit)
       self.truncated = true
     end
     repeat
-        local str = self.e:read(len)
+        local str = self:read(len)
         if str ~= nil then
             self.raw_bytes = self.raw_bytes + string.len(str)
             len = len - string.len(str)
@@ -190,7 +229,7 @@ end
 
 function te_chunked(self, content_enc_func, read_limit)
     while true do
-        local str = self.e:read("\n")
+        local str = self:read("\n")
         if str == nil then error("bad chunk transfer") end
         local hexlen = string.match(str, "^([0-9a-fA-F]+)")
         if hexlen == nil then error("bad chunk length: " .. str) end
@@ -199,7 +238,7 @@ function te_chunked(self, content_enc_func, read_limit)
           if self.hooks.consume ~= nil then self.hooks.consume("") end
           break 
         end
-        str = self.e:read(len)
+        str = self:read(len)
         if string.len(str or "") ~= len then error("short chunked read") end
         self.raw_bytes = self.raw_bytes + string.len(str)
         local decoded = content_enc_func(str)
@@ -214,12 +253,12 @@ function te_chunked(self, content_enc_func, read_limit)
           end
         end
         -- each chunk ('cept a 0 size one) is followed by a \r\n
-        str = self.e:read("\n")
+        str = self:read("\n")
         if str ~= "\r\n" and str ~= "\n" then error("short chunked boundary read") end
     end
     -- read trailers
     while true do
-        local str = self.e:read("\n")
+        local str = self:read("\n")
         if str == nil then error("bad chunk trailers") end
         if str == "\r\n" or str == "\n" then break end
     end

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -103,6 +103,12 @@ nl_extended_free(void *vcl) {
   if(cl->inbuff) free(cl->inbuff);
   free(cl);
 }
+static void
+lua_timeout_callback_ref_free(void* cb) {
+  lua_timeout_callback_ref *callback_ref = (lua_timeout_callback_ref*) cb;
+  luaL_unref(callback_ref->L, LUA_REGISTRYINDEX, callback_ref->callback_reference);
+  free(callback_ref);
+}
 static int
 lua_push_inet_ntop(lua_State *L, struct sockaddr *r) {
   char remote_str[128];
@@ -1067,14 +1073,20 @@ mtev_lua_socket_read_complete(eventer_t e, int mask, void *vcl,
   int len;
   int args = 0;
 
+  ci = mtev_lua_get_resume_info(cl->L);
+  assert(ci);
+
+  if(cl->timeout_event) {
+    eventer_remove_timed(cl->timeout_event);
+    mtev_lua_deregister_event(ci, cl->timeout_event, 1);
+    cl->timeout_event = NULL;
+  }
+
   /* If the pointer has been cleared, this has been gc'd */
   if(!*(cl->eptr)) {
     mtevL(nlerr, "mtev.eventer callback post GC\n");
     return 0;
   }
-
-  ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
 
   len = mtev_lua_socket_do_read(e, &mask, cl, &args);
   if(len >= 0) {
@@ -1094,6 +1106,42 @@ mtev_lua_socket_read_complete(eventer_t e, int mask, void *vcl,
   (*cl->eptr)->refcnt = 1;
   mtev_lua_register_event(ci, *cl->eptr);
   ci->lmc->resume(ci, args);
+  return 0;
+}
+
+static int on_timeout(eventer_t e, int mask, void *closure,
+    struct timeval *now) {
+  struct nl_slcl *cl;
+    mtev_lua_resume_info_t *ci;
+  lua_timeout_callback_ref* cb_ref;
+  lua_State *L;
+
+  cb_ref = (lua_timeout_callback_ref*)closure;
+  L = cb_ref->L;
+
+  // run the timeout callback
+  lua_rawgeti( L, LUA_REGISTRYINDEX, cb_ref->callback_reference );
+  lua_call(L, 0, 0);
+
+  cl = cb_ref->timed_out_eventer->closure;
+  ci = mtev_lua_get_resume_info(L);
+  assert(ci);
+  
+
+  // remove the original read event
+  eventer_remove_fd(cb_ref->timed_out_eventer->fd);
+  mtev_lua_deregister_event(ci, cb_ref->timed_out_eventer, 0);
+  *(cl->eptr) = eventer_alloc();
+  memcpy(*cl->eptr, cb_ref->timed_out_eventer, sizeof(*cb_ref->timed_out_eventer));
+  (*cl->eptr)->refcnt = 1;
+  mtev_lua_register_event(ci, *cl->eptr);
+  
+  // return into the original Lua call which spawned this timeout
+  lua_pushnil(L);
+  ci->lmc->resume(ci, 1);
+
+  mtev_lua_deregister_event(ci, e, 1);
+
   return 0;
 }
 
@@ -1158,18 +1206,49 @@ mtev_lua_socket_read(lua_State *L) {
   if(args == 1) return 1; /* completed read, return result */
   if(len == -1 && errno == EAGAIN) {
     /* we need to drop into eventer */
+    eventer_remove_fd(e->fd);
+    e->callback = mtev_lua_socket_read_complete;
+    e->mask = mask | EVENTER_EXCEPTION;
+    eventer_add(e);
+
+    if (lua_gettop(L) == 5 && lua_isfunction(L, 5)) {
+      double timeout_user;
+      int timeout_s;
+      int timeout_us;
+      timeout_s = 10;
+      timeout_us = 0;
+      if(lua_isnumber(L, 4)) {
+        timeout_user = lua_tonumber(L, 4);
+        timeout_s = floor(timeout_user);
+        timeout_us = (timeout_user - timeout_s) * 1000000;
+      }
+
+      lua_timeout_callback_ref* cb_ref = malloc(sizeof(lua_timeout_callback_ref));
+      cb_ref->free = lua_timeout_callback_ref_free;
+      cb_ref->L = L;
+      cb_ref->callback_reference = luaL_ref( L, LUA_REGISTRYINDEX );
+      cb_ref->timed_out_eventer = e;
+
+      eventer_t timeout_eventer = eventer_alloc();
+      timeout_eventer->mask = EVENTER_TIMER;
+      gettimeofday(&timeout_eventer->whence, NULL);
+      timeout_eventer->whence.tv_sec += timeout_s;
+      timeout_eventer->whence.tv_usec += timeout_us;
+      timeout_eventer->callback = on_timeout;
+      timeout_eventer->closure = cb_ref;
+      mtev_lua_register_event(ci, timeout_eventer);
+      eventer_add_timed(timeout_eventer);
+
+      cl->timeout_event = timeout_eventer;
+    }
+
+    return mtev_lua_yield(ci, 0);
   }
   else {
     lua_pushnil(cl->L);
     args = 1;
     return args;
   }
-
-  eventer_remove_fd(e->fd);
-  e->callback = mtev_lua_socket_read_complete;
-  e->mask = mask | EVENTER_EXCEPTION;
-  eventer_add(e);
-  return mtev_lua_yield(ci, 0);
 }
 static int
 mtev_lua_socket_write_complete(eventer_t e, int mask, void *vcl,

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -84,6 +84,13 @@ struct nl_intcl {
   mtev_lua_resume_info_t *ri;
 };
 
+typedef struct lua_timeout_callback_ref {
+  void (*free)(void *);
+  lua_State *L;
+  int callback_reference;
+  eventer_t timed_out_eventer;
+} lua_timeout_callback_ref;
+
 struct nl_slcl {
   void (*free)(void *);
   int send_size;
@@ -99,6 +106,7 @@ struct nl_slcl {
   size_t write_goal;
   eventer_t *eptr;
   eventer_t pending_event;
+  eventer_t timeout_event;
 
   int sendto; /* whether this send is a sendto call */
   union {


### PR DESCRIPTION
e.timeout now as double
registering timeout events so that they are cleaned up when a coro is canceled
HttpClient timeout counts for a request instead of a read call