### PR TITLE
initializing lmc->pending

### DIFF
--- a/src/modules/lua_general.c
+++ b/src/modules/lua_general.c
@@ -375,6 +375,7 @@ mtev_lua_general_init(mtev_dso_generic_t *self) {
   }
 
   lmc->pending = calloc(1, sizeof(*lmc->pending));
+  mtev_hash_init(lmc->pending);
 
   if(conf->booted) return true;
   conf->booted = mtev_true;

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -411,6 +411,7 @@ mtev_lua_web_driver_init(mtev_dso_generic_t *self) {
   }
 
   lmc->pending = calloc(1, sizeof(*lmc->pending));
+  mtev_hash_init(lmc->pending);
   dso_post_init_hook_register("web_lua", late_stage_rest_register, self);
   return 0;
 }


### PR DESCRIPTION
without that I got flooded by `warning: null hashtable in mtev_hash_store... initializing`