### PR TITLE
Add Error Message If NDEBUG Is Defined

### DIFF
--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -174,6 +174,7 @@ API_EXPORT(int)
 } while(0)
 
 #ifdef NDEBUG
+#error "need to audit mtevAssert usage"
 #define mtevAssert(condition) do {} while(0)
 #define mtevEvalAssert(condition) do { if (!(condition)) ; } while(0)
 #else


### PR DESCRIPTION
If NDEBUG is defined, add an #error that audit of mtevAssert is
required.