### PR TITLE
Reinitialize Response Hash If Freed

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -223,7 +223,10 @@ static void inplace_urldecode(char *c) {
 }
 
 /* We can free a response, but still try to use it.... make sure
- * we reinitialize here so we don't use trash */
+ * we reinitialize here so we don't use trash
+ * TODO: Audit all this code to make sure we don't try to use
+ * the response after we free at all - need to audit use of 
+ * reference count in particular */
 static void check_realloc_response(mtev_http_response *res) {
   if (res->freed == mtev_true) {
     mtev_hash_init(&res->headers);


### PR DESCRIPTION
If we've freed the response hash table, we need to reinitialize it so we
don't attempt to use a freed hash table.

Long term, this code likely needs to be refactored to avoid this
condition at all; this is a band-aid.