### PR TITLE
Thread binding changes

### DIFF
--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -308,7 +308,7 @@ static void eventer_loop_prime() {
   int i;
   for(i=1; i<__loop_concurrency; i++) {
     pthread_t tid;
-    mtev_thread_create(&tid, NULL, thrloopwrap, (void *)(vpsized_int)i);
+    pthread_create(&tid, NULL, thrloopwrap, (void *)(vpsized_int)i);
   }
   while(__loops_started < __loop_concurrency);
 }

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -196,6 +196,11 @@ mtev_main(const char *appname,
     mtev_time_toggle_tsc(mtev_false);
   }
 
+  char *disable_binding = getenv("MTEV_THREAD_BINDING_DISABLE");
+  if (disable_binding && strcmp(disable_binding, "1") == 0) {
+    mtev_thread_disable_binding();
+  }
+
   /* First initialize logging, so we can log errors */
   mtev_log_init(debug);
   mtev_log_stream_add_stream(mtev_debug, mtev_stderr);

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -55,6 +55,7 @@ gettid(void)
 
 static uint32_t mtev_current_cpu;
 static __thread mtev_boolean mtev_thread_is_bound = mtev_false;
+static mtev_boolean mtev_disable_binding = mtev_false;
 
 mtev_boolean
 mtev_thread_bind_to_cpu(int cpu)
@@ -147,9 +148,18 @@ mtev_thread_create(pthread_t *thread, const pthread_attr_t *attr,
 void
 mtev_thread_init() 
 {  
+  if (mtev_disable_binding == mtev_true) {
+    return;
+  }
   long nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
   int cpu = ck_pr_faa_uint(&mtev_current_cpu, 1) % nrcpus;
   mtev_thread_bind_to_cpu(cpu);
+}
+
+void
+mtev_thread_disable_binding()
+{
+  mtev_disable_binding = mtev_true;
 }
 
 mtev_boolean
@@ -157,3 +167,4 @@ mtev_thread_is_bound_to_cpu()
 {
   return mtev_thread_is_bound;
 }
+

--- a/src/mtev_thread.h
+++ b/src/mtev_thread.h
@@ -68,4 +68,12 @@ API_EXPORT(mtev_boolean)
 API_EXPORT(void)
   mtev_thread_init();
 
+/**
+ * Switches off and disallows binding of threads to cores. If you call this on startup,
+ * mtev_thread_init and mtev_thread_create will not bind the current LWP to the next core
+ * in sequence.  They will silently noop.
+ */
+API_EXPORT(void)
+  mtev_thread_disable_binding();
+
 #endif

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -547,7 +547,7 @@ asynch_thread_create(mtev_log_stream_t ls, asynch_log_ctx *actx, void* function)
   }
   pthread_attr_init(&tattr);
   pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
-  if(mtev_thread_create(&actx->writer, &tattr, function, ls) != 0) {
+  if(pthread_create(&actx->writer, &tattr, function, ls) != 0) {
     return -1;
   }
   return 0;

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -66,7 +66,7 @@ void mtev_memory_init() {
   pthread_attr_init(&tattr);
   pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
   asynch_gc = 1;
-  if(mtev_thread_create(&tid, &tattr, mtev_memory_gc, NULL) == 0) {
+  if(pthread_create(&tid, &tattr, mtev_memory_gc, NULL) == 0) {
     mtevL(mtev_stderr, "mtev_memory starting gc thread\n");
   }
   else {


### PR DESCRIPTION
* do not bind the mtev gc thread, asynch log thread or the eventer threads
* leave jobq threads bound to cores
* provide an env var MTEV_THREAD_BINDING_DISABLE which allows turning off binding for everything