### PR TITLE
Replace "assert" Calls With "mtevAssert"

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -36,7 +36,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <assert.h>
 
 eventer_impl_t __eventer;
 mtev_log_stream_t eventer_err;
@@ -86,7 +85,7 @@ int64_t eventer_allocations_total() {
 void eventer_ref(eventer_t e) {
   register int32_t newval;
   newval = mtev_atomic_inc32(&e->refcnt);
-  assert(newval != 1);
+  mtevAssert(newval != 1);
   (void)newval;
 }
 

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -45,7 +45,6 @@
 #include <sys/epoll.h>
 #include <signal.h>
 #include <pthread.h>
-#include <assert.h>
 #include <fcntl.h>
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
@@ -123,7 +122,7 @@ static void eventer_epoll_impl_add(eventer_t e) {
   struct epoll_spec *spec;
   struct epoll_event _ev;
   ev_lock_state_t lockstate;
-  assert(e->mask);
+  mtevAssert(e->mask);
 
   if(e->mask & EVENTER_ASYNCH) {
     eventer_add_asynch(NULL, e);
@@ -144,7 +143,7 @@ static void eventer_epoll_impl_add(eventer_t e) {
 
   spec = eventer_get_spec_for_event(e);
   /* file descriptor event */
-  assert(e->whence.tv_sec == 0 && e->whence.tv_usec == 0);
+  mtevAssert(e->whence.tv_sec == 0 && e->whence.tv_usec == 0);
   memset(&_ev, 0, sizeof(_ev));
   _ev.data.fd = e->fd;
   if(e->mask & EVENTER_READ) _ev.events |= (EPOLLIN|EPOLLPRI);
@@ -262,14 +261,14 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
     if(master_fds[fd].e != NULL) {
       mtevL(eventer_deb, "Attempting to trigger already-registered event fd: %d cross thread.\n", fd);
     }
-    /* assert(master_fds[fd].e == NULL); */
+    /* mtevAssert(master_fds[fd].e == NULL); */
   }
   if(!pthread_equal(pthread_self(), e->thr_owner)) {
     /* If we're triggering across threads, it can't be registered yet */
     if(master_fds[fd].e != NULL) {
       mtevL(eventer_deb, "Attempting to trigger already-registered event fd: %d cross thread.\n", fd);
     }
-    /* assert(master_fds[fd].e == NULL); */
+    /* mtevAssert(master_fds[fd].e == NULL); */
     
     eventer_cross_thread_trigger(e,mask);
     return;
@@ -281,7 +280,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
   if(e != master_fds[fd].e) return;
   lockstate = acquire_master_fd(fd);
   if(lockstate == EV_ALREADY_OWNED) return;
-  assert(lockstate == EV_OWNED);
+  mtevAssert(lockstate == EV_OWNED);
 
   gettimeofday(&__now, NULL);
   cbname = eventer_name_for_callback_e(e->callback, e);
@@ -308,15 +307,15 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
         pthread_t tgt = e->thr_owner;
         e->thr_owner = pthread_self();
         spec = eventer_get_spec_for_event(e);
-        assert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) == 0);
+        mtevAssert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) == 0);
         e->thr_owner = tgt;
         spec = eventer_get_spec_for_event(e);
-        assert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_ADD, fd, &_ev) == 0);
+        mtevAssert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_ADD, fd, &_ev) == 0);
         mtevL(eventer_deb, "moved event[%p] from t@%d to t@%d\n", e, (int)pthread_self(), (int)tgt);
       }
       else {
         spec = eventer_get_spec_for_event(e);
-        assert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_MOD, fd, &_ev) == 0);
+        mtevAssert(epoll_ctl(spec->epoll_fd, EPOLL_CTL_MOD, fd, &_ev) == 0);
       }
     }
     /* Set our mask */

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -40,7 +40,6 @@
 #include "libmtev_dtrace_probes.h"
 #include <pthread.h>
 #include <errno.h>
-#include <assert.h>
 #include <netinet/in.h>
 #include <hwloc.h>
 
@@ -164,7 +163,7 @@ void *eventer_get_spec_for_event(eventer_t e) {
   struct eventer_impl_data *t;
   if(e == NULL) t = get_my_impl_data();
   else t = get_event_impl_data(e);
-  assert(t);
+  mtevAssert(t);
   if(t->spec == NULL) t->spec = __eventer->alloc_spec();
   return t->spec;
 }
@@ -215,7 +214,7 @@ eventer_jobq_t *eventer_default_backq(eventer_t e) {
   struct eventer_impl_data *impl_data;
   tid = e ? e->thr_owner : pthread_self();
   impl_data = get_tls_impl_data(tid);
-  assert(impl_data);
+  mtevAssert(impl_data);
   return &impl_data->__global_backq;
 }
 
