### PR TITLE
Add FQ-modules-only install target

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -203,9 +203,9 @@ AC_SUBST(ATOMIC_OBJS)
 AC_DEFINE_UNQUOTED(MODULEEXT, "$MODULEEXT", [module extension])
 AC_MSG_CHECKING([enable build/install of the Java IEP and Jezebel bits])
 
-LUA_MODULE=lua_mtev.$MODULEEXT
+LUA4MTEV=lua_mtev.$MODULEEXT
 if test "$ENABLE_LUA" = "no"; then
-  LUA_MODULE=
+  LUA4MTEV=
 fi
 
 # Checks for data types
@@ -253,7 +253,7 @@ AS_IF([test "x$enable_zipkin_fq" != "xno"], [
 	OLD_LIBS=$LIBS
 	LIBS=
 	AC_CHECK_LIB(fq, fq_client_init, [
-		BUILD_MODULES="$BUILD_MODULES zipkin_fq.$MODULEEXT"
+		FQ_MODULES="$FQ_MODULES zipkin_fq.$MODULEEXT"
 	], [AC_MSG_ERROR([*** can't build zipkin-fq, no -lfq ***])])
 	LIBS=$OLD_LIBS
 ])
@@ -265,7 +265,8 @@ AS_IF([test "x$enable_fq" != "xno"], [
 	OLD_LIBS=$LIBS
 	LIBS=
 	AC_CHECK_LIB(fq, fq_client_init, [
-		BUILD_MODULES="$BUILD_MODULES fq.$MODULEEXT"
+		FQ_MODULES="$FQ_MODULES fq.$MODULEEXT"
+                FQ_HEADERS=mtev_fq.h
 	], [AC_MSG_ERROR([*** can't build fq, no -lfq ***])])
 	LIBS=$OLD_LIBS
 ])
@@ -693,8 +694,9 @@ if test "x$ac_cv_have_ssize_t" = "xyes" ; then
 	AC_DEFINE(HAVE_SSIZE_T)
 fi
 
-BUILD_MODULES="$BUILD_MODULES $LUA_MODULE"
-AC_SUBST(BUILD_MODULES)
+AC_SUBST(FQ_MODULES)
+AC_SUBST(FQ_HEADERS)
+AC_SUBST(LUA4MTEV)
 
 docdir="docs"
 mansubdir="man"

--- a/configure.in
+++ b/configure.in
@@ -266,7 +266,6 @@ AS_IF([test "x$enable_fq" != "xno"], [
 	LIBS=
 	AC_CHECK_LIB(fq, fq_client_init, [
 		FQ_MODULES="$FQ_MODULES fq.$MODULEEXT"
-                FQ_HEADERS=mtev_fq.h
 	], [AC_MSG_ERROR([*** can't build fq, no -lfq ***])])
 	LIBS=$OLD_LIBS
 ])
@@ -695,7 +694,6 @@ if test "x$ac_cv_have_ssize_t" = "xyes" ; then
 fi
 
 AC_SUBST(FQ_MODULES)
-AC_SUBST(FQ_HEADERS)
 AC_SUBST(LUA4MTEV)
 
 docdir="docs"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -107,7 +107,8 @@ MAPPEDHEADERS= \
 	json-lib/mtev_arraylist.h json-lib/mtev_bits.h json-lib/mtev_debug.h \
 	json-lib/mtev_json_object.h \
 	json-lib/mtev_json_tokener.h json-lib/mtev_json_util.h json-lib/mtev_json.h \
-	json-lib/mtev_linkhash.h json-lib/mtev_printbuf.h
+	json-lib/mtev_linkhash.h json-lib/mtev_printbuf.h \
+	modules/mtev_fq.h
 
 
 JSON_LIB_OBJS=json-lib/mtev_arraylist.lo json-lib/mtev_debug.lo json-lib/mtev_json_object.lo \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -107,8 +107,7 @@ MAPPEDHEADERS= \
 	json-lib/mtev_arraylist.h json-lib/mtev_bits.h json-lib/mtev_debug.h \
 	json-lib/mtev_json_object.h \
 	json-lib/mtev_json_tokener.h json-lib/mtev_json_util.h json-lib/mtev_json.h \
-	json-lib/mtev_linkhash.h json-lib/mtev_printbuf.h \
-	modules/mtev_fq.h
+	json-lib/mtev_linkhash.h json-lib/mtev_printbuf.h
 
 
 JSON_LIB_OBJS=json-lib/mtev_arraylist.lo json-lib/mtev_debug.lo json-lib/mtev_json_object.lo \
@@ -283,6 +282,7 @@ clean:
 	rm -rf mdb-support/*.lo mdb-support/*.so
 	(cd eventer && $(MAKE) clean)
 	(cd man && $(MAKE) clean)
+	(cd modules && $(MAKE) clean)
 	(cd noitedit && $(MAKE) clean)
 	(cd utils && $(MAKE) clean)
 	(cd json-lib && $(MAKE) clean)
@@ -303,7 +303,7 @@ Makefile.dep:
 include Makefile.dep
 
 distclean-subdirs:
-	for dir in eventer man noitedit utils json-lib ; do \
+	for dir in eventer man modules noitedit utils json-lib ; do \
 		(cd $$dir && $(MAKE) distclean) ; \
 	done
 

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -34,12 +34,15 @@ LUALIBS=@LUALIBS@
 
 top_srcdir=@top_srcdir@
 
-MODULES=@BUILD_MODULES@
-LUA_MODULES=mtev_lua/mtev.so
-HEADERS=lua_mtev.h
+MODULES=@FQ_MODULES@ @LUA4MTEV@
+MTEV4LUA=mtev_lua/mtev.so
+HEADERS=@FQ_HEADERS@ lua_mtev.h
 LUA_FILES=mtev/extras.lua mtev/timeval.lua mtev/HttpClient.lua
 
-all:	$(MODULES) $(LUA_MODULES)
+FQ_MODULES=@FQ_MODULES@
+FQ_HEADERS=@FQ_HEADERS@
+
+all:	$(MODULES) $(MTEV4LUA)
 
 .xml.xmlh:
 	$(Q)$(XML2H) `echo $< | sed -e 's/\.xml$$//;'`_xml_description < $< > $@
@@ -109,6 +112,16 @@ install-modules:	$(MODULES)
 	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(MODULES_DIR)/lua/mtev
 	for lua in $(LUA_FILES); do \
 		$(INSTALL) -m 0755 lua-support/$$lua $(DESTDIR)$(MODULES_DIR)/lua/$$lua ; \
+	done
+
+install-fq:	$(FQ_MODULES)
+	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(includedir)
+	for h in $(FQ_HEADERS); do \
+		$(INSTALL) -m 0444 $$h $(DESTDIR)$(includedir)/$$h ; \
+	done
+	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(MODULES_DIR)
+	for mod in $(FQ_MODULES); do \
+		$(INSTALL) -m 0755 $$mod $(DESTDIR)$(MODULES_DIR)/$$mod ; \
 	done
 
 clean:

--- a/src/modules/Makefile.in
+++ b/src/modules/Makefile.in
@@ -36,11 +36,10 @@ top_srcdir=@top_srcdir@
 
 MODULES=@FQ_MODULES@ @LUA4MTEV@
 MTEV4LUA=mtev_lua/mtev.so
-HEADERS=@FQ_HEADERS@ lua_mtev.h
+HEADERS=lua_mtev.h
 LUA_FILES=mtev/extras.lua mtev/timeval.lua mtev/HttpClient.lua
 
 FQ_MODULES=@FQ_MODULES@
-FQ_HEADERS=@FQ_HEADERS@
 
 all:	$(MODULES) $(MTEV4LUA)
 
@@ -115,10 +114,6 @@ install-modules:	$(MODULES)
 	done
 
 install-fq:	$(FQ_MODULES)
-	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(includedir)
-	for h in $(FQ_HEADERS); do \
-		$(INSTALL) -m 0444 $$h $(DESTDIR)$(includedir)/$$h ; \
-	done
 	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(MODULES_DIR)
 	for mod in $(FQ_MODULES); do \
 		$(INSTALL) -m 0755 $$mod $(DESTDIR)$(MODULES_DIR)/$$mod ; \


### PR DESCRIPTION
Facilitates packaging, where we want to deliver the optional FQ
modules separately. Only one change is present for default builds:
mtev_fq.h is no longer installed unless we are building with
FQ support. This header is useless without fq.so anyway.

As part of this fix we disambiguate the Lua-related modules to reduce
confusion. There is one module that provides Lua functionality to
libmtev apps (LUA4MTEV) and one that provides libmtev functionality to
Lua apps (MTEV4LUA).

Also fixed is a bug with cleaning where we were not cleaning up in the
src/modules directory.