### PR TITLE
Passing change type to handle_node_update_hook

### DIFF
--- a/src/examples/example1.c
+++ b/src/examples/example1.c
@@ -48,15 +48,16 @@ parse_cli_args(int argc, char * const *argv) {
 }
 
 static mtev_hook_return_t
-on_node_updated(void *closure, mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+on_node_updated(void *closure, mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
     struct timeval old_boot_time) {
   mtev_boolean i_am_oldest = mtev_cluster_am_i_oldest_node(my_cluster);
 
   mtevL(mtev_stderr, "The cluster topology has changed (seq=%"PRId64"): I am oldest node: %d\n",
       updated_node->config_seq, i_am_oldest);
-  if(node_change == mtev_cluster_node_rebooted) {
+  if(node_changes & MTEV_CLUSTER_NODE_REBOOTED) {
     mtevL(mtev_stderr, "Found new node\n");
-  } else  if(node_change == mtev_cluster_node_rebooted) {
+  }
+  if(node_changes & MTEV_CLUSTER_NODE_CHANGED_PAYLOAD) {
     mtevL(mtev_stderr, "Node's payload has changed:\n");
   }
 

--- a/src/examples/example1.c
+++ b/src/examples/example1.c
@@ -48,21 +48,27 @@ parse_cli_args(int argc, char * const *argv) {
 }
 
 static mtev_hook_return_t
-on_node_updated(void *closure, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+on_node_updated(void *closure, mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
     struct timeval old_boot_time) {
   mtev_boolean i_am_oldest = mtev_cluster_am_i_oldest_node(my_cluster);
 
   mtevL(mtev_stderr, "The cluster topology has changed (seq=%"PRId64"): I am oldest node: %d\n",
       updated_node->config_seq, i_am_oldest);
+  if(node_change == mtev_cluster_node_rebooted) {
+    mtevL(mtev_stderr, "Found new node\n");
+  } else  if(node_change == mtev_cluster_node_rebooted) {
+    mtevL(mtev_stderr, "Node's payload has changed:\n");
+  }
+
   if(updated_node->payload) {
     char* payload = NULL;
     char* payload2 = NULL;
     assert(mtev_cluster_get_heartbeat_payload(updated_node, 2, 1, (void**)&payload) == -1);
     mtev_cluster_get_heartbeat_payload(updated_node, 1, 1, (void**)&payload);
     mtev_cluster_get_heartbeat_payload(updated_node, 1, 2, (void**)&payload2);
-    mtevL(mtev_stderr, "Payload attached to cluster heartbeats: 1: %s\t2:%s\n", payload, payload2);
+    mtevL(mtev_stderr, "Payloads attached to cluster heartbeat: 1: %s\t2:%s\n", payload, payload2);
   } else {
-    mtevL(mtev_stderr, "No payload attached to cluster heartbeats\n");
+    mtevL(mtev_stderr, "No payload attached to cluster heartbeat\n");
   }
 
   // Changing the payload will trigger another node update on all cluster members

--- a/src/examples/example1.c
+++ b/src/examples/example1.c
@@ -48,7 +48,7 @@ parse_cli_args(int argc, char * const *argv) {
 }
 
 static mtev_hook_return_t
-on_node_updated(void *closure, mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+on_node_updated(void *closure, mtev_cluster_node_changes_t node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
     struct timeval old_boot_time) {
   mtev_boolean i_am_oldest = mtev_cluster_am_i_oldest_node(my_cluster);
 

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -1159,7 +1159,6 @@ static int on_timeout(eventer_t e, int mask, void *closure,
   cl = cb_ref->timed_out_eventer->closure;
   ci = mtev_lua_get_resume_info(L);
   assert(ci);
-  
 
   // remove the original read event
   eventer_remove_fd(cb_ref->timed_out_eventer->fd);
@@ -1168,7 +1167,7 @@ static int on_timeout(eventer_t e, int mask, void *closure,
   memcpy(*cl->eptr, cb_ref->timed_out_eventer, sizeof(*cb_ref->timed_out_eventer));
   (*cl->eptr)->refcnt = 1;
   mtev_lua_register_event(ci, *cl->eptr);
-  
+
   // return into the original Lua call which spawned this timeout
   lua_pushnil(L);
   ci->lmc->resume(ci, 1);

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -87,10 +87,10 @@ struct mtev_cluster_t {
 
 
 MTEV_HOOK_IMPL(mtev_cluster_handle_node_update,
-  (mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+  (mtev_cluster_node_changes_t node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
       struct timeval old_boot_time),
   void *, closure,
-  (void *closure, mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+  (void *closure, mtev_cluster_node_changes_t node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
       struct timeval old_boot_time),
   (closure,node_change,updated_node,cluster,old_boot_time))
 
@@ -195,7 +195,7 @@ mtev_cluster_find_oldest_node(mtev_cluster_t *cluster) {
 static void
 mtev_cluster_on_node_changed(mtev_cluster_t *cluster,
     mtev_cluster_node_t *sender, const struct timeval *new_boot_time,
-    int64_t seq, mtev_cluster_node_changes node_change) {
+    int64_t seq, mtev_cluster_node_changes_t node_change) {
   struct timeval old_boot_time = sender->boot_time;
   sender->boot_time = *new_boot_time;
   sender->config_seq = seq;
@@ -342,7 +342,7 @@ mtev_cluster_info_process(void *msg, int len, void *c) {
   uint8_t number_of_payloads;
   uint16_t payload_len;
   mtev_boolean node_changed = mtev_false;
-  mtev_cluster_node_changes node_changes = 0;
+  mtev_cluster_node_changes_t node_changes = 0;
 
   /* messages from other cluster members (including me) arrive here */
   MEMREAD(&version, 1);

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -56,12 +56,11 @@ typedef struct {
   uint8_t number_of_payloads;
 } mtev_cluster_node_t;
 
-typedef enum {
-  mtev_cluster_node_died,
-  mtev_cluster_node_rebooted,
-  mtev_cluster_node_changed_seq,
-  mtev_cluster_node_changed_payload
-} mtev_cluster_node_changes;
+#define MTEV_CLUSTER_NODE_DIED 1 << 0
+#define MTEV_CLUSTER_NODE_REBOOTED 1 << 1
+#define MTEV_CLUSTER_NODE_CHANGED_SEQ 1 << 2
+#define MTEV_CLUSTER_NODE_CHANGED_PAYLOAD 1 << 3
+typedef uint8_t mtev_cluster_node_changes;
 
 typedef void (*mtev_cluster_node_update_cb)(mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster);
 
@@ -233,10 +232,10 @@ API_EXPORT(struct timeval)
    \return Returns mtev_true if the cluster is not NULL, mtev_false otherwise
  */
 MTEV_HOOK_PROTO(mtev_cluster_handle_node_update,
-                (mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time),
                 void *, closure,
-                (void *closure, mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (void *closure, mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time));
 
 

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -60,7 +60,7 @@ typedef struct {
 #define MTEV_CLUSTER_NODE_REBOOTED 1 << 1
 #define MTEV_CLUSTER_NODE_CHANGED_SEQ 1 << 2
 #define MTEV_CLUSTER_NODE_CHANGED_PAYLOAD 1 << 3
-typedef uint8_t mtev_cluster_node_changes;
+typedef uint8_t mtev_cluster_node_changes_t;
 
 typedef void (*mtev_cluster_node_update_cb)(mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster);
 
@@ -232,10 +232,10 @@ API_EXPORT(struct timeval)
    \return Returns mtev_true if the cluster is not NULL, mtev_false otherwise
  */
 MTEV_HOOK_PROTO(mtev_cluster_handle_node_update,
-                (mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (mtev_cluster_node_changes_t node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time),
                 void *, closure,
-                (void *closure, mtev_cluster_node_changes node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (void *closure, mtev_cluster_node_changes_t node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time));
 
 

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -56,6 +56,13 @@ typedef struct {
   uint8_t number_of_payloads;
 } mtev_cluster_node_t;
 
+typedef enum {
+  mtev_cluster_node_died,
+  mtev_cluster_node_rebooted,
+  mtev_cluster_node_changed_seq,
+  mtev_cluster_node_changed_payload
+} mtev_cluster_node_changes;
+
 typedef void (*mtev_cluster_node_update_cb)(mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster);
 
 /*! \fn void mtev_cluster_init()
@@ -131,6 +138,8 @@ API_EXPORT(void) mtev_cluster_set_self(uuid_t);
    Pouplates the passed uuid_t with the local node's UUID.
  */
 API_EXPORT(void) mtev_cluster_get_self(uuid_t);
+
+API_EXPORT(mtev_boolean) mtev_cluster_is_that_me(mtev_cluster_node_t *node);
 
 /* \fn int mtev_cluster_get_nodes(mtev_cluster_t *cluster, mtev_cluster_node_t **nodes, int n, mtev_boolean includeme)
    \brief Reports all nodes in the cluster (possible excluding the local node)
@@ -224,10 +233,10 @@ API_EXPORT(struct timeval)
    \return Returns mtev_true if the cluster is not NULL, mtev_false otherwise
  */
 MTEV_HOOK_PROTO(mtev_cluster_handle_node_update,
-                (mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time),
                 void *, closure,
-                (void *closure, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
+                (void *closure, mtev_cluster_node_changes node_change, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time));
 
 


### PR DESCRIPTION
Added an enum defining the possible reason an `node_update_hook` has been called. The corresponding value is passed to the hook.