### PR TITLE
Enabled appending of arbitrary payload to cluster heartbeats

### DIFF
--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -562,7 +562,7 @@ void eventer_dispatch_timed(struct timeval *now, struct timeval *next) {
   }
 }
 void
-eventer_foreach_timedevent (void (*f)(eventer_t e, void *), void *closure) {
+eventer_foreach_timedevent(void (*f)(eventer_t e, void *), void *closure) {
   mtev_skiplist_node *iter = NULL;
   int i;
   for(i=0;i<__loop_concurrency;i++) {

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -2622,7 +2622,7 @@ nl_conf_get_integer(lua_State *L) {
     mtev_conf_section_t section;
     char *element, *base;
     SPLIT_PATH(path, base, element);
-    
+
     section = mtev_conf_get_section(NULL, base);
     if(!section || !element) lua_pushboolean(L, 0);
     else {
@@ -2646,7 +2646,7 @@ nl_conf_get_boolean(lua_State *L) {
     mtev_conf_section_t section;
     char *element, *base;
     SPLIT_PATH(path, base, element);
-    
+
     section = mtev_conf_get_section(NULL, base);
     if(!section || !element) lua_pushboolean(L, 0);
     else {

--- a/src/mtev_net_heartbeat.c
+++ b/src/mtev_net_heartbeat.c
@@ -190,7 +190,6 @@ mtev_net_headerbeat_sendall(mtev_net_heartbeat_ctx *ctx, void *payload, int payl
         mtevL(mtev_error, "Bad send on mtev_net_heartbeat != %d", payload_len);
       }
     }
-    
   }
   return rv;
 }


### PR DESCRIPTION
Also the config_seq is stored in the node struct and passed to the user (he should decide what to do if the configs diverged)