### PR TITLE
RDTSC changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ src/libmtev_dtrace_probes.h
 test/Makefile
 test/hash_test
 test/uuid_test
+test/time_test

--- a/configure.in
+++ b/configure.in
@@ -31,7 +31,7 @@ fi
 
 AC_ARG_ENABLE(rdtsc,
 	[AC_HELP_STRING([--disable-rdtsc],
-		[Compile with warnings treated as errors])],
+		[Turn off usage of rdtsc for high res clock])],
 	enable_rdtsc="$enableval",
 	enable_rdtsc=yes)
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -89,7 +89,7 @@ HEADERS=mtev_capabilities_listener.h mtev_conf.h mtev_version.h \
 	mtev_defines.h mtev_events_rest.h \
 	mtev_http.h mtev_listener.h \
 	mtev_main.h mtev_dso.h mtev_reverse_socket.h mtev_rest.h \
-	mtev_tokenizer.h mtev_xml.h \
+	mtev_thread.h mtev_tokenizer.h mtev_xml.h \
 	eventer/OETS_asn1_helper.h eventer/eventer.h \
 	eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
 	eventer/eventer_jobq.h \
@@ -103,11 +103,12 @@ HEADERS=mtev_capabilities_listener.h mtev_conf.h mtev_version.h \
 MAPPEDHEADERS= \
 	utils/mtev_atomic.h utils/mtev_b32.h utils/mtev_b64.h \
 	utils/mtev_btrie.h utils/mtev_cht.h utils/mtev_confstr.h \
-	utils/mtev_getip.h utils/mtev_hash.h utils/mtev_hooks.h \
+	utils/mtev_cpuid.h utils/mtev_getip.h utils/mtev_hash.h utils/mtev_hooks.h \
 	utils/mtev_lockfile.h utils/mtev_log.h utils/mtev_memory.h \
 	utils/mtev_mkdir.h utils/mtev_security.h utils/mtev_sem.h \
-	utils/mtev_skiplist.h utils/mtev_str.h utils/mtev_watchdog.h \
-	utils/mtev_uuid_parse.h utils/mtev_perftimer.h utils/mtev_zipkin.h \
+	utils/mtev_skiplist.h utils/mtev_str.h utils/mtev_time.h \
+	utils/mtev_watchdog.h utils/mtev_uuid_parse.h utils/mtev_perftimer.h \
+	utils/mtev_zipkin.h \
 	json-lib/mtev_arraylist.h json-lib/mtev_bits.h json-lib/mtev_debug.h \
 	json-lib/mtev_json_object.h \
 	json-lib/mtev_json_tokener.h json-lib/mtev_json_util.h json-lib/mtev_json.h \
@@ -132,9 +133,9 @@ EVENTER_LIB_OBJS=eventer/OETS_asn1_helper.lo eventer/eventer.lo \
         eventer/eventer_POSIX_fd_opset.lo eventer/eventer_SSL_fd_opset.lo \
         eventer/eventer_impl.lo eventer/eventer_jobq.lo $(EVENTER_IMPL_OBJS)
 MTEV_UTILS_OBJS=utils/mtev_b32.lo utils/mtev_b64.lo utils/mtev_btrie.lo \
-	utils/mtev_confstr.lo utils/mtev_getip.lo utils/mtev_hash.lo \
+	utils/mtev_confstr.lo utils/mtev_cpuid.lo utils/mtev_getip.lo utils/mtev_hash.lo \
 	utils/mtev_lockfile.lo utils/mtev_log.lo utils/mtev_mkdir.lo \
-	utils/mtev_security.lo utils/mtev_sem.lo utils/mtev_skiplist.lo \
+	utils/mtev_security.lo utils/mtev_sem.lo utils/mtev_time.lo utils/mtev_skiplist.lo \
 	utils/mtev_str.lo utils/mtev_watchdog.lo utils/mtev_zipkin.lo \
 	utils/mtev_memory.lo utils/mtev_cht.lo utils/mtev_uuid_parse.lo \
 	utils/mtev_perftimer.lo \
@@ -144,7 +145,7 @@ LIBMTEV_OBJS=mtev_main.lo mtev_listener.lo mtev_cluster.lo \
 	mtev_console.lo mtev_console_state.lo mtev_console_telnet.lo \
 	mtev_console_complete.lo mtev_xml.lo \
 	mtev_conf.lo mtev_http.lo mtev_rest.lo mtev_tokenizer.lo \
