### PR TITLE
Add Locking To Certain Hash Tables

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -191,8 +191,8 @@ int eventer_choose(const char *name) {
 }
 
 void eventer_init_globals() {
-  mtev_hash_init_locks(&__name_to_func, 256, MTEV_HASH_LOCK_MODE_MUTEX);
-  mtev_hash_init_locks(&__func_to_name, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&__name_to_func, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&__func_to_name, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
   eventer_ssl_init_globals();
 }
 

--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -191,8 +191,8 @@ int eventer_choose(const char *name) {
 }
 
 void eventer_init_globals() {
-  mtev_hash_init(&__name_to_func);
-  mtev_hash_init(&__func_to_name);
+  mtev_hash_init_locks(&__name_to_func, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&__func_to_name, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   eventer_ssl_init_globals();
 }
 

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -520,8 +520,8 @@ int mtev_lua_dns_index_func(lua_State *L) {
 }
 
 void mtev_lua_init_dns_globals() {
-  mtev_hash_init_locks(&dns_rtypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
-  mtev_hash_init_locks(&dns_ctypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_rtypes, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_ctypes, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 
 void mtev_lua_init_dns() {

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -520,8 +520,8 @@ int mtev_lua_dns_index_func(lua_State *L) {
 }
 
 void mtev_lua_init_dns_globals() {
-  mtev_hash_init(&dns_rtypes);
-  mtev_hash_init(&dns_ctypes);
+  mtev_hash_init_locks(&dns_rtypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dns_ctypes, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 
 void mtev_lua_init_dns() {

--- a/src/mtev_capabilities_listener.c
+++ b/src/mtev_capabilities_listener.c
@@ -450,5 +450,5 @@ cleanup_shutdown:
 
 void
 mtev_capabilities_init_globals() {
-  mtev_hash_init_locks(&features, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&features, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }

--- a/src/mtev_capabilities_listener.c
+++ b/src/mtev_capabilities_listener.c
@@ -450,5 +450,5 @@ cleanup_shutdown:
 
 void
 mtev_capabilities_init_globals() {
-  mtev_hash_init(&features);
+  mtev_hash_init_locks(&features, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -824,7 +824,7 @@ mtev_cluster_init() {
   mtev_conf_section_t *clusters, parent;
 
   gettimeofday(&my_boot_time, NULL);
-  mtev_hash_init(&global_clusters);
+  mtev_hash_init_locks(&global_clusters, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 
   parent = mtev_conf_get_section(NULL, "//clusters");
   if(!parent) return;

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -824,7 +824,7 @@ mtev_cluster_init() {
   mtev_conf_section_t *clusters, parent;
 
   gettimeofday(&my_boot_time, NULL);
-  mtev_hash_init_locks(&global_clusters, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&global_clusters, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 
   parent = mtev_conf_get_section(NULL, "//clusters");
   if(!parent) return;

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -2746,6 +2746,6 @@ void mtev_console_conf_init() {
 }
 
 void mtev_conf_init_globals() {
-  mtev_hash_init_locks(&_compiled_fallback, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&_compiled_fallback, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -2746,6 +2746,6 @@ void mtev_console_conf_init() {
 }
 
 void mtev_conf_init_globals() {
-  mtev_hash_init(&_compiled_fallback);
+  mtev_hash_init_locks(&_compiled_fallback, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -390,8 +390,8 @@ void mtev_dso_add_type(const char *name, int (*list)(const char ***)) {
 }
 
 void mtev_dso_init_globals() {
-  mtev_hash_init_locks(&loaders, 256, MTEV_HASH_LOCK_MODE_MUTEX);
-  mtev_hash_init_locks(&generics, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&loaders, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&generics, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 
 #define userdata_accessors(type, field) \

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -390,8 +390,8 @@ void mtev_dso_add_type(const char *name, int (*list)(const char ***)) {
 }
 
 void mtev_dso_init_globals() {
-  mtev_hash_init(&loaders);
-  mtev_hash_init(&generics);
+  mtev_hash_init_locks(&loaders, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&generics, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 
 #define userdata_accessors(type, field) \

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -575,7 +575,7 @@ mtev_control_dispatch_delegate(eventer_func_t listener_dispatch,
                          (char *)&listener_dispatch, sizeof(listener_dispatch),
                          &vdelegation_table)) {
     delegation_table = calloc(1, sizeof(*delegation_table));
-    mtev_hash_init_locks(delegation_table, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+    mtev_hash_init_locks(delegation_table, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
     handler_copy = malloc(sizeof(*handler_copy));
     *handler_copy = listener_dispatch;
     mtev_hash_store(&listener_commands,
@@ -637,6 +637,6 @@ mtev_listener_init(const char *toplevel) {
 
 void
 mtev_listener_init_globals() {
-  mtev_hash_init_locks(&listener_commands, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&listener_commands, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -575,7 +575,7 @@ mtev_control_dispatch_delegate(eventer_func_t listener_dispatch,
                          (char *)&listener_dispatch, sizeof(listener_dispatch),
                          &vdelegation_table)) {
     delegation_table = calloc(1, sizeof(*delegation_table));
-    mtev_hash_init(delegation_table);
+    mtev_hash_init_locks(delegation_table, 256, MTEV_HASH_LOCK_MODE_MUTEX);
     handler_copy = malloc(sizeof(*handler_copy));
     *handler_copy = listener_dispatch;
     mtev_hash_store(&listener_commands,
@@ -637,6 +637,6 @@ mtev_listener_init(const char *toplevel) {
 
 void
 mtev_listener_init_globals() {
-  mtev_hash_init(&listener_commands);
+  mtev_hash_init_locks(&listener_commands, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -981,7 +981,7 @@ mtev_hash_store(&mime_type_defaults, strdup(ext), strlen(ext), strdup(type))
                                  mtev_http_rest_handler);
 }
 void mtev_http_rest_init_globals() {
-  mtev_hash_init(&dispatch_points);
+  mtev_hash_init_locks(&dispatch_points, 256, MTEV_HASH_LOCK_MODE_MUTEX);
   mtev_hash_init(&mime_type_defaults);
 }
 

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -981,7 +981,7 @@ mtev_hash_store(&mime_type_defaults, strdup(ext), strlen(ext), strdup(type))
                                  mtev_http_rest_handler);
 }
 void mtev_http_rest_init_globals() {
-  mtev_hash_init_locks(&dispatch_points, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&dispatch_points, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
   mtev_hash_init(&mime_type_defaults);
 }
 

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -1754,8 +1754,6 @@ mtev_console_reverse_opts(mtev_console_closure_t ncct,
     int klen, i = 0;
     void *vconn;
     reverse_socket_t *ctx;
-    mtev_hash_table dedup;
-    mtev_hash_init(&dedup);
 
     pthread_rwlock_rdlock(&reverse_sockets_lock);
     while(mtev_hash_next(&reverse_sockets, &iter, &key_id, &klen, &vconn)) {
@@ -1763,14 +1761,12 @@ mtev_console_reverse_opts(mtev_console_closure_t ncct,
       if(!strncmp(ctx->id, argv[0], strlen(argv[0]))) {
         if(idx == i) {
           pthread_rwlock_unlock(&reverse_sockets_lock);
-          mtev_hash_destroy(&dedup, NULL, NULL);
           return strdup(ctx->id);
         }
         i++;
       }
     }
     pthread_rwlock_unlock(&reverse_sockets_lock);
-    mtev_hash_destroy(&dedup, NULL, NULL);
   }
   if(argc == 2)
     return mtev_console_opt_delegate(ncct, stack, dstate, argc-1, argv+1, idx);

--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -42,7 +42,6 @@
 #include <unistd.h>
 
 #define ONSTACK_KEY_SIZE 128
-#define NoitHASH_INITIAL_SIZE (1<<7)
 
 #define mix(a,b,c) \
 { \
@@ -129,7 +128,7 @@ hs_compare(const void *previous, const void *compare)
 
 static int rand_init;
 void mtev_hash_init(mtev_hash_table *h) {
-  return mtev_hash_init_size(h, NoitHASH_INITIAL_SIZE);
+  return mtev_hash_init_size(h, MTEV_HASH_DEFAULT_SIZE);
 }
 
 static void *

--- a/src/utils/mtev_hash.h
+++ b/src/utils/mtev_hash.h
@@ -88,6 +88,7 @@ CK_CC_CONTAINER(ck_key_t, struct ck_hash_attr, key,
 
 #define MTEV_HASH_EMPTY { {{ NULL, NULL, 0, 0, NULL, NULL}} }
 #define MTEV_HASH_ITER_ZERO CK_HS_ITERATOR_INITIALIZER
+#define MTEV_HASH_DEFAULT_SIZE (1<<7)
 
 /**
  * will default to LOCK_MODE_MUTEX

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1795,7 +1795,7 @@ mtev_log_list(mtev_log_stream_t *loggers, int nsize) {
 
 void
 mtev_log_init_globals() {
-  mtev_hash_init(&mtev_loggers);
-  mtev_hash_init(&mtev_logops);
+  mtev_hash_init_locks(&mtev_loggers, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&mtev_logops, 256, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1795,7 +1795,7 @@ mtev_log_list(mtev_log_stream_t *loggers, int nsize) {
 
 void
 mtev_log_init_globals() {
-  mtev_hash_init_locks(&mtev_loggers, 256, MTEV_HASH_LOCK_MODE_MUTEX);
-  mtev_hash_init_locks(&mtev_logops, 256, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&mtev_loggers, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
+  mtev_hash_init_locks(&mtev_logops, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 }
 


### PR DESCRIPTION
Did an audit to initialize certain hash tables as locking. I didn't mess
with any tables that manually have locks around them, and I tried to be
conservative with initializing the locks so that we don't lock
unnecessarily - this may require tweaking at a later point, but this is
a good start.