### PR TITLE
Set SONAME to major.minor

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -63,7 +63,7 @@ SHLDFLAGS="$LDFLAGS"
 CPPFLAGS="$CPPFLAGS -D _REENTRANT -D _XOPEN_SOURCE=600 -D _POSIX_SOURCE -D _POSIX_C_SOURCE=200112L -D _DEFAULT_SOURCE "'-I$(top_srcdir)/src'
 DTRACEHDR=libmtev_dtrace_probes.h
 DOTSO=.so
-LD_LIBMTEV_VERSION='-Wl,-soname,libmtev.so.$(LIBMTEV_VERSION)'
+LD_LIBMTEV_VERSION='-Wl,-soname,libmtev.so.$(SEMVER_MAJOR).$(SEMVER_MINOR)'
 
 case $host in
 *-*-darwin*)
@@ -77,7 +77,7 @@ case $host in
 	MODULELD="$CC -bundle -flat_namespace -undefined suppress"
 	SHLD="$CC -dynamiclib -single_module -undefined dynamic_lookup -fPIC"
   DOTDYLIB=.dylib
-	LD_LIBMTEV_VERSION='-current_version $(LIBMTEV_VERSION) -install_name $(libdir)/libmtev.$(LIBMTEV_VERSION).dylib'
+	LD_LIBMTEV_VERSION='-current_version $(SEMVER_MAJOR).$(SEMVER_MINOR) -install_name $(libdir)/libmtev.$(LIBMTEV_VERSION).dylib'
 	MODULEEXT=bundle
 	# This is needed for luajit on Mac OS X
 	if test "x$ENABLE_LUA" = "xLuaJIT"; then

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -5,7 +5,10 @@ ifeq ($(V),)
 	Q=@
 endif
 
-LIBMTEV_VERSION=0.0.6
+SEMVER_MAJOR=0
+SEMVER_MINOR=0
+SEMVER_PATCH=6
+LIBMTEV_VERSION=$(SEMVER_MAJOR).$(SEMVER_MINOR).$(SEMVER_PATCH)
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
@@ -70,6 +73,7 @@ NOWHOLE_ARCHIVE=@NOWHOLE_ARCHIVE@
 DTRACEOBJ=@DTRACEOBJ@
 LIBMTEV_DTRACEOBJ=$(DTRACEOBJ:%dtrace_stub.o=libmtev_%dtrace_stub.lo)
 LIBMTEV_V=libmtev@DOTSO@.$(LIBMTEV_VERSION)@DOTDYLIB@
+LIBMTEV_MINOR=libmtev@DOTSO@.$(SEMVER_MAJOR).$(SEMVER_MINOR)@DOTDYLIB@
 LIBMTEV=libmtev@DOTSO@@DOTDYLIB@
 
 TARGETS=$(LIBMTEV) luamtev @MDB_MODS@
@@ -263,6 +267,7 @@ install-libs:	mtevlibs
 	$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)$(libdir)
 	$(INSTALL) -m 0755 $(LIBMTEV_V) $(DESTDIR)$(libdir)/$(LIBMTEV_V)
 	ln -sf $(LIBMTEV_V) $(DESTDIR)$(libdir)/$(LIBMTEV)
+	ln -sf $(LIBMTEV_V) $(DESTDIR)$(libdir)/$(LIBMTEV_MINOR)
 	if test -n "@MDB_MODS@" ; then \
 		$(top_srcdir)/buildtools/mkinstalldirs $(DESTDIR)/usr/lib/mdb/proc/amd64 ; \
 		$(INSTALL) -m 0755 mdb-support/libmtev.so $(DESTDIR)/usr/lib/mdb/proc/amd64/libmtev.so ; \


### PR DESCRIPTION
This eases patch-level, bugfix updates by getting dependent
applications to depend only on major.minor as the library filename.