### PR TITLE
Explicitly Initialize Mtev Hash Structures

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -120,8 +120,8 @@ free_callback_details(void *vcd) {
   free(vcd);
 }
 
-static mtev_hash_table __name_to_func = MTEV_HASH_EMPTY;
-static mtev_hash_table __func_to_name = MTEV_HASH_EMPTY;
+static mtev_hash_table __name_to_func;
+static mtev_hash_table __func_to_name;
 int eventer_name_callback(const char *name, eventer_func_t f) {
   eventer_name_callback_ext(name, f, NULL, NULL);
   return 0;
@@ -189,3 +189,10 @@ int eventer_choose(const char *name) {
   }
   return -1;
 }
+
+void eventer_init_globals() {
+  mtev_hash_init(&__name_to_func);
+  mtev_hash_init(&__func_to_name);
+  eventer_ssl_init_globals();
+}
+

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -185,6 +185,7 @@ API_EXPORT(int) eventer_choose(const char *name);
 API_EXPORT(void) eventer_loop();
 API_EXPORT(int) eventer_is_loop(pthread_t tid);
 API_EXPORT(int) eventer_loop_concurrency();
+API_EXPORT(void) eventer_init_globals();
 
 #define eventer_propset       __eventer->propset
 #define eventer_init          __eventer->init

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -69,7 +69,7 @@ typedef struct {
   mtev_atomic32_t refcnt;
 } ssl_ctx_cache_node;
 
-static mtev_hash_table ssl_ctx_cache = MTEV_HASH_EMPTY;
+static mtev_hash_table ssl_ctx_cache;
 static pthread_mutex_t ssl_ctx_cache_lock = PTHREAD_MUTEX_INITIALIZER;
 static int ssl_ctx_cache_expiry = 5;
 static int ssl_ctx_cache_finfo_expiry = 5;
@@ -1131,5 +1131,9 @@ void eventer_ssl_init() {
     eventer_add_asynch(NULL, e);
   }
   return;
+}
+
+void eventer_ssl_init_globals() {
+  mtev_hash_init(&ssl_ctx_cache);
 }
 

--- a/src/eventer/eventer_SSL_fd_opset.h
+++ b/src/eventer/eventer_SSL_fd_opset.h
@@ -132,6 +132,8 @@ API_EXPORT(int)
   eventer_ssl_config(const char *key, const char *value);
 API_EXPORT(int)
   eventer_ssl_get_local_commonname(eventer_ssl_ctx_t *ctx, char *buff, int len);
+API_EXPORT(void)
+  eventer_ssl_init_globals();
 
 #endif
 

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -50,7 +50,7 @@
 static mtev_atomic32_t threads_jobq_inited = 0;
 static pthread_key_t threads_jobq;
 static sigset_t alarm_mask;
-static mtev_hash_table all_queues = MTEV_HASH_EMPTY;
+static mtev_hash_table all_queues;
 pthread_mutex_t all_queues_lock;
 
 static void
@@ -563,4 +563,7 @@ void eventer_jobq_process_each(void (*func)(eventer_jobq_t *, void *),
     func((eventer_jobq_t *)vjobq, closure);
   }
   pthread_mutex_unlock(&all_queues_lock);
+}
+void eventer_jobq_init_globals() {
+  mtev_hash_init(&all_queues);
 }

--- a/src/eventer/eventer_jobq.h
+++ b/src/eventer/eventer_jobq.h
@@ -105,5 +105,6 @@ void eventer_jobq_increase_concurrency(eventer_jobq_t *jobq);
 void eventer_jobq_decrease_concurrency(eventer_jobq_t *jobq);
 void *eventer_jobq_consumer(eventer_jobq_t *jobq);
 void eventer_jobq_process_each(void (*func)(eventer_jobq_t *, void *), void *);
+void eventer_jobq_init_globals();
 
 #endif

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -47,9 +47,9 @@
 
 static mtev_log_stream_t nlerr = NULL;
 static mtev_log_stream_t nldeb = NULL;
-static mtev_hash_table mtev_lua_states = MTEV_HASH_EMPTY;
+static mtev_hash_table mtev_lua_states;
 static pthread_mutex_t mtev_lua_states_lock = PTHREAD_MUTEX_INITIALIZER;
