### PR TITLE
Support mtev programs that avoid mtev_main and still need init_globals.

### DIFF
--- a/src/mtev_main.h
+++ b/src/mtev_main.h
@@ -40,6 +40,9 @@ typedef enum {
   MTEV_LOCK_OP_WAIT
 } mtev_lock_op_t;
 
+API_EXPORT(void)
+  mtev_init_globals();
+
 API_EXPORT(int)
   mtev_main(const char *appname,
             const char *config_filename, int debug, int foreground,


### PR DESCRIPTION
Make mtev_init_globals non-static.
Make it callable multiple times safely.
Make it called in the .init section if libmtev is linked shared.