### PR TITLE
Add Macro To Choose Eventer Owner

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -58,7 +58,7 @@
 
 #define EVENTER_DEFAULT_ASYNCH_ABORT EVENTER_EVIL_BRUTAL
 
-#define EVENTER_CHOOSE_THREAD_FOR_EVENT_FD(e) eventer_choose_owner(e->fd);
+#define EVENTER_CHOOSE_THREAD_FOR_EVENT_FD(e) eventer_choose_owner((e)->fd+1)
 
 /* All of these functions act like their POSIX couterparts with two
  * additional arguments.  The first is the mask they require to be active

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -58,6 +58,8 @@
 
 #define EVENTER_DEFAULT_ASYNCH_ABORT EVENTER_EVIL_BRUTAL
 
+#define EVENTER_CHOOSE_THREAD_FOR_EVENT_FD(e) eventer_choose_owner(e->fd);
+
 /* All of these functions act like their POSIX couterparts with two
  * additional arguments.  The first is the mask they require to be active
  * to make progress in the event of an EAGAIN.  The second is a closure


### PR DESCRIPTION
Add macro, EVENTER_CHOOSE_THREAD_FOR_EVENT_FD, that sets the owner
thread to the event fd (eventer_choose_owner(e->fd);)