### PR TITLE
Bugfix: Shortly dead cluster nodes became oldest node

### DIFF
--- a/src/examples/cluster2.conf
+++ b/src/examples/cluster2.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf8" standalone="yes"?>
-<example1 lockfile="/var/tmp/cluster1.lock">
+<example1 lockfile="/var/tmp/cluster2.lock">
   <!--
   <watchdog glider="/opt/local/bin/bt"
             tracedir="/var/cores/example"/>
@@ -53,7 +53,7 @@
         <document_root>/path/to/docroot</document_root>
       </config>
     </listener>
-    <listener type="control_dispatch" address="*" port="43191" ssl="off">
+    <listener type="control_dispatch" address="*" port="43192" ssl="off">
     </listener>
   </listeners>
   <rest>
@@ -61,8 +61,8 @@
       <rule type="allow"/>
     </acl>
   </rest>
-  <clusters my_id="183bf75c-507a-48db-8fb4-5fdcf77e1089">
-    <cluster name="ponies" port="43191" key="shame_on_me" period="1000" timeout="5000" maturity="10000" seq="1">
+  <clusters my_id="553dfa34-a9f3-495a-b286-ee3d5ad9fa1b">
+    <cluster name="ponies" port="43192" key="shame_on_me" period="1000" timeout="5000" maturity="10000" seq="1">
       <node id="183bf75c-507a-48db-8fb4-5fdcf77e1089" cn="sparkling" address="127.0.0.1" port="43191"/>
       <node id="553dfa34-a9f3-495a-b286-ee3d5ad9fa1b" cn="dancing" address="127.0.0.1" port="43192"/>
     </cluster>


### PR DESCRIPTION
If a cluster node that was the oldest node died and came up within a short time (shorter then the timeout) it became oldest node again.