### PR TITLE
Log When We Init Hashes In Failure Case

### DIFF
--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -34,6 +34,7 @@
 #include "mtev_config.h"
 #include "mtev_hash.h"
 #include "mtev_log.h"
+#include "mtev_watchdog.h"
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -291,7 +292,11 @@ void mtev_hash_init_locks(mtev_hash_table *h, int size, mtev_hash_lock_mode_t lo
 }
 
 int mtev_hash_size(mtev_hash_table *h) {
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_size... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
   return ck_hs_count(&h->u.hs);
 }
 int mtev_hash_replace(mtev_hash_table *h, const char *k, int klen, void *data,
@@ -302,7 +307,11 @@ int mtev_hash_replace(mtev_hash_table *h, const char *k, int klen, void *data,
   ck_hash_attr_t *data_struct;
   ck_hash_attr_t *attr = calloc(1, sizeof(ck_hash_attr_t) + klen + 1);
 
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_replace... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   memcpy(attr->key.label, k, klen);
   attr->key.label[klen] = 0;
@@ -333,7 +342,11 @@ int mtev_hash_store(mtev_hash_table *h, const char *k, int klen, void *data) {
   int ret = 0;
   ck_hash_attr_t *attr = calloc(1, sizeof(ck_hash_attr_t) + klen + 1);
 
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_store... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   memcpy(attr->key.label, k, klen);
   attr->key.label[klen] = 0;
@@ -359,7 +372,11 @@ int mtev_hash_retrieve(mtev_hash_table *h, const char *k, int klen, void **data)
   ck_hash_attr_t *data_struct;
 
   if(!h) return 0;
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_retrieve... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   if(klen > ONSTACK_KEY_SIZE) key = calloc(1, sizeof(ck_key_t) + klen + 1);
   memcpy(key->label, k, klen);
@@ -405,7 +422,11 @@ int mtev_hash_delete(mtev_hash_table *h, const char *k, int klen,
   ck_key_t *key = &onstack_key.key;
 
   if(!h) return 0;
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_delete... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   if(klen > ONSTACK_KEY_SIZE) key = calloc(1, sizeof(ck_key_t) + klen + 1);
   memcpy(key->label, k, klen);
@@ -435,7 +456,11 @@ void mtev_hash_delete_all(mtev_hash_table *h, NoitHashFreeFunc keyfree, NoitHash
   ck_hash_attr_t *data_struct;
 
   if(!h) return;
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_delete_all... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   int count = mtev_hash_size(h);
   LOCK(h);
@@ -453,7 +478,11 @@ void mtev_hash_delete_all(mtev_hash_table *h, NoitHashFreeFunc keyfree, NoitHash
 
 void mtev_hash_destroy(mtev_hash_table *h, NoitHashFreeFunc keyfree, NoitHashFreeFunc datafree) {
   if(!h) return;
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_destroy... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
   mtev_hash_delete_all(h, keyfree, datafree);
   LOCK(h);
   ck_hs_destroy(&h->u.hs);
@@ -479,7 +508,11 @@ int mtev_hash_next(mtev_hash_table *h, mtev_hash_iter *iter,
   ck_key_t *key;
   ck_hash_attr_t *data_struct;
 
-  if(h->u.hs.hf == NULL) mtev_hash_init(h);
+  if(h->u.hs.hf == NULL) {
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_next... initializing\n");
+    mtev_stacktrace(mtev_error);
+    mtev_hash_init(h);
+  }
 
   if(!ck_hs_next(&h->u.hs, iter, &cursor)) return 0;
   key = (ck_key_t *)cursor;


### PR DESCRIPTION
If we try to use a hash function on an uninitialized hash table, log a
failure (including a stack trace), then initialize it. The idea is to
eventually require hashes to be initialized before use - this will aid
in the transition.