-	mtev_reverse_socket.lo \
+	mtev_thread.lo mtev_reverse_socket.lo \
 	mtev_capabilities_listener.lo mtev_dso.lo \
 	mtev_events_rest.lo mtev_net_heartbeat.lo \
 	$(MTEVEDIT_LIB_OBJS) $(EVENTER_LIB_OBJS) \

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -37,6 +37,7 @@
 #include "mtev_defines.h"
 #include "mtev_log.h"
 #include "mtev_atomic.h"
+#include "mtev_time.h"
 #include <sys/time.h>
 #include <sys/socket.h>
 
@@ -203,14 +204,8 @@ API_EXPORT(void) eventer_init_globals();
 
 extern eventer_impl_t registered_eventers[];
 
-#if defined(__MACH__)
-typedef u_int64_t eventer_hrtime_t;
-#elif defined(linux) || defined(__linux) || defined(__linux__)
-typedef long long unsigned int eventer_hrtime_t;
-#else
-typedef hrtime_t eventer_hrtime_t;
-#endif
-API_EXPORT(eventer_hrtime_t) eventer_gethrtime(void);
+#define eventer_hrtime_t mtev_hrtime_t
+#define eventer_gethrtime mtev_gethrtime
 
 #include "eventer/eventer_jobq.h"
 

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -35,6 +35,7 @@
 #include "mtev_memory.h"
 #include "mtev_log.h"
 #include "mtev_atomic.h"
+#include "mtev_thread.h"
 #include "eventer/eventer.h"
 #include "libmtev_dtrace_probes.h"
 #include <errno.h>
@@ -193,7 +194,7 @@ eventer_jobq_maybe_spawn(eventer_jobq_t *jobq) {
           jobq->queue_name, jobq->concurrency);
     pthread_attr_init(&tattr);
     pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