@@ -416,7 +415,7 @@ int eventer_impl_init() {
   for(i=0; i<__default_queue_threads; i++)
     eventer_jobq_increase_concurrency(&__default_jobq);
 
-  assert(eventer_impl_tls_data == NULL);
+  mtevAssert(eventer_impl_tls_data == NULL);
   eventer_impl_tls_data = calloc(__loop_concurrency, sizeof(*eventer_impl_tls_data));
 
   eventer_per_thread_init(&eventer_impl_tls_data[0]);
@@ -449,7 +448,7 @@ void eventer_add_asynch(eventer_jobq_t *q, eventer_t e) {
 
 void eventer_add_timed(eventer_t e) {
   struct eventer_impl_data *t;
-  assert(e->mask & EVENTER_TIMER);
+  mtevAssert(e->mask & EVENTER_TIMER);
   if(EVENTER_DEBUGGING) {
     const char *cbname;
     cbname = eventer_name_for_callback_e(e->callback, e);
@@ -464,7 +463,7 @@ void eventer_add_timed(eventer_t e) {
 eventer_t eventer_remove_timed(eventer_t e) {
   struct eventer_impl_data *t;
   eventer_t removed = NULL;
-  assert(e->mask & EVENTER_TIMER);
+  mtevAssert(e->mask & EVENTER_TIMER);
   t = get_event_impl_data(e);
   pthread_mutex_lock(&t->te_lock);
   if(mtev_skiplist_remove_compare(t->timed_events, e, NULL,
@@ -478,7 +477,7 @@ eventer_t eventer_remove_timed(eventer_t e) {
 }
 void eventer_update_timed(eventer_t e, int mask) {
   struct eventer_impl_data *t;
-  assert(mask & EVENTER_TIMER);
+  mtevAssert(mask & EVENTER_TIMER);
   t = get_event_impl_data(e);
   pthread_mutex_lock(&t->te_lock);
   mtev_skiplist_remove_compare(t->timed_events, e, NULL, mtev_compare_voidptr);
@@ -650,7 +649,7 @@ void eventer_wakeup_noop(eventer_t e) { }
 void eventer_add_recurrent(eventer_t e) {
   struct eventer_impl_data *t;
   struct recurrent_events *node;
-  assert(e->mask & EVENTER_RECURRENT);
+  mtevAssert(e->mask & EVENTER_RECURRENT);
   t = get_event_impl_data(e);
   pthread_mutex_lock(&t->recurrent_lock);
   for(node = t->recurrent_events; node; node = node->next)

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -39,7 +39,6 @@
 #include "libmtev_dtrace_probes.h"
 #include <errno.h>
 #include <setjmp.h>
-#include <assert.h>
 #include <signal.h>
 
 #ifndef JOBQ_SIGNAL
@@ -80,7 +79,7 @@ eventer_jobq_handler(int signo)
   sigjmp_buf *env;
 
   jobq = pthread_getspecific(threads_jobq);
-  assert(jobq);
+  mtevAssert(jobq);
   env = pthread_getspecific(jobq->threadenv);
   job = pthread_getspecific(jobq->activejob);
   if(env && job && job->fd_event && job->fd_event->mask & EVENTER_EVIL_BRUTAL)
@@ -204,7 +203,7 @@ eventer_jobq_maybe_spawn(eventer_jobq_t *jobq) {
     mtevL(mtev_error, "jobq_queue[%s] induced [%d/%d] game over.\n",
           jobq->queue_name, jobq->pending_cancels,
           jobq->desired_concurrency);
-    assert(jobq->pending_cancels != jobq->desired_concurrency);
+    mtevAssert(jobq->pending_cancels != jobq->desired_concurrency);
   }
 }
 void
@@ -336,7 +335,7 @@ eventer_jobq_consume_available(eventer_t e, int mask, void *closure,
   /* This can only be called with a backq jobq
    * (a standalone queue with no backq itself)
    */
-  assert(jobq);
+  mtevAssert(jobq);
   while((job = eventer_jobq_dequeue_nowait(jobq)) != NULL) {
     int newmask;
     if(job->fd_event) {
@@ -357,7 +356,7 @@ eventer_jobq_consume_available(eventer_t e, int mask, void *closure,
       }
       job->fd_event = NULL;
     }
-    assert(job->timeout_event == NULL);
+    mtevAssert(job->timeout_event == NULL);
     mtev_atomic_dec32(&jobq->inflight);
     free(job);
   }

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -116,7 +116,7 @@ static void alter_fd_dissociate(eventer_t e, int mask, struct ports_spec *spec) 
   if (ret == -1) {
     if(s_errno == ENOENT) return; /* Fine */
     if(s_errno == EBADFD) return; /* Fine */
-    mtevL(mtev_error,
+    mtevFatal(mtev_error,
           "eventer port_dissociate failed(%d-%d): %d/%s\n", e->fd, spec->port_fd, s_errno, strerror(s_errno));
   }
 }

--- a/src/modules/lua_general.c
+++ b/src/modules/lua_general.c
@@ -37,7 +37,6 @@
 
 #define LUA_COMPAT_MODULE
 #include "lua_mtev.h"
-#include <assert.h>
 #include <dlfcn.h>
 
 #define MTEV_LUA_REPL_USERDATA "mtev::state::lua_repl"
@@ -98,7 +97,7 @@ lua_general_resume(mtev_lua_resume_info_t *ri, int nargs) {
   const char *err = NULL;
   int status, base, rv = 0;
 
-  assert(pthread_equal(pthread_self(), ri->bound_thread));
+  mtevAssert(pthread_equal(pthread_self(), ri->bound_thread));
 
 #if LUA_VERSION_NUM >= 502
   status = lua_resume(ri->coro_state, ri->lmc->lua_state, nargs);

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -33,7 +33,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <math.h>
 #include <errno.h>
 #include <unistd.h>
@@ -174,7 +173,7 @@ mtev_lua_socket_close(lua_State *L) {
   *eptr = NULL;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   mtev_lua_deregister_event(ci, e, 0);
   eventer_remove_fd(e->fd);
@@ -200,7 +199,7 @@ mtev_lua_socket_connect_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   eventer_remove_fd(e->fd);
   mtev_lua_deregister_event(ci, e, 0);
 
@@ -245,7 +244,7 @@ mtev_lua_socket_recv_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
 
   if(mask & EVENTER_EXCEPTION) {
     lua_pushinteger(cl->L, -1);
@@ -302,7 +301,7 @@ mtev_lua_socket_recv(lua_State *L) {
   socklen_t alen;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -353,7 +352,7 @@ mtev_lua_socket_send_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
 
   if(mask & EVENTER_EXCEPTION) {
     lua_pushinteger(cl->L, -1);
@@ -408,7 +407,7 @@ mtev_lua_socket_send(lua_State *L) {
   ssize_t sbytes;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -457,7 +456,7 @@ mtev_lua_socket_sendto(lua_State *L) {
   } a;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -531,7 +530,7 @@ mtev_lua_socket_bind(lua_State *L) {
   } a;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -607,7 +606,7 @@ mtev_lua_socket_accept_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
 
   inlen = sizeof(addr.in);
   fd = e->opset->accept(e->fd, &addr.in, &inlen, &newmask, e);
@@ -659,7 +658,7 @@ mtev_lua_socket_listen(lua_State *L) {
   int rv;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -690,10 +689,10 @@ mtev_lua_socket_own(lua_State *L) {
   if(cl->L == L) return 0;
   
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   mtev_lua_deregister_event(ci, e, 0);
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
   cl->L = L;
   mtev_lua_register_event(ci, e);
   return 0;
@@ -714,7 +713,7 @@ mtev_lua_socket_accept(lua_State *L) {
   int fd, newmask;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   mtevL(nldeb, "accept starting\n");
   eptr = lua_touserdata(L, lua_upvalueindex(1));
@@ -776,7 +775,7 @@ mtev_lua_socket_setsockopt(lua_State *L) {
   int value;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   if(lua_gettop(L) != 3) {
     lua_pushinteger(L, -1);
@@ -842,7 +841,7 @@ mtev_lua_socket_connect(lua_State *L) {
   } a;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -921,7 +920,7 @@ mtev_lua_ssl_upgrade(eventer_t e, int mask, void *vcl,
   if(rv <= 0 && errno == EAGAIN) return mask | EVENTER_EXCEPTION;
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   mtev_lua_deregister_event(ci, e, 0);
 
   *(cl->eptr) = eventer_alloc();
@@ -955,7 +954,7 @@ mtev_lua_socket_connect_ssl(lua_State *L) {
   int tmpmask, rv;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -1074,7 +1073,7 @@ mtev_lua_socket_read_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
 
   len = mtev_lua_socket_do_read(e, &mask, cl, &args);
   if(len >= 0) {
@@ -1105,7 +1104,7 @@ mtev_lua_socket_read(lua_State *L) {
   eventer_t e, *eptr;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -1148,7 +1147,7 @@ mtev_lua_socket_read(lua_State *L) {
          */
         cl->read_goal = strlen(cl->read_terminator) + cp - cl->inbuff;
         cl->read_terminator = NULL;
-        assert(cl->read_goal <= cl->read_sofar);
+        mtevAssert(cl->read_goal <= cl->read_sofar);
         goto i_know_better;
       }
     }
@@ -1186,7 +1185,7 @@ mtev_lua_socket_write_complete(eventer_t e, int mask, void *vcl,
   }
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
 
   if(mask & EVENTER_EXCEPTION) {
     lua_pushinteger(cl->L, -1);
@@ -1199,7 +1198,7 @@ mtev_lua_socket_write_complete(eventer_t e, int mask, void *vcl,
                                   (cl->write_goal - cl->write_sofar)),
                               &mask, e)) > 0) {
     cl->write_sofar += rv;
-    assert(cl->write_sofar <= cl->write_goal);
+    mtevAssert(cl->write_sofar <= cl->write_goal);
     if(cl->write_sofar == cl->write_goal) break;
   }
   if(rv > 0) {
@@ -1237,7 +1236,7 @@ mtev_lua_socket_write(lua_State *L) {
   eventer_t e, *eptr;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   eptr = lua_touserdata(L, lua_upvalueindex(1));
   if(eptr != lua_touserdata(L, 1))
@@ -1258,7 +1257,7 @@ mtev_lua_socket_write(lua_State *L) {
                                   (cl->write_goal - cl->write_sofar)),
                               &mask, e)) > 0) {
     cl->write_sofar += rv;
-    assert(cl->write_sofar <= cl->write_goal);
+    mtevAssert(cl->write_sofar <= cl->write_goal);
     if(cl->write_sofar == cl->write_goal) break;
   }
   if(rv > 0) {
@@ -1303,7 +1302,7 @@ mtev_eventer_index_func(lua_State *L) {
   const char *k;
   eventer_t *udata;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.eventer")) {
     luaL_error(L, "metatable error, arg1 not a mtev.eventer!");
   }
@@ -1356,7 +1355,7 @@ mtev_ssl_ctx_index_func(lua_State *L) {
   const char *k;
   eventer_ssl_ctx_t **udata, *ssl_ctx;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.eventer.ssl_ctx")) {
     luaL_error(L, "metatable error, arg1 not a mtev.eventer.ssl_ctx!");
   }
@@ -1423,7 +1422,7 @@ nl_waitfor_notify(lua_State *L) {
   int nargs;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
   nargs = lua_gettop(L);
   if(nargs < 1) {
     return 0;
@@ -1437,7 +1436,7 @@ nl_waitfor_notify(lua_State *L) {
   lua_xmove(L, cl->L, nargs);
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   eventer_remove(cl->pending_event);
   mtev_lua_deregister_event(ci, cl->pending_event, 0);
   ci->lmc->resume(ci, nargs);
@@ -1453,7 +1452,7 @@ nl_waitfor_timeout(eventer_t e, int mask, void *vcl, struct timeval *now) {
   double p_int;
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   mtev_lua_deregister_event(ci, e, 0);
   mtev_hash_delete(ci->lmc->pending, cl->inbuff, strlen(cl->inbuff), free, NULL);
   free(cl);
@@ -1471,7 +1470,7 @@ nl_waitfor(lua_State *L) {
   double p_int;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
   if(lua_gettop(L) != 2) {
     luaL_error(L, "waitfor(key, timeout) wrong arguments");
   }
@@ -1511,7 +1510,7 @@ nl_sleep_complete(eventer_t e, int mask, void *vcl, struct timeval *now) {
   double p_int;
 
   ci = mtev_lua_get_resume_info(cl->L);
-  assert(ci);
+  mtevAssert(ci);
   mtev_lua_deregister_event(ci, e, 0);
 
   sub_timeval(*now, cl->start, &diff);
@@ -1531,7 +1530,7 @@ nl_sleep(lua_State *L) {
   double p_int;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   p_int = lua_tonumber(L, 1);
   cl = calloc(1, sizeof(*cl));
@@ -2147,7 +2146,7 @@ nl_socket_internal(lua_State *L, int family, int proto) {
   }
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   cl = calloc(1, sizeof(*cl));
   cl->free = nl_extended_free;
@@ -2818,7 +2817,7 @@ mtev_xmlnode_index_func(lua_State *L) {
   const char *k;
   xmlNodePtr *udata;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.xmlnode")) {
     luaL_error(L, "metatable error, arg1 not a mtev.xmlnode!");
   }
@@ -2881,7 +2880,7 @@ mtev_xmldoc_index_func(lua_State *L) {
   const char *k;
   xmlDocPtr *udata;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.xmldoc")) {
     luaL_error(L, "metatable error, arg1 not a mtev.xmldoc!");
   }
@@ -3115,7 +3114,7 @@ mtev_json_index_func(lua_State *L) {
   const char *k;
   json_crutch **udata;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.json")) {
     luaL_error(L, "metatable error, arg1 not a mtev.json!");
   }
@@ -3157,7 +3156,7 @@ int nl_spawn(lua_State *L) {
   mtev_lua_resume_info_t *ri;
 
   ri = mtev_lua_get_resume_info(L);
-  assert(ri);
+  mtevAssert(ri);
   spawn_info = (struct spawn_info *)lua_newuserdata(L, sizeof(*spawn_info));
   memset(spawn_info, 0, sizeof(*spawn_info));
   spawn_info->pid = -1;
@@ -3316,7 +3315,7 @@ mtev_lua_process_index_func(lua_State *L) {
   const char *k;
   struct spawn_info *udata;
   n = lua_gettop(L); /* number of arguments */
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.process")) {
     luaL_error(L, "metatable error, arg1 not a mtev.process!");
   }
@@ -3350,7 +3349,7 @@ mtev_lua_eventer_gc(lua_State *L) {
     int newmask;
 
     ci = mtev_lua_get_resume_info(cl->L);
-    assert(ci);
+    mtevAssert(ci);
     mtev_lua_deregister_event(ci, e, 0);
     if(e->mask & (EVENTER_EXCEPTION|EVENTER_READ|EVENTER_WRITE))
       eventer_remove_fd(e->fd);
@@ -3382,7 +3381,7 @@ nl_cancel_coro(lua_State *L) {
   mtev_lua_resume_info_t *ci;
   lua_State *co = lua_tothread(L,1);
   ci = mtev_lua_get_resume_info(co);
-  assert(ci);
+  mtevAssert(ci);
   mtev_lua_cancel_coro(ci);
   return 0;
 }

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -34,6 +34,7 @@
 
 #include "mtev_defines.h"
 
+#include <assert.h>
 #include <openssl/x509.h>
 #include <lua.h>
 #include <lauxlib.h>

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -34,7 +34,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <openssl/x509.h>
 #include <lua.h>
 #include <lauxlib.h>
@@ -179,7 +178,7 @@ mtev_lua_setup_restc(lua_State *L,
 
 #define RETURN_INT(L, object, func, expr) do { \
   int base = lua_gettop(L); \
-  assert(base == 1); \
+  mtevAssert(base == 1); \
   if(lua_isnumber(L, -1)) { \
     int rv; \
     rv = lua_tointeger(L, -1); \

--- a/src/modules/lua_mtev_crypto.c
+++ b/src/modules/lua_mtev_crypto.c
@@ -75,7 +75,7 @@ mtev_lua_crypto_x509_index_func(lua_State *L) {
   X509 *cert;
   int j;
 
-  assert(lua_gettop(L) == 2);
+  mtevAssert(lua_gettop(L) == 2);
   if(!luaL_checkudata(L, 1, "crypto.x509")) {
     luaL_error(L, "metatable error, arg1 not a crypto.x509!");
   }
@@ -181,7 +181,7 @@ mtev_lua_crypto_ssl_session_index_func(lua_State *L) {
   SSL_SESSION *ssl_session;
   int j;
 
-  assert(lua_gettop(L) == 2);
+  mtevAssert(lua_gettop(L) == 2);
   if(!luaL_checkudata(L, 1, "crypto.ssl_session")) {
     luaL_error(L, "metatable error, arg1 not a crypto.ssl_session!");
   }
@@ -439,7 +439,7 @@ static int
 mtev_lua_crypto_rsa_index_func(lua_State *L) {
   const char *k;
   void *udata;
-  assert(lua_gettop(L) == 2);
+  mtevAssert(lua_gettop(L) == 2);
   if(!luaL_checkudata(L, 1, "crypto.rsa")) {
     luaL_error(L, "metatable error, arg1 not a crypto.rsa!");
   }
@@ -491,7 +491,7 @@ static int
 mtev_lua_crypto_req_index_func(lua_State *L) {
   const char *k;
   void **udata;
-  assert(lua_gettop(L) == 2);
+  mtevAssert(lua_gettop(L) == 2);
   if(!luaL_checkudata(L, 1, "crypto.req")) {
     luaL_error(L, "metatable error, arg1 not a crypto.req!");
   }
@@ -781,7 +781,7 @@ static int
 mtev_lua_crypto_bignum_index_func(lua_State *L) {
   const char *k;
   void **udata;
-  assert(lua_gettop(L) == 2);
+  mtevAssert(lua_gettop(L) == 2);
   if(!luaL_checkudata(L, 1, "crypto.bignum")) {
     luaL_error(L, "metatable error, arg1 not a crypto.req!");
   }

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -33,7 +33,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <math.h>
 #include <errno.h>
 #include <unistd.h>
@@ -102,7 +101,7 @@ static void eventer_dns_utm_fn(struct dns_ctx *ctx, int timeout, void *data) {
     if(h->timeout) e = eventer_remove(h->timeout);
   }
   else {
-    assert(h->ctx == ctx);
+    mtevAssert(h->ctx == ctx);
     if(timeout < 0) e = eventer_remove(h->timeout);
     else {
       newe = eventer_alloc();
@@ -133,7 +132,7 @@ static void dns_ctx_handle_free(void *vh) {
   }
   dns_close(h->ctx);
   dns_free(h->ctx);
-  assert(h->timeout == NULL);
+  mtevAssert(h->timeout == NULL);
   free(h);
 }
 
@@ -196,7 +195,7 @@ static void dns_ctx_release(dns_ctx_handle_t *h) {
   if(!dns_ctx_store) dns_ctx_store = calloc(1, sizeof(*dns_ctx_store));
   if(mtev_atomic_dec32(&h->refcnt) == 0) {
     /* I was the last one */
-    assert(mtev_hash_delete(dns_ctx_store, h->ns, strlen(h->ns),
+    mtevAssert(mtev_hash_delete(dns_ctx_store, h->ns, strlen(h->ns),
                             NULL, dns_ctx_handle_free));
   }
 }
@@ -219,7 +218,7 @@ int nl_dns_lookup(lua_State *L) {
   mtev_lua_resume_info_t *ci;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
   if(lua_gettop(L) > 0)
     nameserver = lua_tostring(L, 1);
   holder = (dns_lookup_ctx_t **)lua_newuserdata(L, sizeof(*holder));
@@ -421,7 +420,7 @@ static int mtev_lua_dns_lookup(lua_State *L) {
   int rv;
 
   ci = mtev_lua_get_resume_info(L);
-  assert(ci);
+  mtevAssert(ci);
 
   holder = (dns_lookup_ctx_t **)lua_touserdata(L, lua_upvalueindex(1));
   if(holder != lua_touserdata(L,1))
@@ -504,7 +503,7 @@ int mtev_lua_dns_index_func(lua_State *L) {
   dns_lookup_ctx_t **udata;
 
   n = lua_gettop(L);
-  assert(n == 2);
+  mtevAssert(n == 2);
   if(!luaL_checkudata(L, 1, "mtev.dns"))
     luaL_error(L, "metatable error, arg1 is not a mtev.dns");
   udata = lua_touserdata(L, 1);

--- a/src/modules/lua_mtev_http.c
+++ b/src/modules/lua_mtev_http.c
@@ -32,7 +32,6 @@
 
 #include <errno.h>
 #include <sys/mman.h>
-#include <assert.h>
 #include <ctype.h>
 #include <lauxlib.h>
 
@@ -45,7 +44,7 @@
   const char *methodvar; \
   int n; \
   n = lua_gettop(L);    /* number of arguments */ \
-  assert(n == 2); \
+  mtevAssert(n == 2); \
   if(!luaL_checkudata(L, 1, #type)) { \
     luaL_error(L, "metatable error, arg1 not " #type "!"); \
   } \

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -30,7 +30,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <dlfcn.h>
 
 #include "mtev_dso.h"
@@ -114,7 +113,7 @@ lua_web_resume(mtev_lua_resume_info_t *ri, int nargs) {
     conne = mtev_http_connection_event(mtev_http_session_connection(restc->http_ctx));
   }
 
-  assert(pthread_equal(pthread_self(), ri->bound_thread));
+  mtevAssert(pthread_equal(pthread_self(), ri->bound_thread));
 
 #if LUA_VERSION_NUM >= 502
   status = lua_resume(ri->coro_state, ri->lmc->lua_state, nargs);
@@ -363,7 +362,7 @@ static mtev_hook_return_t late_stage_rest_register(void *cl) {
     mtevL(mtev_debug, "Registering [%s][%s][%s] -> %s\n",
           conf->mounts[i].method, conf->mounts[i].mount,
           conf->mounts[i].expr, conf->mounts[i].module);
-    assert(
+    mtevAssert(
       mtev_http_rest_register_closure(
         conf->mounts[i].method, conf->mounts[i].mount,
         conf->mounts[i].expr, lua_web_handler,

--- a/src/mtev_capabilities_listener.c
+++ b/src/mtev_capabilities_listener.c
@@ -49,7 +49,6 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 #include <sys/utsname.h>
-#include <assert.h>
 
 #include <libxml/xmlsave.h>
 #include <libxml/tree.h>
@@ -80,7 +79,7 @@ mtev_capabilities_listener_init() {
   mtev_control_dispatch_delegate(mtev_control_dispatch,
                                  MTEV_CAPABILITIES_SERVICE,
                                  mtev_capabilities_handler);
-  assert(mtev_http_rest_register("GET", "/", "capa(\\.json)?",
+  mtevAssert(mtev_http_rest_register("GET", "/", "capa(\\.json)?",
                                  mtev_capabilities_rest) == 0);
 }
 

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -30,7 +30,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <libxml/tree.h>
 #include <inttypes.h>
 
@@ -841,11 +840,11 @@ mtev_cluster_init() {
   }
   if(clusters) free(clusters);
 
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/", "^cluster(?:/(.+))?$", rest_show_cluster,
              mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "POST", "/", "^cluster$", rest_update_cluster,
              mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -38,7 +38,6 @@
 #include <fcntl.h>
 #include <dirent.h>
 #include <errno.h>
-#include <assert.h>
 #include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
@@ -424,7 +423,7 @@ void mtev_conf_init(const char *toplevel) {
 static void
 mtev_conf_magic_separate_includes(include_node_t **root_include_nodes, int *cnt) {
   include_node_t *include_nodes = *root_include_nodes;
-  assert(*cnt != -1);
+  mtevAssert(*cnt != -1);
   if(include_nodes) {
     int i;
     for(i=0; i<*cnt; i++) {
@@ -448,7 +447,7 @@ mtev_conf_magic_separate_includes(include_node_t **root_include_nodes, int *cnt)
 static void
 mtev_conf_magic_separate() {
   mtev_conf_magic_separate_includes(&config_include_nodes, &config_include_cnt);
-  assert(config_include_nodes == NULL);
+  mtevAssert(config_include_nodes == NULL);
   if(backingstore_include_nodes) {
     int i;
     for(i=0; i<backingstore_include_cnt; i++) {
@@ -531,7 +530,7 @@ remove_emancipated_child_node(xmlNodePtr oldp, xmlNodePtr node) {
   /* node was once a child of oldp... it's still in it's children list
    * but node's parent isn't this child.
    */
-  assert(node->parent != oldp);
+  mtevAssert(node->parent != oldp);
   if(oldp->children == NULL) return;
   if(oldp->children == node) {
     oldp->children = node->next;
@@ -858,10 +857,10 @@ mtev_conf_magic_mix(const char *parentfile, xmlDocPtr doc, include_node_t* inc_n
     master = 1;
   }
 
-  assert(*include_cnt == -1);
+  mtevAssert(*include_cnt == -1);
 
   if (master) {
-    assert(backingstore_include_cnt == -1);
+    mtevAssert(backingstore_include_cnt == -1);
     backingstore_include_cnt = 0;
   }
   mix_ctxt = xmlXPathNewContext(doc);
@@ -1760,7 +1759,7 @@ struct config_line_vstr {
 static int
 mtev_config_log_write_xml(void *vstr, const char *buffer, int len) {
   struct config_line_vstr *clv = vstr;
-  assert(clv->encoded == CONFIG_RAW);
+  mtevAssert(clv->encoded == CONFIG_RAW);
   if(!clv->buff) {
     clv->allocd = 8192;
     clv->buff = malloc(clv->allocd);
@@ -1792,7 +1791,7 @@ mtev_config_log_close_xml(void *vstr) {
     return 0;
   }
   clv->raw_len = clv->len;
-  assert(clv->encoded == CONFIG_RAW);
+  mtevAssert(clv->encoded == CONFIG_RAW);
   if(clv->encoded == clv->target) return 0;
 
   /* Compress */

--- a/src/mtev_console.c
+++ b/src/mtev_console.c
@@ -33,7 +33,6 @@
 
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <unistd.h>
 #ifdef HAVE_ALLOCA_H
@@ -465,7 +464,7 @@ socket_error:
         int written;
         written = write(ncct->pty_slave, sbuf, len);
         if(written <= 0) goto socket_error;
-        assert(written == len);
+        mtevAssert(written == len);
       }
     }
     if(buffer) {
@@ -585,7 +584,7 @@ socket_error:
         int written;
         written = write(ncct->pty_slave, sbuf, len);
         if(written <= 0) goto socket_error;
-        assert(written == len);
+        mtevAssert(written == len);
       }
     }
     if(buffer) {

--- a/src/mtev_console_state.c
+++ b/src/mtev_console_state.c
@@ -48,7 +48,6 @@
 #include <pcre.h>
 #include <errno.h>
 #include <sys/utsname.h>
-#include <assert.h>
 
 int cmd_info_comparek(const void *akv, const void *bv) {
   char *ak = (char *)akv;
@@ -427,7 +426,7 @@ mtev_console_generic_apply(mtev_console_closure_t ncct,
   if(!count) {
     nc_printf(ncct, "apply error: '%s' range produced nothing [%s]\n",
               range, err ? err : "unknown error");
-    assert(expanded == NULL);
+    mtevAssert(expanded == NULL);
     return -1;
   }
   if(count < 0) {

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -35,7 +35,6 @@
 
 #include <stdio.h>
 #include <dlfcn.h>
-#include <assert.h>
 
 #include <libxml/parser.h>
 #include <libxslt/xslt.h>

--- a/src/mtev_events_rest.c
+++ b/src/mtev_events_rest.c
@@ -35,7 +35,6 @@
 #include "mtev_conf.h"
 #include "eventer/eventer.h"
 #include "mtev_json.h"
-#include <assert.h>
 #include <errno.h>
 #include <arpa/inet.h>
 
@@ -251,7 +250,7 @@ mtev_rest_eventer_logs(mtev_http_rest_closure_t *restc, int n, char **p) {
   last_s = mtev_http_request_querystring(req, "last");
   if(last_s) last = atoi(last_s);
 
-  assert(n==1);
+  mtevAssert(n==1);
   ls = mtev_log_stream_find(p[0]);
   if(!ls || strcmp(mtev_log_stream_get_type(ls),"memory"))
     goto not_found;
@@ -284,23 +283,23 @@ mtev_rest_eventer_logs(mtev_http_rest_closure_t *restc, int n, char **p) {
 
 void
 mtev_events_rest_init() {
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/eventer/", "^memory\\.json$",
     mtev_rest_eventer_memory, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/eventer/", "^sockets\\.json$",
     mtev_rest_eventer_sockets, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/eventer/", "^timers\\.json$",
     mtev_rest_eventer_timers, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/eventer/", "^jobq\\.json$",
     mtev_rest_eventer_jobq, mtev_http_rest_client_cert_auth
   ) == 0);
-  assert(mtev_http_rest_register_auth(
+  mtevAssert(mtev_http_rest_register_auth(
     "GET", "/eventer/", "^logs/(.+)\\.json$",
     mtev_rest_eventer_logs, mtev_http_rest_client_cert_auth
   ) == 0);

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -41,7 +41,6 @@
 #include <netinet/in.h>
 #include <sys/un.h>
 #include <arpa/inet.h>
-#include <assert.h>
 
 #include "eventer/eventer.h"
 #include "mtev_log.h"
@@ -515,7 +514,7 @@ mtev_control_dispatch(eventer_t e, int mask, void *closure,
   mtev_hash_table *delegation_table = NULL;
   acceptor_closure_t *ac = closure;
 
-  assert(ac->rlen >= 0);
+  mtevAssert(ac->rlen >= 0);
   while(len >= 0 && ac->rlen < sizeof(cmd)) {
     len = e->opset->read(e->fd, ((char *)&cmd) + ac->rlen,
                          sizeof(cmd) - ac->rlen, &mask, e);
@@ -524,7 +523,7 @@ mtev_control_dispatch(eventer_t e, int mask, void *closure,
 
     if(len > 0) ac->rlen += len;
   }
-  assert(ac->rlen >= 0 && ac->rlen <= sizeof(cmd));
+  mtevAssert(ac->rlen >= 0 && ac->rlen <= sizeof(cmd));
 
   if(callmask & EVENTER_EXCEPTION || ac->rlen != sizeof(cmd)) {
     int newmask;

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -32,7 +32,6 @@
  */
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/src/mtev_net_heartbeat.c
+++ b/src/mtev_net_heartbeat.c
@@ -149,7 +149,7 @@ mtev_net_heartbeat_handler(eventer_t e, int mask, void *closure, struct timeval 
     /* decrypt payload into text */
     len = msg.msg_iov[2].iov_len;
     EVP_CipherInit(&evp_ctx, EVP_aes_256_cbc(), ctx->key, ivec, false);
-    assert(EVP_CIPHER_CTX_iv_length(&evp_ctx) == HDR_IVSIZE);
+    mtevAssert(EVP_CIPHER_CTX_iv_length(&evp_ctx) == HDR_IVSIZE);
     EVP_DecryptUpdate(&evp_ctx,text,&outlen1,
                       (unsigned char *)payload,len);
     EVP_DecryptFinal(&evp_ctx,text+outlen1,&outlen2);
@@ -233,12 +233,12 @@ mtev_net_heartbeat_serialize_and_send(mtev_net_heartbeat_ctx *ctx) {
   /* 2 words of magic */
   hdr[i++] = htonl(HBPKTMAGIC1);
   hdr[i++] = htonl(HBPKTMAGIC2);
-  assert(i==9);
+  mtevAssert(i==9);
 
   EVP_CipherInit(&evp_ctx, EVP_aes_256_cbc(), ctx->key, ivec, true);
   blocksize = EVP_CIPHER_CTX_block_size(&evp_ctx);
   ivecsize = EVP_CIPHER_CTX_iv_length(&evp_ctx);
-  assert(ivecsize == HDR_IVSIZE);
+  mtevAssert(ivecsize == HDR_IVSIZE);
   if(len + blocksize*2 > cipher_buf_len) {
     if(cipher_buf != cipher_buf_static) free(cipher_buf);
     cipher_buf = malloc(len + blocksize * 2);

--- a/src/mtev_xml.c
+++ b/src/mtev_xml.c
@@ -38,7 +38,6 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
-#include <assert.h>
 
 struct mtev_xml_buffer_ptr {
   char *buff;
@@ -86,7 +85,7 @@ mtev_xmlSaveToBuffer(xmlDocPtr doc) {
   out = xmlOutputBufferCreateIO(mtev_xml_save_writer,
                                 mtev_xml_save_closer,
                                 &buf, enc);
-  assert(out);
+  mtevAssert(out);
   xmlSaveFormatFileTo(out, doc, "utf8", 1);
   return buf.buff;
 }
@@ -137,7 +136,7 @@ mtev_xmlSaveToFile(xmlDocPtr doc, const char *filename) {
   }
   enc = xmlGetCharEncodingHandler(XML_CHAR_ENCODING_UTF8);
   out = xmlOutputBufferCreateFd(fd, enc);
-  assert(out);
+  mtevAssert(out);
   xmlSaveFormatFileTo(out, doc, "utf8", 1);
   close(fd);
   rv = 0;

--- a/src/noitedit/key.c
+++ b/src/noitedit/key.c
@@ -71,7 +71,6 @@ __RCSID("$NetBSD: key.c,v 1.12 2001/05/17 01:02:17 christos Exp $");
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <assert.h>
 
 #include "noitedit/el.h"
 

--- a/src/utils/mtev_btrie.c
+++ b/src/utils/mtev_btrie.c
@@ -33,13 +33,13 @@
 
 #include "mtev_defines.h"
 #include "mtev_btrie.h"
+#include "mtev_log.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <arpa/inet.h>
-#include <assert.h>
 // BITS should be either 32 or 128
 #define MAXBITS 128
 
@@ -223,7 +223,7 @@ void mtev_add_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
   btrie_node *node, *parent, *down, *newnode;
   int bits_in_common;
 
-  assert(prefix_len <= MAXBITS);
+  mtevAssert(prefix_len <= MAXBITS);
   if(!*tree) {
     node = (btrie_node *)calloc(1, sizeof(*node));
     node->data = data;
@@ -256,7 +256,7 @@ void mtev_add_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
   bits_in_common = calc_bits_in_commons(down, key, prefix_len);
   parent = node;
   if(bits_in_common > prefix_len) bits_in_common = prefix_len;
-  assert(!parent || parent->prefix_len < prefix_len);
+  mtevAssert(!parent || parent->prefix_len < prefix_len);
 
   /* we either need to make a new branch above down and newnode
    * or newnode can be the branch.  newnode can be the branch if
@@ -265,7 +265,7 @@ void mtev_add_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
     /* newnode can be the branch */
     int plen = parent ? parent->prefix_len+1 : 1;
     if(parent)
-      assert(BIT_AT(newnode->bits, plen) == BIT_AT(down->bits, plen));
+      mtevAssert(BIT_AT(newnode->bits, plen) == BIT_AT(down->bits, plen));
     newnode->bit[BIT_AT(down->bits, newnode->prefix_len+1)] = down;
     if(!parent) *tree = newnode;
     else parent->bit[BIT_AT(newnode->bits, plen)] = newnode;
@@ -278,7 +278,7 @@ void mtev_add_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
     node->incidental = 1;
     memcpy(node->bits, newnode->bits, sizeof(node->bits));
     DA(node, node->prefix_len, "incidental");
-    assert(BIT_AT(down->bits, node->prefix_len+1) !=
+    mtevAssert(BIT_AT(down->bits, node->prefix_len+1) !=
            BIT_AT(newnode->bits, node->prefix_len+1));
     node->bit[BIT_AT(down->bits, node->prefix_len+1)] = down;
     node->bit[BIT_AT(newnode->bits, node->prefix_len+1)] = newnode;
@@ -291,7 +291,7 @@ void mtev_add_route(btrie *tree, uint32_t *key, unsigned char prefix_len,
 void mtev_add_route_ipv4(btrie *tree, struct in_addr *a,
                     unsigned char prefix_len, void *data) {
   uint32_t ia = ntohl(a->s_addr), mask;
-  assert(prefix_len <= 32);
+  mtevAssert(prefix_len <= 32);
   mask = (prefix_len == 32) ? 0xffffffff : ~(0xffffffff >> prefix_len);
   ia &= mask;
   mtev_add_route(tree, &ia, prefix_len, data);
@@ -308,7 +308,7 @@ void mtev_add_route_ipv6(btrie *tree, struct in6_addr *a,
       mask = (splen >= 32) ? 0xffffffff : ~(0xffffffff >> splen);
     ia[i] = ntohl(ia[i]) & mask;
   }
-  assert(prefix_len <= 128);
+  mtevAssert(prefix_len <= 128);
   mtev_add_route(tree, ia, prefix_len, data);
 }
 

--- a/src/utils/mtev_cht.c
+++ b/src/utils/mtev_cht.c
@@ -30,8 +30,7 @@
 
 #include "mtev_cht.h"
 #include "mtev_hash.h"
-
-#include <assert.h>
+#include "mtev_log.h"
 
 #define DEFAULT_CHT_BITS 32
 #define DEFAULT_WEIGHT 32
@@ -147,14 +146,14 @@ mtev_cht_calculate_ring(mtev_cht_t *cht) {
   for(i=0;i<rsize-1;i++) {
     s = &cht->ring[i];
     e = &cht->ring[i+1];
-    assert(s->pos <= max);
+    mtevAssert(s->pos <= max);
     cht->nodes[s->node_idx].owned +=
       (double)(e->pos - s->pos)/((double)max + 1.0);
   }
   /* the last element wraps */
   s = &cht->ring[rsize-1];
   e = &cht->ring[0];
-  assert(s->pos <= max);
+  mtevAssert(s->pos <= max);
   cht->nodes[s->node_idx].owned +=
     ((double)(max - s->pos) + 1.0 + (double)(e->pos))/((double)max + 1.0);
 }
@@ -230,7 +229,7 @@ mtev_cht_vlookup_n(mtev_cht_t *cht, const void *key, size_t keylen,
 
   /* handle wrap under */
   if(hash < cht->ring[m].pos) {
-    assert(m == 0);
+    mtevAssert(m == 0);
     m = rsize - 1;
   }
   for(i=m;w_out < cht->node_cnt && i < rsize+m;i++) {

--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -33,8 +33,8 @@
 
 #include "mtev_config.h"
 #include "mtev_hash.h"
+#include "mtev_log.h"
 #include <time.h>
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ck_epoch.h>
@@ -197,9 +197,9 @@ void mtev_hash_init_size(mtev_hash_table *h, int size) {
 
   if(size < 8) size = 8;
 
-  assert(ck_hs_init(&h->hs, CK_HS_MODE_OBJECT | CK_HS_MODE_SPMC, hs_hash, hs_compare, &my_allocator,
+  mtevAssert(ck_hs_init(&h->hs, CK_HS_MODE_OBJECT | CK_HS_MODE_SPMC, hs_hash, hs_compare, &my_allocator,
                          size, lrand48()));
-  assert(h->hs.hf != NULL);
+  mtevAssert(h->hs.hf != NULL);
 }
 int mtev_hash_size(mtev_hash_table *h) {
   if(h->hs.hf == NULL) mtev_hash_init(h);

--- a/src/utils/mtev_hooks.h
+++ b/src/utils/mtev_hooks.h
@@ -35,7 +35,6 @@
 #define UTILS_MTEV_HOOKS
 
 #include <mtev_atomic.h>
-#include <assert.h>
 #include <dlfcn.h>
 
 /*#* DOCBOOK
@@ -204,7 +203,7 @@ static inline RTYPE FUNCNAME PROTO { \
       mtevL(mtev_error, "runtime resolution of '%s %s%s' failed.\n", \
             #RTYPE, #FUNCNAME, #PROTO); \
     } \
-    assert(f_); \
+    mtevAssert(f_); \
   } \
   return f_ PARAMS; \
 }

--- a/src/utils/mtev_hooks.h
+++ b/src/utils/mtev_hooks.h
@@ -35,6 +35,7 @@
 #define UTILS_MTEV_HOOKS
 
 #include <mtev_atomic.h>
+#include <assert.h>
 #include <dlfcn.h>
 
 /*#* DOCBOOK

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -172,11 +172,18 @@ API_EXPORT(int)
   mtevL(ls, "[FATAL] " args); \
   abort(); \
 } while(0)
+
+#ifdef NDEBUG
+#define mtevAssert(condition) do {} while(0)
+#define mtevEvalAssert(condition) do { if (!(condition)) ; } while(0)
+#else
 #define mtevAssert(condition) do {\
   if(!(condition)) { \
-    mtevFatal(mtev_error, "%s\n", #condition);\
+    mtevFatal(mtev_error, "assertion (%s) at %s:%d failed\n", #condition, __FILE__, __LINE__);\
   }\
 } while(0)
+#define mtevEvalAssert(condition) mtevAssert(condition)
+#endif
 
 #define SETUP_LOG(a, b) do { if(!a##_log) a##_log = mtev_log_stream_find(#a); \
                              if(!a##_log) { b; } } while(0)

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -172,6 +172,11 @@ API_EXPORT(int)
   mtevL(ls, "[FATAL] " args); \
   abort(); \
 } while(0)
+#define mtevAssert(condition) do {\
+  if(!(condition)) { \
+    mtevFatal(mtev_error, "%s\n", #condition);\
+  }\
+} while(0)
 
 #define SETUP_LOG(a, b) do { if(!a##_log) a##_log = mtev_log_stream_find(#a); \
                              if(!a##_log) { b; } } while(0)

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -31,7 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <assert.h>
 #include <ck_epoch.h>
 #include <ck_fifo.h>
 #include "mtev_log.h"
@@ -208,7 +207,7 @@ mtev_memory_maintenance_ex(mtev_memory_maintenance_method_t method) {
     }
     method = MTEV_MM_BARRIER;
   }
-  assert(epoch_rec->active == 0);
+  mtevAssert(epoch_rec->active == 0);
   switch(method) {
     case MTEV_MM_BARRIER:
       ck_epoch_barrier(epoch_rec);
@@ -317,7 +316,7 @@ mtev_memory_ck_free_func(void *p, size_t b, bool r,
 
   if(p == NULL) return;
   (void)b;
-  assert(e->magic == MTEV_EPOCH_SAFE_MAGIC);
+  mtevAssert(e->magic == MTEV_EPOCH_SAFE_MAGIC);
 
   if (r == true) {
     /* Destruction requires safe memory reclamation. */

--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -19,11 +19,11 @@
 
 #include "mtev_defines.h"
 #include "mtev_skiplist.h"
+#include "mtev_log.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 #ifdef HAVE_ALLOCA_H
 #include <alloca.h>
 #endif
@@ -168,7 +168,7 @@ void *mtev_skiplist_find_neighbors_compare(mtev_skiplist *sli,
     sl = sli;
   } else {
     mtev_skiplist_find(sli->index, (void *)comp, &m);
-    assert(m);
+    mtevAssert(m);
     sl= (mtev_skiplist *) m->data;
   }
   mtev_skiplisti_find_compare(sl, data, iter, prev, next, sl->comparek);
@@ -305,11 +305,11 @@ mtev_skiplist_node *mtev_skiplist_insert_compare(mtev_skiplist *sl,
   if(sl->index != NULL) {
     /* this is a external insertion, we must insert into each index as well */
     mtev_skiplist_node *p, *ni, *li;
-    assert(ret);
+    mtevAssert(ret);
     li=ret;
     for(p = mtev_skiplist_getlist(sl->index); p; mtev_skiplist_next(sl->index, &p)) {
       ni = mtev_skiplist_insert((mtev_skiplist *)p->data, ret->data);
-      assert(ni);
+      mtevAssert(ni);
       li->nextindex = ni;
       ni->previndex = li;
       li = ni;
@@ -326,7 +326,7 @@ int mtev_skiplist_remove(mtev_skiplist *sl,
 int mtev_skiplist_remove_node(mtev_skiplist *sl, mtev_skiplist_node *m,
                               mtev_freefunc_t myfree) {
   while(m->previndex) m = m->previndex;
-  assert(sl == m->sl);
+  mtevAssert(sl == m->sl);
   return mtev_skiplisti_remove(sl, m, myfree);
 }
 int mtev_skiplisti_remove(mtev_skiplist *sl, mtev_skiplist_node *m, mtev_freefunc_t myfree) {
@@ -365,7 +365,7 @@ int mtev_skiplist_remove_compare(mtev_skiplist *sli,
     sl = sli;
   } else {
     mtev_skiplist_find(sli->index, (void *)comp, &m);
-    assert(m);
+    mtevAssert(m);
     sl= (mtev_skiplist *) m->data;
   }
   mtev_skiplisti_find_compare(sl, data, &m, NULL, NULL, sl->comparek);

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -32,7 +32,6 @@
  */
 #include "mtev_defines.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -371,7 +370,7 @@ void clear_signals() {
   struct itimerval izero;
 
   memset(&izero, 0, sizeof(izero));
-  assert(setitimer(ITIMER_REAL, &izero, NULL) == 0);
+  mtevAssert(setitimer(ITIMER_REAL, &izero, NULL) == 0);
   sigfillset(&all);
   sigprocmask(SIG_UNBLOCK, &all, NULL);
   memset(&act, 0, sizeof(act));
@@ -401,7 +400,7 @@ void setup_signals(sigset_t *mysigs) {
   one_second.it_value.tv_usec = 0;
   one_second.it_interval.tv_sec = 1;
   one_second.it_interval.tv_usec = 0;
-  assert(setitimer(ITIMER_REAL, &one_second, NULL) == 0);
+  mtevAssert(setitimer(ITIMER_REAL, &one_second, NULL) == 0);
 }
 
 int mtev_watchdog_start_child(const char *app, int (*func)(),
@@ -617,7 +616,7 @@ static int watchdog_tick(eventer_t e, int mask, void *unused, struct timeval *no
 int mtev_watchdog_child_eventer_heartbeat() {
   eventer_t e;
 
-  assert(__eventer);
+  mtevAssert(__eventer);
 
  /* Setup our hearbeat */
   e = eventer_alloc();

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -37,7 +37,6 @@
 #include <time.h>
 #include "mtev_config.h"
 #include "mtev_defines.h"
-#include "mtev_log.h"
 
 /*! \fn int mtev_watchdog_prefork_init()
     \brief Prepare the program to split into a child/parent-monitor relationship.

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -37,6 +37,7 @@
 #include <time.h>
 #include "mtev_config.h"
 #include "mtev_defines.h"
+#include "mtev_log.h"
 
 /*! \fn int mtev_watchdog_prefork_init()
     \brief Prepare the program to split into a child/parent-monitor relationship.


### PR DESCRIPTION
Add a custom call, "mtevAssert", that will replace normal assert calls.
This will log the error to mtevError, flush the log, then abort.

In addition, this makes it much easier if we wish to add other prints or
information to the logging when we need to assert.