### PR TITLE
mtev_http_session_req_consume shouldn't return 0 when it starts readi…

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1186,9 +1186,11 @@ mtev_http_session_req_consume(mtev_http_session_ctx *ctx,
         RELEASE_BCHAIN(tofree);
         if(in == NULL) {
           ctx->req.last_input = NULL;
-          mtevL(http_debug, " ... mtev_http_session_req_consume = %d\n",
-                (int)bytes_read);
-          return bytes_read;
+          if (bytes_read != 0) {
+            mtevL(http_debug, " ... mtev_http_session_req_consume = %d\n",
+                  (int)bytes_read);
+            return bytes_read;
+          }
         }
       }
     }


### PR DESCRIPTION
…ng an empty bchain buffer.

mtev_http_request_finalize can sometimes leave an empty bchain
buffer as the only buffer on the bchain. It had been the case
that mtev_http_session_req_consume would, in this case, return 0,
but better to actually try another non-blocking read, instead.