-static mtev_hash_table mtev_coros = MTEV_HASH_EMPTY;
+static mtev_hash_table mtev_coros;
 static pthread_mutex_t coro_lock = PTHREAD_MUTEX_INITIALIZER;
 
 void
@@ -818,4 +818,10 @@ mtev_lua_open(const char *module_name, void *lmc,
   pthread_mutex_unlock(&mtev_lua_states_lock);
 
   return L;
+}
+
+void
+mtev_lua_init_globals() {
+  mtev_hash_init(&mtev_lua_states);
+  mtev_hash_init(&mtev_coros);
 }

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -3469,6 +3469,7 @@ static void mtev_lua_init() {
   static int done = 0;
   if(done) return;
   done = 1;
+  mtev_lua_init_globals();
   register_console_lua_commands();
   eventer_name_callback("lua/sleep", nl_sleep_complete);
   eventer_name_callback("lua/socket_read",

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -130,6 +130,7 @@ int mtev_lua_coroutine_spawn(lua_State *Lp,
     mtev_lua_resume_info_t *(*new_ri_f)(lua_module_closure_t *));
 lua_State *mtev_lua_open(const char *module_name, void *lmc,
                          const char *script_dir, const char *cpath);
+void mtev_lua_init_globals();
 void register_console_lua_commands();
 int mtev_lua_traceback(lua_State *L);
 void mtev_lua_new_coro(mtev_lua_resume_info_t *);

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -49,8 +49,8 @@
 #include "lua_mtev.h"
 #include <udns.h>
 
-static mtev_hash_table dns_rtypes = MTEV_HASH_EMPTY;
-static mtev_hash_table dns_ctypes = MTEV_HASH_EMPTY;
+static mtev_hash_table dns_rtypes;
+static mtev_hash_table dns_ctypes;
 static __thread mtev_hash_table *dns_ctx_store = NULL;
 
 typedef struct dns_ctx_handle {
@@ -519,10 +519,17 @@ int mtev_lua_dns_index_func(lua_State *L) {
   return 0;
 }
 
+void mtev_lua_init_dns_globals() {
+  mtev_hash_init(&dns_rtypes);
+  mtev_hash_init(&dns_ctypes);
+}
+
 void mtev_lua_init_dns() {
   int i;
   const struct dns_nameval *nv;
   struct dns_ctx *pctx;
+
+  mtev_lua_init_dns_globals();
 
   /* HASH the rr types */
   for(i=0, nv = &dns_typetab[i]; nv->name; nv = &dns_typetab[++i])
@@ -544,3 +551,4 @@ void mtev_lua_init_dns() {
   else
     dns_free(pctx);
 }
+

--- a/src/mtev_capabilities_listener.c
+++ b/src/mtev_capabilities_listener.c
@@ -65,7 +65,7 @@ typedef struct mtev_capsvc_closure {
   size_t towrite;
 } mtev_capsvc_closure_t;
 
-static mtev_hash_table features = MTEV_HASH_EMPTY;
+static mtev_hash_table features;
 static int
   mtev_capabilities_rest(mtev_http_rest_closure_t *, int, char **);
 static void
@@ -448,4 +448,7 @@ cleanup_shutdown:
   goto cleanup_shutdown;
 }
 
-
+void
+mtev_capabilities_init_globals() {
+  mtev_hash_init(&features);
+}

--- a/src/mtev_capabilities_listener.h
+++ b/src/mtev_capabilities_listener.h
@@ -41,6 +41,9 @@
 #define MTEV_CAPABILITIES_SERVICE 0x43415041
 
 API_EXPORT(void)
+  mtev_capabilities_init_globals();
+
+API_EXPORT(void)
   mtev_capabilities_listener_init(void);
 
 API_EXPORT(void)

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -282,7 +282,7 @@ mtev_conf_watch_and_journal_watchdog(int (*f)(void *), void *c) {
   mtev_conf_watch_config_and_journal(NULL, EVENTER_TIMER, rj, &__now);
 }
 
-static mtev_hash_table _compiled_fallback = MTEV_HASH_EMPTY;
+static mtev_hash_table _compiled_fallback;
 
 static struct {
   const char *key;
@@ -1389,6 +1389,7 @@ mtev_conf_get_namespaced_hash(mtev_conf_section_t section,
   mtev_hash_table *table = NULL;
 
   table = calloc(1, sizeof(*table));
+  mtev_hash_init(table);
   mtev_conf_get_into_hash(section, path, table, ns);
   if(mtev_hash_size(table) == 0) {
     mtev_hash_destroy(table, free, free);
@@ -1403,6 +1404,7 @@ mtev_conf_get_hash(mtev_conf_section_t section, const char *path) {
   mtev_hash_table *table = NULL;
 
   table = calloc(1, sizeof(*table));
+  mtev_hash_init(table);
   mtev_conf_get_into_hash(section, path, table, NULL);
   return table;
 }
@@ -2742,3 +2744,8 @@ void mtev_console_conf_init() {
           mtev_console_state_delegate, mtev_console_opt_delegate,
           _write_state, NULL);
 }
+
+void mtev_conf_init_globals() {
+  mtev_hash_init(&_compiled_fallback);
+}
+

--- a/src/mtev_conf.h
+++ b/src/mtev_conf.h
@@ -98,6 +98,7 @@ API_EXPORT(void) mtev_conf_watch_and_journal_watchdog(int (*f)(void *), void *c)
 API_EXPORT(void) mtev_conf_mark_changed();
 
 API_EXPORT(void) mtev_conf_init(const char *toplevel);
+API_EXPORT(void) mtev_conf_init_globals();
 API_EXPORT(void)
   mtev_conf_poke(const char *toplevel, const char *key, const char *val);
 API_EXPORT(void)

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -70,8 +70,8 @@ mtev_dso_loader_t __mtev_image_loader = {
   mtev_load_generic_image
 };
 
-static mtev_hash_table loaders = MTEV_HASH_EMPTY;
-static mtev_hash_table generics = MTEV_HASH_EMPTY;
+static mtev_hash_table loaders;
+static mtev_hash_table generics;
 static int mtev_dso_load_failure_count = 0;
 
 int mtev_dso_load_failures() {
@@ -387,6 +387,11 @@ void mtev_dso_add_type(const char *name, int (*list)(const char ***)) {
   node->list = list;
   node->next = dso_types;
   dso_types = node;
+}
+
+void mtev_dso_init_globals() {
+  mtev_hash_init(&loaders);
+  mtev_hash_init(&generics);
 }
 
 #define userdata_accessors(type, field) \

--- a/src/mtev_dso.h
+++ b/src/mtev_dso.h
@@ -134,6 +134,8 @@ API_EXPORT(void)
   mtev_dso_add_type(const char *name, int (*list)(const char ***));
 API_EXPORT(struct dso_type *)
   mtev_dso_get_types();
+API_EXPORT(void)
+  mtev_dso_init_globals();
 
 MTEV_HOOK_PROTO(dso_post_init,
                 (),

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -50,7 +50,7 @@
 
 static mtev_log_stream_t nlerr = NULL;
 static mtev_log_stream_t nldeb = NULL;
-static mtev_hash_table listener_commands = MTEV_HASH_EMPTY;
+static mtev_hash_table listener_commands;
 mtev_hash_table *
 mtev_listener_commands() {
   return &listener_commands;
@@ -401,6 +401,7 @@ mtev_listener(char *host, unsigned short port, int type,
   listener_closure->family = family;
   listener_closure->port = htons(port);
   listener_closure->sslconfig = calloc(1, sizeof(mtev_hash_table));
+  mtev_hash_init(listener_closure->sslconfig);
   mtev_hash_merge_as_dict(listener_closure->sslconfig, sslconfig);
   listener_closure->dispatch_callback = handler;
 
@@ -574,6 +575,7 @@ mtev_control_dispatch_delegate(eventer_func_t listener_dispatch,
                          (char *)&listener_dispatch, sizeof(listener_dispatch),
                          &vdelegation_table)) {
     delegation_table = calloc(1, sizeof(*delegation_table));
+    mtev_hash_init(delegation_table);
     handler_copy = malloc(sizeof(*handler_copy));
     *handler_copy = listener_dispatch;
     mtev_hash_store(&listener_commands,
@@ -631,5 +633,10 @@ mtev_listener_init(const char *toplevel) {
   eventer_name_callback("mtev_listener_accept_ssl", mtev_listener_accept_ssl);
   eventer_name_callback("control_dispatch", mtev_control_dispatch);
   mtev_listener_reconfig(toplevel);
+}
+
+void
+mtev_listener_init_globals() {
+  mtev_hash_init(&listener_commands);
 }
 

--- a/src/mtev_listener.h
+++ b/src/mtev_listener.h
@@ -69,6 +69,7 @@ typedef struct {
 } * listener_closure_t;
 
 API_EXPORT(void) mtev_listener_init(const char *toplevel);
+API_EXPORT(void) mtev_listener_init_globals();
 
 API_EXPORT(void) mtev_listener_skip(const char *address, int port);
 

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -49,6 +49,11 @@
 #include "mtev_memory.h"
 #include "mtev_watchdog.h"
 #include "mtev_lockfile.h"
+#include "mtev_listener.h"
+#include "mtev_capabilities_listener.h"
+#include "mtev_rest.h"
+#include "mtev_reverse_socket.h"
+#include "mtev_dso.h"
 #include "eventer/eventer.h"
 
 #define MAX_CLI_LOGS 128
@@ -129,6 +134,18 @@ void cli_log_switches() {
   }
 }
 
+static void
+mtev_init_globals() {
+  eventer_init_globals();
+  eventer_jobq_init_globals();
+  mtev_capabilities_init_globals();
+  mtev_conf_init_globals();
+  mtev_dso_init_globals();
+  mtev_http_rest_init_globals();
+  mtev_listener_init_globals();
+  mtev_reverse_socket_init_globals();
+}
+
 int
 mtev_main(const char *appname,
           const char *config_filename, int debug, int foreground,
@@ -153,6 +170,7 @@ mtev_main(const char *appname,
   wait_for_lock = (lock == MTEV_LOCK_OP_WAIT) ? 1 : 0;
 
   mtev_memory_init();
+  mtev_init_globals();
 
   /* First initialize logging, so we can log errors */
   mtev_log_init(debug);

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -79,7 +79,7 @@ struct rule_container {
   struct rest_url_dispatcher *rules;
   struct rest_url_dispatcher *rules_endptr;
 };
-mtev_hash_table dispatch_points = MTEV_HASH_EMPTY;
+mtev_hash_table dispatch_points;
 
 struct mtev_rest_acl_rule {
   mtev_boolean allow;
@@ -97,7 +97,7 @@ struct mtev_rest_acl {
   struct mtev_rest_acl *next;
 };
 
-static mtev_hash_table mime_type_defaults = MTEV_HASH_EMPTY;
+static mtev_hash_table mime_type_defaults;
 
 static struct mtev_rest_acl *global_rest_acls = NULL;
 
@@ -979,5 +979,9 @@ mtev_hash_store(&mime_type_defaults, strdup(ext), strlen(ext), strdup(type))
   mtev_control_dispatch_delegate(mtev_control_dispatch,
                                  MTEV_CONTROL_PUT,
                                  mtev_http_rest_handler);
+}
+void mtev_http_rest_init_globals() {
+  mtev_hash_init(&dispatch_points);
+  mtev_hash_init(&mime_type_defaults);
 }
 

--- a/src/mtev_rest.h
+++ b/src/mtev_rest.h
@@ -69,6 +69,7 @@ struct mtev_http_rest_closure {
 };
 
 API_EXPORT(void) mtev_http_rest_init();
+API_EXPORT(void) mtev_http_rest_init_globals();
 
 API_EXPORT(void)
   mtev_http_rest_clean_request(mtev_http_rest_closure_t *restc);

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -100,10 +100,10 @@ static const int CMD_BUFF_LEN = 4096;
 
 static mtev_log_stream_t nlerr = NULL;
 static mtev_log_stream_t nldeb = NULL;
-static mtev_hash_table reverse_sockets = MTEV_HASH_EMPTY;
+static mtev_hash_table reverse_sockets;
 static pthread_rwlock_t reverse_sockets_lock;
 static pthread_mutex_t reverses_lock;
-static mtev_hash_table reverses = MTEV_HASH_EMPTY;
+static mtev_hash_table reverses;
 
 
 static void mtev_connection_initiate_connection(mtev_connection_ctx_t *ctx);
@@ -1750,7 +1750,8 @@ mtev_console_reverse_opts(mtev_console_closure_t ncct,
     int klen, i = 0;
     void *vconn;
     reverse_socket_t *ctx;
-    mtev_hash_table dedup = MTEV_HASH_EMPTY;
+    mtev_hash_table dedup;
+    mtev_hash_init(&dedup);
 
     pthread_rwlock_rdlock(&reverse_sockets_lock);
     while(mtev_hash_next(&reverse_sockets, &iter, &key_id, &klen, &vconn)) {
@@ -2063,4 +2064,9 @@ mtev_lua_help_initiate_mtev_connection(const char *address, int port,
                            mtev_reverse_socket_alloc(),
                            mtev_reverse_socket_deref);
   return 0;
+}
+void
+mtev_reverse_socket_init_globals() {
+  mtev_hash_init(&reverse_sockets);
+  mtev_hash_init(&reverses);
 }

--- a/src/mtev_reverse_socket.h
+++ b/src/mtev_reverse_socket.h
@@ -108,4 +108,7 @@ API_EXPORT(int)
 API_EXPORT(int)
   mtev_reverse_socket_connection_shutdown(const char *address, int port);
 
+API_EXPORT(void)
+  mtev_reverse_socket_init_globals();
+
 #endif

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -362,8 +362,8 @@ mtev_log_memory_lines_since(mtev_log_stream_t ls, u_int64_t afterwhich,
 #define IS_DEBUG_BELOW(ls) ((ls)->flags_below & MTEV_LOG_STREAM_DEBUG)
 #define IS_FACILITY_BELOW(ls) ((ls)->flags_below & MTEV_LOG_STREAM_FACILITY)
 
-static mtev_hash_table mtev_loggers = MTEV_HASH_EMPTY;
-static mtev_hash_table mtev_logops = MTEV_HASH_EMPTY;
+static mtev_hash_table mtev_loggers;
+static mtev_hash_table mtev_logops;
 mtev_log_stream_t mtev_stderr = NULL;
 mtev_log_stream_t mtev_error = NULL;
 mtev_log_stream_t mtev_debug = NULL;
@@ -1177,8 +1177,7 @@ static logops_t jlog_logio_ops = {
 
 void
 mtev_log_init(int debug_on) {
-  mtev_hash_init(&mtev_loggers);
-  mtev_hash_init(&mtev_logops);
+  mtev_log_init_globals();
   mtev_register_logops("file", &posix_logio_ops);
   mtev_register_logops("jlog", &jlog_logio_ops);
   mtev_register_logops("memory", &membuf_logio_ops);
@@ -1792,5 +1791,11 @@ mtev_log_list(mtev_log_stream_t *loggers, int nsize) {
     total++;
   }
   return total * out_of_space_flag;
+}
+
+void
+mtev_log_init_globals() {
+  mtev_hash_init(&mtev_loggers);
+  mtev_hash_init(&mtev_logops);
 }
 

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -158,6 +158,8 @@ API_EXPORT(int)
                               int (*f)(u_int64_t, const struct timeval *,
                                       const char *, size_t, void *),
                               void *closure);
+API_EXPORT(void)
+  mtev_log_init_globals();
 
 #define mtevLT(ls, t, args...) do { \
   if((ls) && (mtev_log_global_enabled() || N_L_S_ON(ls))) \

--- a/test/hash_test.c
+++ b/test/hash_test.c
@@ -20,7 +20,7 @@ void *thread_func(void *arg)
 #define THREAD_COUNT 4
 
 static void do_test(mtev_hash_lock_mode_t lock_mode) {
-  mtev_hash_table hash = MTEV_HASH_EMPTY;
+  mtev_hash_table hash;
 
   mtev_hash_init_locks(&hash, 400, lock_mode);
 


### PR DESCRIPTION
Rather than setting them with MTEV_HASH_EMPTY, explcitly call
mtev_hash_init to initialize hash tables.