### PR TITLE
add fd back to spec->epoll_fd when doing implicit eventer_add during …

### DIFF
--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -254,6 +254,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
   const char *cbname;
   ev_lock_state_t lockstate;
   int cross_thread = mask & EVENTER_CROSS_THREAD_TRIGGER;
+  int added_to_master_fds = 0;
 
   mask = mask & ~(EVENTER_RESERVED);
   fd = e->fd;
@@ -274,21 +275,9 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
     return;
   }
   if(master_fds[fd].e == NULL) {
-    struct epoll_event _ev;
-    memset(&_ev, 0, sizeof(_ev));
-    _ev.data.fd = fd;
-    if(mask & EVENTER_READ) _ev.events |= (EPOLLIN|EPOLLPRI);
-    if(mask & EVENTER_WRITE) _ev.events |= (EPOLLOUT);
-    if(mask & EVENTER_EXCEPTION) _ev.events |= (EPOLLERR|EPOLLHUP);
-    spec = eventer_get_spec_for_event(e);
-    if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_ADD, fd, &_ev) != 0) {
-      mtevFatal(mtev_error,
-                "epoll_ctl(spec->epoll_fd, EPOLL_CTL_ADD, fd, &_ev) failed; "
-                "spec->epoll_fd: %d; fd: %d; errno: %d (%s)\n",
-                spec->epoll_fd, fd, errno, strerror(errno));
-    }
     master_fds[fd].e = e;
     e->mask = 0;
+    added_to_master_fds = 1;
   }
   if(e != master_fds[fd].e) return;
   lockstate = acquire_master_fd(fd);
@@ -320,7 +309,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
         pthread_t tgt = e->thr_owner;
         e->thr_owner = pthread_self();
         spec = eventer_get_spec_for_event(e);
-        if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) != 0) {
+        if(! added_to_master_fds && epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) != 0) {
           mtevFatal(mtev_error,
                     "epoll_ctl(spec->epoll_fd, EPOLL_CTL_DEL, fd, &_ev) failed; "
                     "spec->epoll_fd: %d; fd: %d; errno: %d (%s)\n",
@@ -332,8 +321,9 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
         mtevL(eventer_deb, "moved event[%p] from t@%d to t@%d\n", e, (int)pthread_self(), (int)tgt);
       }
       else {
+        int epoll_cmd = added_to_master_fds ? EPOLL_CTL_ADD : EPOLL_CTL_MOD;
         spec = eventer_get_spec_for_event(e);
-        if(epoll_ctl(spec->epoll_fd, EPOLL_CTL_MOD, fd, &_ev) != 0) {
+        if(epoll_ctl(spec->epoll_fd, epoll_cmd, fd, &_ev) != 0) {
           mtevFatal(mtev_error,
                     "epoll_ctl(spec->epoll_fd, EPOLL_CTL_MOD, fd, &_ev) failed; "
                     "spec->epoll_fd: %d; fd: %d; errno: %d (%s)\n",


### PR DESCRIPTION
…eventer_trigger.

seems to fix case where we hit an assertion that EPOLL_CTL_MOD failed due
to the fd not being associated to the epoll_fd.