-    pthread_create(&tid, &tattr, eventer_jobq_consumer_pthreadentry, jobq);
+    mtev_thread_create(&tid, &tattr, eventer_jobq_consumer_pthreadentry, jobq);
   }
   mtevL(eventer_deb, "jobq_queue[%s] pending cancels [%d/%d]\n",
         jobq->queue_name, jobq->pending_cancels,

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -406,6 +406,8 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
     mtevL(eventer_deb, "%p jobq[%s] -> running job [%p]\n", pthread_self_ptr(),
           jobq->queue_name, job);
 
+    mtev_time_maintain();
+
     /* Mark our commencement */
     job->start_hrtime = eventer_gethrtime();
 

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -37,6 +37,7 @@
 #include "mtev_skiplist.h"
 #include "mtev_memory.h"
 #include "mtev_log.h"
+#include "mtev_time.h"
 #include "libmtev_dtrace_probes.h"
 
 #include <errno.h>
@@ -318,6 +319,8 @@ static int eventer_ports_impl_loop() {
     unsigned int fd_cnt = 0;
     int ret;
     port_event_t pevents[MAX_PORT_EVENTS];
+
+    mtev_time_maintain();
 
     if(compare_timeval(eventer_max_sleeptime, __dyna_sleep) < 0)
       __dyna_sleep = eventer_max_sleeptime;

--- a/src/mtev_defines.h
+++ b/src/mtev_defines.h
@@ -155,32 +155,6 @@ typedef long long unsigned int mtev_hrtime_t;
 typedef hrtime_t mtev_hrtime_t;
 #endif
 
-#if defined(linux) || defined(__linux) || defined(__linux__)
-#include <time.h>
-static inline mtev_hrtime_t mtev_gethrtime() {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-  return ((ts.tv_sec * 1000000000) + ts.tv_nsec);
-}
-#elif defined(__MACH__)
-#include <mach/mach.h>
-#include <mach/mach_time.h>
-
-static inline mtev_hrtime_t mtev_gethrtime() {
-  static int initialized = 0;
-  static mach_timebase_info_data_t    sTimebaseInfo;
-  uint64_t t;
-  if(!initialized) {
-    if(sTimebaseInfo.denom == 0)
-      (void) mach_timebase_info(&sTimebaseInfo);
-  }
-  t = mach_absolute_time();
-  return t * sTimebaseInfo.numer / sTimebaseInfo.denom;
-}
-#else
-static inline mtev_hrtime_t mtev_gethrtime() {
-  return (mtev_hrtime_t)gethrtime();
-}
-#endif
+#include "mtev_time.h"
 
 #endif

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -47,6 +47,8 @@
 #include "mtev_main.h"
 #include "mtev_conf.h"
 #include "mtev_memory.h"
+#include "mtev_thread.h"
+#include "mtev_time.h"
 #include "mtev_watchdog.h"
 #include "mtev_lockfile.h"
 #include "mtev_listener.h"

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -191,6 +191,11 @@ mtev_main(const char *appname,
 
   mtev_init_globals();
 
+  char *disable_rdtsc = getenv("MTEV_RDTSC_DISABLE");
+  if (disable_rdtsc && strcmp(disable_rdtsc, "1") == 0) {
+    mtev_time_toggle_tsc(mtev_false);
+  }
+
   /* First initialize logging, so we can log errors */
   mtev_log_init(debug);
   mtev_log_stream_add_stream(mtev_debug, mtev_stderr);

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -80,7 +80,7 @@ mtev_thread_bind_to_cpu(int cpu)
 
   /* if we were able to bind, set the clock */
   if (mtev_thread_is_bound == mtev_true) {
-    mtev_time_start_tsc();
+    mtev_time_start_tsc(cpu);
   }
 
   return mtev_thread_is_bound;
@@ -112,7 +112,7 @@ mtev_thread_unbind_from_cpu(void)
 #endif
 
   if (mtev_thread_is_bound == mtev_false) {
-    mtev_time_stop_tsc();
+    mtev_time_stop_tsc(0);
   }
   return mtev_thread_is_bound == mtev_false;
 }

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <mtev_thread.h>
+#include <mtev_log.h>
+#include <unistd.h>
+
+#ifdef __sun
+#include <sys/processor.h>
+#endif
+#if defined(linux) || defined(__linux) || defined(__linux__)
+#define _GNU_SOURCE
+#include <sched.h>
+
+#ifndef gettid
+static pid_t
+gettid(void)
+{
+  return syscall(__NR_gettid);
+}
+#endif /* gettid */
+#endif
+
+static uint32_t mtev_current_cpu;
+static __thread mtev_boolean mtev_thread_is_bound = mtev_false;
+
+mtev_boolean
+mtev_thread_bind_to_cpu(int cpu)
+{
+#ifdef __sun 
+  if (processor_bind(P_LWPID, P_MYID, cpu, 0)) {
+    mtevL(mtev_error, "Warning: Binding thread to cpu %d failed\n", cpu);
+  }
+  else {
+    mtev_thread_is_bound = mtev_true;
+    mtevL(mtev_debug, "Bound to CPU %i\n", cpu);
+  }
+#endif
+
+#if defined(linux) || defined(__linux) || defined(__linux__)
+  cpu_set_t s;
+  CPU_ZERO(&s);
+  CPU_SET(cpu, &s)
+  int x = sched_setaffinity(gettid(), sizeof(s), &s);
+  if (x == 0) {
+    mtev_thread_is_bound = mtev_true;
+    mtevL(mtev_debug, "Bound to CPU %i\n", cpu);
+  } else {
+    mtevL(mtev_error, "Warning: Binding thread to cpu %d failed\n", cpu);
+  }   
+#endif
+
+  /* if we were able to bind, set the clock */
+  if (mtev_thread_is_bound == mtev_true) {
+    mtev_time_start_tsc();
+  }
+
+  return mtev_thread_is_bound;
+}
+
+mtev_boolean
+mtev_thread_unbind_from_cpu(void)
+{
+#ifdef __sun 
+  if (processor_bind(P_LWPID, P_MYID, PBIND_NONE, 0)) {
+    mtevL(mtev_error, "Warning: Unbinding thread from cpus failed\n");
+  }
+  else {
+    mtev_thread_is_bound = mtev_false;
+    mtevL(mtev_debug, "Unbound from CPUs\n");
+  }
+#endif
+
+#if defined(linux) || defined(__linux) || defined(__linux__)
+  cpu_set_t s;
+  CPU_ZERO(&s);
+  int x = sched_setaffinity(gettid(), sizeof(s), &s);
+  if (x == 0) {
+    mtev_thread_is_bound = mtev_false;
+    mtevL(mtev_debug, "Unbound from CPUs\n");
+  } else {
+    mtevL(mtev_error, "Warning: Unbinding thread from cpus failed\n");
+  }   
+#endif
+
+  if (mtev_thread_is_bound == mtev_false) {
+    mtev_time_stop_tsc();
+  }
+  return mtev_thread_is_bound == mtev_false;
+}
+
+
+struct mtev_thread_closure {
+  void *(*start_routine)(void *);
+  void *arg;
+};
+
+static void * 
+mtev_thread_start_routine(void *arg) {
+  struct mtev_thread_closure *c = arg;
+  mtev_thread_init();
+  void *rval = c->start_routine(c->arg);
+  free(c);
+  return rval;
+}
+
+int
+mtev_thread_create(pthread_t *thread, const pthread_attr_t *attr,
+                     void *(*start_routine) (void *), void *arg)
+{
+  struct mtev_thread_closure *c = malloc(sizeof(struct mtev_thread_closure));
+  c->start_routine = start_routine;
+  c->arg = arg;
+  return pthread_create(thread, attr, mtev_thread_start_routine, c);
+}
+
+void
+mtev_thread_init() 
+{  
+  long nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
+  int cpu = ck_pr_faa_uint(&mtev_current_cpu, 1) % nrcpus;
+  mtev_thread_bind_to_cpu(cpu);
+}
+
+mtev_boolean
+mtev_thread_is_bound_to_cpu() 
+{
+  return mtev_thread_is_bound;
+}

--- a/src/mtev_thread.h
+++ b/src/mtev_thread.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MTEV_THREAD_H
+#define MTEV_THREAD_H
+
+#include <mtev_defines.h>
+#include <pthread.h>
+
+/**
+ * wrapper for pthread_create which performs socket affinity by round robin placing
+ * threads onto cores.
+ */
+API_EXPORT(int)
+  mtev_thread_create(pthread_t *thread, const pthread_attr_t *attr,
+                     void *(*start_routine) (void *), void *arg);
+
+/**
+ * Binds the currently executing thread (LWP) to the numbered CPU
+ */
+API_EXPORT(mtev_boolean)
+  mtev_thread_bind_to_cpu(int cpu);
+
+/**
+ * Unbinds the currently executing thread (LWP) from any specific CPU.
+ * Gives it free rain over any processor.
+ */
+API_EXPORT(mtev_boolean)
+  mtev_thread_unbind_from_cpu(void);
+
+  /**
+   * returns mtev_true if this LWP has been bound to a cpu already
+   */
+API_EXPORT(mtev_boolean)
+  mtev_thread_is_bound_to_cpu();
+
+/**
+ * convenience function if you call pthread_create yourself.  Call this function
+ * from within the spawned thread to affine it to the next CPU in tracked sequence
+ */
+API_EXPORT(void)
+  mtev_thread_init();
+
+#endif

--- a/src/utils/mtev_cht.c
+++ b/src/utils/mtev_cht.c
@@ -205,7 +205,7 @@ mtev_cht_set_nodes(mtev_cht_t *cht, int node_cnt, mtev_cht_node_t *nodes) {
 int
 mtev_cht_vlookup_n(mtev_cht_t *cht, const void *key, size_t keylen,
                    int w, mtev_cht_node_t **nodes) {
-  int i, l, r, m, rsize = cht->node_cnt * cht->weight;
+  int i, l, r, m = 0, rsize = cht->node_cnt * cht->weight;
   int w_out = 0;
   int found[CHT_MAX_W];
   u_int32_t val, hash;

--- a/src/utils/mtev_cpuid.c
+++ b/src/utils/mtev_cpuid.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include "mtev_cpuid.h"
+
+#define BIT(b) (1ULL << (b))
+
+struct cpuid {
+  uint32_t eax;
+  uint32_t ebx;
+  uint32_t ecx;
+  uint32_t edx;
+} __attribute__((packed));
+
+enum {
+  VENDOR_INTEL,
+  VENDOR_AMD,
+  VENDOR_UNKNOWN,
+  VENDOR_LENGTH
+};
+
+static inline void
+mtev_cpuid(struct cpuid *r, uint32_t eax)
+{
+
+  __asm__ __volatile__("cpuid"
+                       : "=a" (r->eax),
+                         "=b" (r->ebx),
+                         "=c" (r->ecx),
+                         "=d" (r->edx)
+                       : "a"  (eax)
+                       : "memory");
+
+  return;
+}
+
+static inline int
+mtev_cpu_vendor() 
+{
+  struct cpuid id;
+  
+  mtev_cpuid(&id, 0);
+  if (id.ebx == 0x756E6547 && id.ecx == 0x6C65746E && id.edx == 0x49656E69) 
+    return VENDOR_INTEL;
+  else if (id.ebx == 0x68747541 && id.ecx == 0x444D4163 && id.edx == 0x69746E65) 
+    return VENDOR_AMD;
+  return VENDOR_UNKNOWN;
+}
+
+mtev_boolean
+mtev_cpuid_feature(int feature)
+{
+  struct cpuid id;
+  uint64_t features;
+  int vendor;
+
+  if (feature < 0 || feature >= MTEV_CPU_FEATURE_LENGTH)
+    return mtev_false;
+
+  vendor = mtev_cpu_vendor();
+
+  if (feature == MTEV_CPU_FEATURE_RDTSC) {
+    if (vendor != VENDOR_INTEL) {
+      return mtev_false;
+    }
+    mtev_cpuid(&id, 1);
+    features = ((uint64_t)id.ecx << 32) | id.edx;
+    return (BIT(4) & features) != 0 ? mtev_true : mtev_false;
+  }
+
+  if (feature == MTEV_CPU_FEATURE_RDTSCP) {
+    if (vendor != VENDOR_INTEL) {
+      return mtev_false;
+    }
+
+    mtev_cpuid(&id, 0x80000001);
+
+    return (id.edx & BIT(27)) != 0 ? mtev_true : mtev_false;
+  }
+  return mtev_false;
+}

--- a/src/utils/mtev_cpuid.h
+++ b/src/utils/mtev_cpuid.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef MTEV_CPUID_H
+#define MTEV_CPUID_H
+
+#include <mtev_defines.h>
+
+enum {
+  MTEV_CPU_FEATURE_RDTSC,
+  MTEV_CPU_FEATURE_RDTSCP,
+  MTEV_CPU_FEATURE_LENGTH
+};
+
+/** one of the enum above */
+API_EXPORT(mtev_boolean)
+  mtev_cpuid_feature(int feature);
+
+#endif

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -54,6 +54,7 @@
 #include "mtev_hash.h"
 #include "mtev_atomic.h"
 #include "mtev_hooks.h"
+#include "mtev_thread.h"
 #include <jlog.h>
 #include <jlog_private.h>
 #ifdef DTRACE_ENABLED
@@ -546,7 +547,7 @@ asynch_thread_create(mtev_log_stream_t ls, asynch_log_ctx *actx, void* function)
   }
   pthread_attr_init(&tattr);
   pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
-  if(pthread_create(&actx->writer, &tattr, function, ls) != 0) {
+  if(mtev_thread_create(&actx->writer, &tattr, function, ls) != 0) {
     return -1;
   }
   return 0;

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -41,6 +41,7 @@
 #include <sys/time.h>
 #include "mtev_hash.h"
 #include "mtev_hooks.h"
+#include "mtev_time.h"
 
 #ifdef mtev_log_impl
 typedef struct _mtev_log_stream * mtev_log_stream_t;

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -35,6 +35,7 @@
 #include <ck_fifo.h>
 #include "mtev_log.h"
 #include "mtev_memory.h"
+#include "mtev_thread.h"
 
 #define MTEV_EPOCH_SAFE_MAGIC 0x5afe5afe
 
@@ -65,7 +66,7 @@ void mtev_memory_init() {
   pthread_attr_init(&tattr);
   pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
   asynch_gc = 1;
-  if(pthread_create(&tid, &tattr, mtev_memory_gc, NULL) == 0) {
+  if(mtev_thread_create(&tid, &tattr, mtev_memory_gc, NULL) == 0) {
     mtevL(mtev_stderr, "mtev_memory starting gc thread\n");
   }
   else {

--- a/src/utils/mtev_time.c
+++ b/src/utils/mtev_time.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ck_pr.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <time.h>
+#include <unistd.h>
+#include <mtev_time.h>
+#include <mtev_cpuid.h>
+#include <mtev_thread.h>
+#include <mtev_log.h>
+#include <mtev_defines.h>
+
+#ifdef __sun
+#include <sys/processor.h>
+#endif
+#if defined(linux) || defined(__linux) || defined(__linux__)
+#define _GNU_SOURCE
+#include <sched.h>
+
+#ifndef gettid
+static pid_t
+gettid(void)
+{
+  return syscall(__NR_gettid);
+}
+#endif /* gettid */
+#endif
+
+
+typedef uint64_t rdtsc_func(void);
+
+static __thread rdtsc_func *rdtsc_function;
+static __thread double ticks_per_nano;
+static __thread uint64_t last_ticks;
+
+#define unlikely(x) __builtin_expect(!!(x), 0)
+
+static inline uint64_t
+mtev_rdtsc(void)
+{
+  uint32_t eax = 0, edx;
+
+  __asm__ __volatile__("xorl %%eax, %%eax;"
+                       "cpuid;"
+                       "rdtsc;"
+                         : "+a" (eax), "=d" (edx)
+                         :
+                         : "%ecx", "%ebx", "memory");
+
+  return (((uint64_t)edx << 32) | eax);
+}
+
+static inline uint64_t
+mtev_rdtscp(void)
+{
+  uint32_t eax = 0, edx;
+
+  __asm__ __volatile__("rdtscp"
+                       : "+a" (eax), "=d" (edx)
+                       :
+                       : "%ecx", "memory");
+
+  return (((uint64_t)edx << 32) | eax);
+}
+
+#if defined(linux) || defined(__linux) || defined(__linux__)
+#include <time.h>
+static inline mtev_hrtime_t 
+mtev_gethrtime_fallback() {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    return ((ts.tv_sec * 1000000000) + ts.tv_nsec);
+  }
+#elif defined(__MACH__)
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+
+static inline mtev_hrtime_t 
+mtev_gethrtime_fallback() {
+    static int initialized = 0;
+    static mach_timebase_info_data_t    sTimebaseInfo;
+    uint64_t t;
+    if(!initialized) {
+        if(sTimebaseInfo.denom == 0)
+            (void) mach_timebase_info(&sTimebaseInfo);
+      }
+    t = mach_absolute_time();
+    return t * sTimebaseInfo.numer / sTimebaseInfo.denom;
+  }
+#else
+static inline mtev_hrtime_t 
+mtev_gethrtime_fallback() {
+    return (mtev_hrtime_t)gethrtime();
+  }
+#endif
+
+
+static mtev_boolean 
+mtev_calibrate_rdtsc_ticks() 
+{
+  if (unlikely(rdtsc_function == NULL)) {
+    return mtev_false;
+  }
+
+  uint64_t start_ticks, end_ticks, start_ts, end_ts;
+  int j = 0;
+
+  /* 
+   * we are pinned to a core here, so sleep for short periods and measure the ticks per nano second
+   */
+  double total_ticks = 0.0, avg_ticks = 0.0;
+  for (int i = 0; i < 100; i++) {
+    start_ticks = rdtsc_function();
+    start_ts = mtev_gethrtime_fallback();
+    usleep(10);
+    end_ts = mtev_gethrtime_fallback();
+    end_ticks = rdtsc_function();
+
+    /* toss out clock weirdnesses */
+    if (start_ticks > end_ticks) {
+      continue;
+    }
+    if (start_ts > end_ts) {
+      continue;
+    }
+    total_ticks += ((double) (end_ticks - start_ticks) - avg_ticks) / (end_ts - start_ts);
+    j++;
+  }
+  mtevAssert(j > 0);
+  avg_ticks = total_ticks / (double)j;
+  ck_pr_store_double(&ticks_per_nano, avg_ticks);
+
+  mtevL(mtev_debug, "%lf ticks/nano\n", ticks_per_nano);
+
+  return true;
+}  
+
+static inline uint64_t
+ticks_to_nanos(const uint64_t ticks)
+{
+  return (uint64_t)llround((double) ticks / ck_pr_load_double(&ticks_per_nano));
+}  
+
+void  
+mtev_time_start_tsc(void)
+{
+  rdtsc_function = NULL;
+  if (mtev_cpuid_feature(MTEV_CPU_FEATURE_RDTSCP) == mtev_true) {
+    mtevL(mtev_debug, "Using rdtscp for clock\n");
+    rdtsc_function = mtev_rdtscp;
+  }
+  else if (mtev_cpuid_feature(MTEV_CPU_FEATURE_RDTSC) == mtev_true)  {
+    mtevL(mtev_debug, "Using rdtsc for clock\n");
+    rdtsc_function = mtev_rdtsc;
+  }
+  else {
+    mtevL(mtev_debug, "CPU is wrong vendor or missing feature.  Cannot use TSC clock.\n");
+    rdtsc_function = NULL;
+    return;
+  }
+
+  mtev_calibrate_rdtsc_ticks();
+}
+
+void 
+mtev_time_stop_tsc(void)
+{
+  rdtsc_function = NULL;
+}
+
+u_int64_t
+mtev_get_nanos(void)
+{
+  if (unlikely(rdtsc_function == NULL)) {
+    return mtev_gethrtime_fallback();
+  }
+
+  uint64_t ticks = mtev_get_ticks();
+  uint64_t nanos = ticks_to_nanos(ticks);
+
+  return nanos;
+}
+
+u_int64_t
+mtev_get_ticks(void)
+{
+  if (unlikely(rdtsc_function == NULL)) {
+    return 0;
+  }
+
+  return rdtsc_function();
+}
+
+mtev_hrtime_t
+mtev_gethrtime()
+{
+  return mtev_get_nanos();
+}
+
+mtev_hrtime_t
+mtev_sys_gethrtime()
+{
+  return mtev_gethrtime_fallback();
+}
+
+
+#define RECALIBRATE_TIMEOUT_NANOS 3e+10
+
+void
+mtev_time_maintain(void)
+{
+  if (unlikely(rdtsc_function == NULL)) {
+    return;
+  }
+
+  uint64_t ticks = rdtsc_function();
+  uint64_t nanos = ticks_to_nanos(ticks);
+  uint64_t last_nanos = ticks_to_nanos(last_ticks);
+
+  if (nanos - last_nanos > RECALIBRATE_TIMEOUT_NANOS) {
+    mtev_calibrate_rdtsc_ticks();
+    last_ticks = ticks;
+  }
+}
+
+

--- a/src/utils/mtev_time.h
+++ b/src/utils/mtev_time.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef MTEV_TIME_H
+#define MTEV_TIME_H
+
+#include <mtev_defines.h>
+
+/**
+ * use TSC clock if possible in the current thread.
+ * 
+ * This will remain active in the thread until you call stop
+ */
+API_EXPORT(void)
+  mtev_time_start_tsc(void);
+
+/** 
+ * Turn off TSC usage in this thread
+ */
+API_EXPORT(void)
+  mtev_time_stop_tsc(void);
+
+/**
+ * safe to call at any time but if you start_tsc, you should call this periodically to recalibrate the clock
+ */
+API_EXPORT(void)
+  mtev_time_maintain(void);
+
+/**
+ * same as mtev_gethrtime.  Number of nanoseconds from some arbitrary time in the past
+ */
+API_EXPORT(u_int64_t)
+  mtev_get_nanos(void);
+
+/**
+ * if start_tsc has been called for this thread and the CPU supports it,
+ * this will return the number of current TSC ticks
+ */
+API_EXPORT(u_int64_t)
+  mtev_get_ticks(void);
+
+/** 
+ * same as mtev_get_nanos.  Number of nanoseconds from some artibrary time in the past 
+ */
+API_EXPORT(mtev_hrtime_t)
+  mtev_gethrtime(void);
+
+/**
+ * Exposes the system gethrtime() or equivalent impl
+ */
+API_EXPORT(mtev_hrtime_t)
+  mtev_sys_gethrtime(void);
+
+#endif

--- a/src/utils/mtev_time.h
+++ b/src/utils/mtev_time.h
@@ -33,18 +33,18 @@
 #include <mtev_defines.h>
 
 /**
- * use TSC clock if possible in the current thread.
+ * use TSC clock if possible for this CPU num
  * 
  * This will remain active in the thread until you call stop
  */
 API_EXPORT(void)
-  mtev_time_start_tsc(void);
+  mtev_time_start_tsc(int cpu);
 
 /** 
- * Turn off TSC usage in this thread
+ * Turn off TSC usage for this cpu num
  */
 API_EXPORT(void)
-  mtev_time_stop_tsc(void);
+  mtev_time_stop_tsc(int cpu);
 
 /**
  * safe to call at any time but if you start_tsc, you should call this periodically to recalibrate the clock

--- a/src/utils/mtev_time.h
+++ b/src/utils/mtev_time.h
@@ -41,10 +41,22 @@ API_EXPORT(void)
   mtev_time_start_tsc(int cpu);
 
 /** 
- * Turn off TSC usage for this cpu num
+ * Turn off TSC usage for the current cpu of this thread (from when start_tsc was called)
  */
 API_EXPORT(void)
   mtev_time_stop_tsc(void);
+
+/**
+ * will switch on/off rdtsc usage across all cores regardless
+ * of detected state of rdtsc or start/stop usage.
+ * 
+ * Defaults to enabled.
+ * 
+ * This is idependent of start_tsc/stop_tsc.  You can disable all and reenable and the thread
+ * will keep going using the state from the last start/stop_tsc
+ */
+API_EXPORT(void)
+  mtev_time_toggle_tsc(mtev_boolean enable);
 
 /**
  * safe to call at any time but if you start_tsc, you should call this periodically to recalibrate the clock

--- a/src/utils/mtev_uuid_parse.c
+++ b/src/utils/mtev_uuid_parse.c
@@ -6,14 +6,6 @@
 #include <string.h>
 #include <ctype.h>
 
-struct uuid {
-  uint32_t time_low;
-  uint16_t time_mid;
-  uint16_t time_hi_and_version;
-  uint16_t clock_seq;
-  uint8_t  node[6];
-};
-
 static unsigned char lut[256] = {
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // gap before first hex digit
   0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 
@@ -27,38 +19,6 @@ static unsigned char lut[256] = {
 };
 
 #define hexvalue(c) ((unsigned long)lut[(unsigned char)(c)])
-
-static inline void uuid_pack(const struct uuid *uu, uuid_t ptr)
-{
-  register uint32_t tmp;
-  register unsigned char *out = ptr;
-
-  tmp = uu->time_low;
-  out[3] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[2] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[1] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[0] = (unsigned char) tmp;
-
-  tmp = uu->time_mid;
-  out[5] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[4] = (unsigned char) tmp;
-
-  tmp = uu->time_hi_and_version;
-  out[7] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[6] = (unsigned char) tmp;
-
-  tmp = uu->clock_seq;
-  out[9] = (unsigned char) tmp;
-  tmp >>= 8;
-  out[8] = (unsigned char) tmp;
-
-  memcpy(out+10, uu->node, 6);
-}
 
 int mtev_uuid_parse(const char *in, uuid_t uu)
 {

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -33,6 +33,10 @@ hash_test: hash_test.c
 uuid_test: uuid_test.c
 	$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS)  -L../src -lmtev -lck -luuid -o uuid_test uuid_test.c
 
+time_test: time_test.c
+	$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS)  -L../src -lmtev -lck -luuid -o time_test time_test.c
+
+
 busted:
 	@busted --version >/dev/null 2>/dev/null || \
 		(echo "Please instead busted: luarocks install busted" && false)

--- a/test/time_test.c
+++ b/test/time_test.c
@@ -1,0 +1,56 @@
+#include <mtev_time.h>
+#include <mtev_thread.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __sun
+#include <sys/processor.h>
+#endif
+
+
+#define FAIL(...)                           \
+  printf("** ");                            \
+  printf( __VA_ARGS__);                     \
+  printf("\n** FAILURE\n"); \
+  exit(1);
+
+#define loop_count 10000000
+
+int main(int argc, char **argv) 
+{
+  mtev_thread_init();
+  mtev_hrtime_t start = mtev_sys_gethrtime();
+  printf("Current CPU: %d\n", getcpuid());
+  uint64_t nstart = mtev_get_nanos();
+  usleep(1000000);
+  printf("After sleep current CPU: %d\n", getcpuid());
+
+  uint64_t nend = mtev_get_nanos();
+  mtev_hrtime_t end = mtev_sys_gethrtime();
+
+  printf("**** 1 second usleep\n");
+  printf("* hrtime elapsed: %llu\n", end - start);
+  printf("* nanos elapsed: %llu\n", nend - nstart);
+
+  start = mtev_sys_gethrtime();
+  for (int i = 0; i < loop_count; i++) {
+    (void) mtev_get_nanos();
+  }
+  end = mtev_sys_gethrtime();
+
+  printf("**** call mtev_get_nanos(), %d times\n", loop_count);
+  printf("* hrtime elapsed: %llu\n", end - start);
+  
+  start = mtev_sys_gethrtime();
+  for (int i = 0; i < loop_count; i++) {
+    (void) mtev_sys_gethrtime();
+  }
+  end = mtev_sys_gethrtime();
+
+  printf("**** call mtev_gethrtime(), %d times\n", loop_count);
+  printf("* hrtime elapsed: %llu\n", end - start);
+
+  printf("* SUCCESS\n");
+}


### PR DESCRIPTION
RDTSC requires cpu identification, thread->core affinity and functions to fallback to gethrtime() equivalents if rdtsc is not available or the thread isn't pinned to a core.

** The controversial part of the this PR is the change to make all `pthread_create` into `mtev_thread_create`.  The latter of which does thread->core affinity in a round robin fashion.  We might not want to do this **