### PR TITLE
Refactor fast time support.

### DIFF
--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -1,26 +1,39 @@
 
-luamtev.o luamtev.lo: luamtev.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_conf.h ../src/utils/mtev_hash.h mtev_console.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/histedit.h \
+luamtev.o luamtev.lo: luamtev.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_conf.h mtev_defines.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  mtev_console.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_time.h ../src/utils/mtev_time.h \
+  eventer/eventer_POSIX_fd_opset.h eventer/eventer.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h \
+  noitedit/histedit.h \
   mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
-  ../src/utils/mtev_hooks.h  \
-  mtev_dso.h mtev_listener.h mtev_main.h ../src/utils/mtev_memory.h \
-  mtev_rest.h mtev_http.h \
+  ../src/utils/mtev_hooks.h  mtev_console.h \
+  mtev_dso.h mtev_conf.h mtev_listener.h mtev_main.h \
+  ../src/utils/mtev_memory.h mtev_rest.h mtev_listener.h mtev_http.h \
   ../src/utils/mtev_zipkin.h ../src/utils/mtev_security.h \
   luamtev.conf.tmpl
 
 mtev_capabilities_listener.o mtev_capabilities_listener.lo: mtev_capabilities_listener.c mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h mtev_version.h eventer/eventer.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h mtev_version.h eventer/eventer.h mtev_defines.h \
   ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_listener.h \
-  mtev_capabilities_listener.h mtev_xml.h \
-  mtev_rest.h mtev_http.h ../src/utils/mtev_hooks.h \
-  ../src/utils/mtev_zipkin.h mtev_dso.h mtev_conf.h mtev_console.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  mtev_listener.h \
+  ../src/utils/mtev_hash.h mtev_capabilities_listener.h mtev_console.h \
   noitedit/histedit.h mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
+  mtev_xml.h  \
+  mtev_rest.h mtev_http.h ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_zipkin.h mtev_dso.h mtev_conf.h \
   ../src/json-lib/mtev_json.h \
   ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_debug.h \
   ../src/json-lib/mtev_linkhash.h ../src/json-lib/mtev_arraylist.h \
@@ -28,550 +41,855 @@ mtev_capabilities_listener.o mtev_capabilities_listener.lo: mtev_capabilities_li
   ../src/json-lib/mtev_json_tokener.h \
 
 mtev_cluster.o mtev_cluster.lo: mtev_cluster.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h \
-  mtev_rest.h mtev_listener.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_http.h \
-  ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h mtev_conf.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_rest.h mtev_listener.h eventer/eventer.h mtev_defines.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_hash.h \
+  mtev_http.h ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h \
   mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h \
-  ../src/utils/mtev_memory.h \
-  mtev_cluster.h ../src/utils/mtev_cht.h mtev_net_heartbeat.h
+  ../src/utils/mtev_skiplist.h mtev_conf.h  \
+  ../src/utils/mtev_memory.h mtev_cluster.h mtev_conf.h \
+  ../src/utils/mtev_cht.h mtev_net_heartbeat.h
 
-mtev_conf.o mtev_conf.lo: mtev_conf.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_conf.h ../src/utils/mtev_hash.h mtev_console.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/histedit.h \
+mtev_conf.o mtev_conf.lo: mtev_conf.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_conf.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  mtev_console.h eventer/eventer.h \
+  mtev_defines.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_time.h ../src/utils/mtev_time.h \
+  eventer/eventer_POSIX_fd_opset.h eventer/eventer.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/histedit.h \
   mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
-  ../src/utils/mtev_hooks.h  \
-  mtev_version.h mtev_xml.h ../src/utils/mtev_b64.h \
-  ../src/utils/mtev_watchdog.h ../src/utils/mtev_security.h \
+  ../src/utils/mtev_hooks.h  mtev_version.h \
+  mtev_xml.h ../src/utils/mtev_b64.h ../src/utils/mtev_watchdog.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_security.h \
   ../src/utils/mtev_str.h
 
-mtev_console.o mtev_console.lo: mtev_console.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_listener.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h mtev_tokenizer.h noitedit/sys.h \
-  noitedit/el.h noitedit/tty.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
 mtev_console_complete.o mtev_console_complete.lo: mtev_console_complete.c mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_listener.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h mtev_tokenizer.h noitedit/sys.h \
-  noitedit/el.h noitedit/tty.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  mtev_listener.h \
+  ../src/utils/mtev_hash.h mtev_console.h noitedit/histedit.h \
+  mtev_console_telnet.h ../src/utils/mtev_skiplist.h mtev_tokenizer.h \
+  noitedit/sys.h noitedit/el.h noitedit/tty.h noitedit/histedit.h \
+  noitedit/prompt.h noitedit/key.h noitedit/el_term.h noitedit/refresh.h \
+  noitedit/chared.h noitedit/common.h noitedit/vi.h noitedit/emacs.h \
+  noitedit/search.h noitedit/fcns.h noitedit/hist.h noitedit/map.h \
+  noitedit/parse.h noitedit/sig.h noitedit/help.h noitedit/fcns.h \
+  noitedit/map.h
 
 mtev_console_state.o mtev_console_state.lo: mtev_console_state.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h mtev_version.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_listener.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h mtev_tokenizer.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_version.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  eventer/eventer_jobq.h \
+  ../src/utils/mtev_hash.h mtev_listener.h mtev_rest.h mtev_http.h \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h mtev_console.h \
+  noitedit/histedit.h mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
+  mtev_tokenizer.h mtev_capabilities_listener.h 
 
 mtev_console_telnet.o mtev_console_telnet.lo: mtev_console_telnet.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h mtev_console.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/histedit.h \
-  mtev_console_telnet.h ../src/utils/mtev_skiplist.h
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_console.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/histedit.h \
+  mtev_console_telnet.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_skiplist.h
 
-mtev_dso.o mtev_dso.lo: mtev_dso.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_dso.h mtev_conf.h ../src/utils/mtev_hash.h mtev_console.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/histedit.h \
+mtev_console.o mtev_console.lo: mtev_console.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  mtev_listener.h \
+  ../src/utils/mtev_hash.h mtev_console.h noitedit/histedit.h \
+  mtev_console_telnet.h ../src/utils/mtev_skiplist.h mtev_tokenizer.h \
+  noitedit/sys.h noitedit/el.h noitedit/tty.h noitedit/histedit.h \
+  noitedit/prompt.h noitedit/key.h noitedit/el_term.h noitedit/refresh.h \
+  noitedit/chared.h noitedit/common.h noitedit/vi.h noitedit/emacs.h \
+  noitedit/search.h noitedit/fcns.h noitedit/hist.h noitedit/map.h \
+  noitedit/parse.h noitedit/sig.h noitedit/help.h noitedit/fcns.h \
+  noitedit/map.h
+
+mtev_dso.o mtev_dso.lo: mtev_dso.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_dso.h mtev_conf.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  mtev_console.h eventer/eventer.h \
+  mtev_defines.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_time.h ../src/utils/mtev_time.h \
+  eventer/eventer_POSIX_fd_opset.h eventer/eventer.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/histedit.h \
   mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
   ../src/utils/mtev_hooks.h 
 
 mtev_events_rest.o mtev_events_rest.lo: mtev_events_rest.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h mtev_listener.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_http.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_listener.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_hash.h \
+  mtev_http.h  \
   ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h mtev_rest.h \
-  mtev_conf.h mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h \
-  ../src/json-lib/mtev_json.h \
-  ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_debug.h \
-  ../src/json-lib/mtev_linkhash.h ../src/json-lib/mtev_arraylist.h \
-  ../src/json-lib/mtev_json_util.h ../src/json-lib/mtev_json_object.h \
-  ../src/json-lib/mtev_json_tokener.h
+  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
+  ../src/utils/mtev_skiplist.h mtev_conf.h  \
+  ../src/json-lib/mtev_json.h ../src/json-lib/mtev_bits.h \
+  ../src/json-lib/mtev_debug.h ../src/json-lib/mtev_linkhash.h \
+  ../src/json-lib/mtev_arraylist.h ../src/json-lib/mtev_json_util.h \
+  ../src/json-lib/mtev_json_object.h ../src/json-lib/mtev_json_tokener.h
 
-mtev_http.o mtev_http.lo: mtev_http.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_http.h \
+mtev_http.o mtev_http.lo: mtev_http.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  ../src/utils/mtev_b64.h mtev_defines.h mtev_http.h \
   eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_hash.h \
   ../src/utils/mtev_hooks.h mtev_listener.h ../src/utils/mtev_zipkin.h \
   ../src/utils/mtev_str.h ../src/utils/mtev_getip.h mtev_conf.h \
   mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h \
+  ../src/utils/mtev_skiplist.h 
 
 mtev_listener.o mtev_listener.lo: mtev_listener.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
+  noitedit/strlcpy.h mtev_config.h \
+  eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
   ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
-  ../src/utils/mtev_watchdog.h mtev_listener.h mtev_conf.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_watchdog.h ../src/utils/mtev_log.h mtev_listener.h \
+  ../src/utils/mtev_hash.h mtev_conf.h mtev_console.h noitedit/histedit.h \
+  mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
+  ../src/utils/mtev_hooks.h 
 
-mtev_main.o mtev_main.lo: mtev_main.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h mtev_main.h \
-  mtev_conf.h mtev_console.h eventer/eventer.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/histedit.h \
+mtev_main.o mtev_main.lo: mtev_main.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  ../src/utils/mtev_log.h mtev_defines.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h mtev_main.h \
+  mtev_conf.h ../src/utils/mtev_hash.h mtev_console.h eventer/eventer.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/histedit.h \
   mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
   ../src/utils/mtev_hooks.h  \
-  ../src/utils/mtev_watchdog.h ../src/utils/mtev_lockfile.h
+  ../src/utils/mtev_memory.h mtev_thread.h ../src/utils/mtev_watchdog.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_lockfile.h mtev_listener.h \
+  mtev_capabilities_listener.h mtev_rest.h mtev_http.h \
+  ../src/utils/mtev_zipkin.h mtev_reverse_socket.h mtev_dso.h
 
 mtev_net_heartbeat.o mtev_net_heartbeat.lo: mtev_net_heartbeat.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
+  noitedit/strlcpy.h mtev_config.h \
+  eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
   ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_conf.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h ../src/utils/mtev_hooks.h \
-  mtev_net_heartbeat.h
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  mtev_conf.h \
+  ../src/utils/mtev_hash.h mtev_console.h noitedit/histedit.h \
+  mtev_console_telnet.h ../src/utils/mtev_skiplist.h \
+  ../src/utils/mtev_hooks.h  mtev_net_heartbeat.h
 
-mtev_rest.o mtev_rest.lo: mtev_rest.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_listener.h eventer/eventer.h ../src/utils/mtev_log.h \
+mtev_rest.o mtev_rest.lo: mtev_rest.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_listener.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
   ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_http.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_hash.h \
+  mtev_http.h  \
   ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h mtev_rest.h \
-  mtev_conf.h mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
-  ../src/utils/mtev_skiplist.h \
+  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
+  ../src/utils/mtev_skiplist.h mtev_conf.h  \
+  ../src/json-lib/mtev_json.h ../src/json-lib/mtev_bits.h \
+  ../src/json-lib/mtev_debug.h ../src/json-lib/mtev_linkhash.h \
+  ../src/json-lib/mtev_arraylist.h ../src/json-lib/mtev_json_util.h \
+  ../src/json-lib/mtev_json_object.h ../src/json-lib/mtev_json_tokener.h
 
 mtev_reverse_socket.o mtev_reverse_socket.lo: mtev_reverse_socket.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h mtev_listener.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_conf.h \
-  mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_listener.h eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_hash.h \
+  mtev_conf.h mtev_console.h noitedit/histedit.h mtev_console_telnet.h \
   ../src/utils/mtev_skiplist.h ../src/utils/mtev_hooks.h \
   mtev_rest.h mtev_http.h \
-  ../src/utils/mtev_zipkin.h mtev_reverse_socket.h \
-  ../src/utils/mtev_str.h ../src/utils/mtev_watchdog.h \
+  ../src/utils/mtev_zipkin.h mtev_reverse_socket.h ../src/utils/mtev_str.h \
+  ../src/utils/mtev_watchdog.h ../src/utils/mtev_log.h \
   ../src/json-lib/mtev_json.h ../src/json-lib/mtev_bits.h \
   ../src/json-lib/mtev_debug.h ../src/json-lib/mtev_linkhash.h \
   ../src/json-lib/mtev_arraylist.h ../src/json-lib/mtev_json_util.h \
   ../src/json-lib/mtev_json_object.h ../src/json-lib/mtev_json_tokener.h \
   libmtev_dtrace_probes.h
 
-mtev_tokenizer.o mtev_tokenizer.lo: mtev_tokenizer.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h
+mtev_stats.o mtev_stats.lo: mtev_stats.c mtev_stats.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_rest.h mtev_listener.h \
+  eventer/eventer.h mtev_defines.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer.h eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h ../src/utils/mtev_hash.h \
+  mtev_http.h  \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_zipkin.h mtev_console.h \
+  noitedit/histedit.h mtev_console_telnet.h ../src/utils/mtev_skiplist.h
 
-mtev_xml.o mtev_xml.lo: mtev_xml.c mtev_defines.h mtev_config.h noitedit/strlcpy.h \
-  mtev_xml.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+mtev_thread.o mtev_thread.lo: mtev_thread.c mtev_thread.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  ../src/utils/mtev_time.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h
+
+mtev_tokenizer.o mtev_tokenizer.lo: mtev_tokenizer.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h
+
+mtev_xml.o mtev_xml.lo: mtev_xml.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  mtev_xml.h  \
+  ../src/utils/mtev_log.h mtev_defines.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
   ../src/utils/mtev_mkdir.h
 
-utils/mtev_b32.o utils/mtev_b32.lo: utils/mtev_b32.c mtev_config.h ../src/utils/mtev_b64.h \
-  mtev_defines.h noitedit/strlcpy.h
+utils/mtev_b32.o utils/mtev_b32.lo: utils/mtev_b32.c mtev_config.h utils/mtev_b64.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h
 
-utils/mtev_b64.o utils/mtev_b64.lo: utils/mtev_b64.c mtev_config.h ../src/utils/mtev_b64.h \
-  mtev_defines.h noitedit/strlcpy.h
+utils/mtev_b64.o utils/mtev_b64.lo: utils/mtev_b64.c mtev_config.h utils/mtev_b64.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h
 
 utils/mtev_btrie.o utils/mtev_btrie.lo: utils/mtev_btrie.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_btrie.h
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_btrie.h utils/mtev_log.h utils/mtev_hash.h \
+  utils/mtev_atomic.h  \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h
 
-utils/mtev_cht.o utils/mtev_cht.lo: utils/mtev_cht.c ../src/utils/mtev_cht.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h ../src/utils/mtev_hash.h
+utils/mtev_cht.o utils/mtev_cht.lo: utils/mtev_cht.c utils/mtev_cht.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_log.h \
+  utils/mtev_hooks.h ../src/utils/mtev_atomic.h utils/mtev_time.h
 
-utils/mtev_confstr.o utils/mtev_confstr.lo: utils/mtev_confstr.c ../src/utils/mtev_confstr.h \
-  mtev_defines.h mtev_config.h noitedit/strlcpy.h
+utils/mtev_confstr.o utils/mtev_confstr.lo: utils/mtev_confstr.c utils/mtev_confstr.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h
 
-utils/mtev_getip.o utils/mtev_getip.lo: utils/mtev_getip.c mtev_config.h ../src/utils/mtev_getip.h \
-  mtev_defines.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h
+utils/mtev_cpuid.o utils/mtev_cpuid.lo: utils/mtev_cpuid.c utils/mtev_cpuid.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h
 
-utils/mtev_hash.o utils/mtev_hash.lo: utils/mtev_hash.c mtev_config.h ../src/utils/mtev_hash.h
+utils/mtev_getip.o utils/mtev_getip.lo: utils/mtev_getip.c mtev_config.h utils/mtev_getip.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+
+utils/mtev_hash.o utils/mtev_hash.lo: utils/mtev_hash.c mtev_config.h utils/mtev_hash.h \
+  utils/mtev_atomic.h  \
+  utils/mtev_log.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  utils/mtev_hooks.h ../src/utils/mtev_atomic.h utils/mtev_time.h \
+  utils/mtev_watchdog.h  \
 
 utils/mtev_lockfile.o utils/mtev_lockfile.lo: utils/mtev_lockfile.c mtev_config.h \
-  ../src/utils/mtev_lockfile.h mtev_defines.h noitedit/strlcpy.h
+  utils/mtev_lockfile.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h
 
 utils/mtev_log.o utils/mtev_log.lo: utils/mtev_log.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h  \
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_log.h \
+  utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h mtev_thread.h \
   libmtev_dtrace_probes.h
 
-utils/mtev_memory.o utils/mtev_memory.lo: utils/mtev_memory.c ../src/utils/mtev_log.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h ../src/utils/mtev_hash.h
+utils/mtev_memory.o utils/mtev_memory.lo: utils/mtev_memory.c  \
+  utils/mtev_log.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h mtev_config.h utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h utils/mtev_memory.h \
+  mtev_thread.h
 
-utils/mtev_mkdir.o utils/mtev_mkdir.lo: utils/mtev_mkdir.c mtev_config.h ../src/utils/mtev_mkdir.h \
-  mtev_defines.h noitedit/strlcpy.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h
+utils/mtev_mkdir.o utils/mtev_mkdir.lo: utils/mtev_mkdir.c mtev_config.h utils/mtev_mkdir.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h utils/mtev_log.h utils/mtev_hash.h \
+  utils/mtev_atomic.h  \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h
+
+utils/mtev_perftimer.o utils/mtev_perftimer.lo: utils/mtev_perftimer.c utils/mtev_perftimer.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h mtev_config.h  \
+  utils/mtev_time.h
 
 utils/mtev_security.o utils/mtev_security.lo: utils/mtev_security.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_security.h
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_log.h utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h utils/mtev_security.h
 
 utils/mtev_sem.o utils/mtev_sem.lo: utils/mtev_sem.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_sem.h
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_sem.h
 
 utils/mtev_skiplist.o utils/mtev_skiplist.lo: utils/mtev_skiplist.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_skiplist.h
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_skiplist.h utils/mtev_log.h utils/mtev_hash.h \
+  utils/mtev_atomic.h  \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h
 
 utils/mtev_str.o utils/mtev_str.lo: utils/mtev_str.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_str.h
+  noitedit/strlcpy.h mtev_config.h \
+  utils/mtev_str.h utils/mtev_log.h utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h utils/mtev_time.h
+
+utils/mtev_time.o utils/mtev_time.lo: utils/mtev_time.c  \
+  mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h utils/mtev_time.h utils/mtev_cpuid.h mtev_thread.h \
+  utils/mtev_log.h utils/mtev_hash.h utils/mtev_atomic.h \
+  utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h
+
+utils/mtev_uuid_parse.o utils/mtev_uuid_parse.lo: utils/mtev_uuid_parse.c utils/mtev_uuid_parse.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h mtev_config.h
 
 utils/mtev_watchdog.o utils/mtev_watchdog.lo: utils/mtev_watchdog.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
-  ../src/utils/mtev_watchdog.h
+  noitedit/strlcpy.h mtev_config.h \
+  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  utils/mtev_log.h \
+  utils/mtev_watchdog.h
 
 utils/mtev_zipkin.o utils/mtev_zipkin.lo: utils/mtev_zipkin.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_hooks.h ../src/utils/mtev_atomic.h \
+  noitedit/strlcpy.h mtev_config.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_hooks.h ../src/utils/mtev_time.h \
   ../src/utils/mtev_zipkin.h
 
-eventer/OETS_asn1_helper.o eventer/OETS_asn1_helper.lo: eventer/OETS_asn1_helper.c \
-
-eventer/eventer.o eventer/eventer.lo: eventer/eventer.c eventer/eventer.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h ../src/utils/mtev_log.h \
+eventer/eventer_epoll_impl.o eventer/eventer_epoll_impl.lo: eventer/eventer_epoll_impl.c mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h ../src/utils/mtev_log.h \
   ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h
-
-eventer/eventer_POSIX_fd_opset.o eventer/eventer_POSIX_fd_opset.lo: eventer/eventer_POSIX_fd_opset.c mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h libmtev_dtrace_probes.h
-
-eventer/eventer_SSL_fd_opset.o eventer/eventer_SSL_fd_opset.lo: eventer/eventer_SSL_fd_opset.c mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
-  eventer/OETS_asn1_helper.h libmtev_dtrace_probes.h \
-
-eventer/eventer_impl.o eventer/eventer_impl.lo: eventer/eventer_impl.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
-  ../src/utils/mtev_memory.h ../src/utils/mtev_skiplist.h \
-  ../src/utils/mtev_watchdog.h libmtev_dtrace_probes.h
-
-eventer/eventer_jobq.o eventer/eventer_jobq.lo: eventer/eventer_jobq.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h ../src/utils/mtev_memory.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h eventer/eventer.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h libmtev_dtrace_probes.h
-
-eventer/eventer_kqueue_impl.o eventer/eventer_kqueue_impl.lo: eventer/eventer_kqueue_impl.c mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
   ../src/utils/mtev_skiplist.h ../src/utils/mtev_memory.h \
   libmtev_dtrace_probes.h eventer/eventer_impl_private.h
 
+eventer/eventer_impl.o eventer/eventer_impl.lo: eventer/eventer_impl.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  eventer/eventer_impl_private.h ../src/utils/mtev_memory.h \
+  ../src/utils/mtev_skiplist.h mtev_thread.h ../src/utils/mtev_watchdog.h \
+  ../src/utils/mtev_log.h libmtev_dtrace_probes.h \
+
+eventer/eventer_jobq.o eventer/eventer_jobq.lo: eventer/eventer_jobq.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  ../src/utils/mtev_memory.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h mtev_thread.h \
+  eventer/eventer.h ../src/utils/mtev_time.h \
+  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
+  eventer/eventer_jobq.h ../src/utils/mtev_sem.h mtev_stats.h \
+  mtev_defines.h  \
+  eventer/eventer_impl_private.h libmtev_dtrace_probes.h
+
+eventer/eventer_kqueue_impl.o eventer/eventer_kqueue_impl.lo: eventer/eventer_kqueue_impl.c mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_skiplist.h ../src/utils/mtev_memory.h \
+  libmtev_dtrace_probes.h eventer/eventer_impl_private.h
+
+eventer/eventer_ports_impl.o eventer/eventer_ports_impl.lo: eventer/eventer_ports_impl.c mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  ../src/utils/mtev_skiplist.h ../src/utils/mtev_memory.h \
+  libmtev_dtrace_probes.h eventer/eventer_impl_private.h
+
+eventer/eventer_POSIX_fd_opset.o eventer/eventer_POSIX_fd_opset.lo: eventer/eventer_POSIX_fd_opset.c mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  libmtev_dtrace_probes.h
+
+eventer/eventer_SSL_fd_opset.o eventer/eventer_SSL_fd_opset.lo: eventer/eventer_SSL_fd_opset.c mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  eventer/OETS_asn1_helper.h \
+  libmtev_dtrace_probes.h
+
+eventer/eventer.o eventer/eventer.lo: eventer/eventer.c eventer/eventer.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  eventer/eventer_impl_private.h ../src/utils/mtev_hash.h
+
+eventer/OETS_asn1_helper.o eventer/OETS_asn1_helper.lo: eventer/OETS_asn1_helper.c
+
 noitedit/chared.o noitedit/chared.lo: noitedit/chared.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/el.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/common.o noitedit/common.lo: noitedit/common.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/el.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/el.o noitedit/el.lo: noitedit/el.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
   eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/emacs.o noitedit/emacs.lo: noitedit/emacs.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/fcns.o noitedit/fcns.lo: noitedit/fcns.c noitedit/sys.h mtev_config.h noitedit/el.h \
-  mtev_defines.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/fgetln.o noitedit/fgetln.lo: noitedit/fgetln.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/compat.h noitedit/fgetln.h
-
-noitedit/help.o noitedit/help.lo: noitedit/help.c noitedit/sys.h mtev_config.h noitedit/el.h \
-  mtev_defines.h noitedit/strlcpy.h eventer/eventer.h \
-  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/hist.o noitedit/hist.lo: noitedit/hist.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/history.o noitedit/history.lo: noitedit/history.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/histedit.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h
-
-noitedit/key.o noitedit/key.lo: noitedit/key.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/map.o noitedit/map.lo: noitedit/map.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/parse.o noitedit/parse.lo: noitedit/parse.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h noitedit/tokenizer.h
-
-noitedit/prompt.o noitedit/prompt.lo: noitedit/prompt.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/el.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/read.o noitedit/read.lo: noitedit/read.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/readline.o noitedit/readline.lo: noitedit/readline.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/histedit.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h \
-  noitedit/readline/readline.h noitedit/sys.h noitedit/el.h \
-  noitedit/tty.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
   noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
   noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
   noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
 
-noitedit/refresh.o noitedit/refresh.lo: noitedit/refresh.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/el.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/search.o noitedit/search.lo: noitedit/search.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
-  noitedit/el.h eventer/eventer.h ../src/utils/mtev_log.h \
-  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
-  eventer/eventer_POSIX_fd_opset.h eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
-
-noitedit/sig.o noitedit/sig.lo: noitedit/sig.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+noitedit/common.o noitedit/common.lo: noitedit/common.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
   eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
 
-noitedit/strlcpy.o noitedit/strlcpy.lo: noitedit/strlcpy.c mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h
+noitedit/el.o noitedit/el.lo: noitedit/el.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
 
-noitedit/term.o noitedit/term.lo: noitedit/term.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+noitedit/emacs.o noitedit/emacs.lo: noitedit/emacs.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/fcns.o noitedit/fcns.lo: noitedit/fcns.c noitedit/sys.h mtev_config.h noitedit/el.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/fgetln.o noitedit/fgetln.lo: noitedit/fgetln.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/compat.h noitedit/fgetln.h
+
+noitedit/help.o noitedit/help.lo: noitedit/help.c noitedit/sys.h mtev_config.h noitedit/el.h \
+  mtev_defines.h mtev_config.h  \
+  noitedit/strlcpy.h eventer/eventer.h ../src/utils/mtev_log.h \
+  ../src/utils/mtev_hash.h ../src/utils/mtev_atomic.h \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/hist.o noitedit/hist.lo: noitedit/hist.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/history.o noitedit/history.lo: noitedit/history.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/histedit.h \
   eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
 
-noitedit/tokenizer.o noitedit/tokenizer.lo: noitedit/tokenizer.c noitedit/compat.h mtev_defines.h \
-  mtev_config.h noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h \
+noitedit/key.o noitedit/key.lo: noitedit/key.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/map.o noitedit/map.lo: noitedit/map.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/parse.o noitedit/parse.lo: noitedit/parse.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h \
   noitedit/tokenizer.h
 
-noitedit/tty.o noitedit/tty.lo: noitedit/tty.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+noitedit/prompt.o noitedit/prompt.lo: noitedit/prompt.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
   eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/read.o noitedit/read.lo: noitedit/read.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/readline.o noitedit/readline.lo: noitedit/readline.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/histedit.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/readline/readline.h noitedit/sys.h noitedit/el.h noitedit/tty.h \
+  noitedit/prompt.h noitedit/key.h noitedit/el_term.h noitedit/refresh.h \
+  noitedit/chared.h noitedit/common.h noitedit/vi.h noitedit/emacs.h \
+  noitedit/search.h noitedit/fcns.h noitedit/hist.h noitedit/map.h \
+  noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/refresh.o noitedit/refresh.lo: noitedit/refresh.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/search.o noitedit/search.lo: noitedit/search.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
+  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/sig.o noitedit/sig.lo: noitedit/sig.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/strlcpy.o noitedit/strlcpy.lo: noitedit/strlcpy.c mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h
+
+noitedit/term.o noitedit/term.lo: noitedit/term.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
+
+noitedit/tokenizer.o noitedit/tokenizer.lo: noitedit/tokenizer.c noitedit/compat.h mtev_defines.h \
+  mtev_config.h  noitedit/strlcpy.h \
+  mtev_config.h noitedit/fgetln.h noitedit/sys.h noitedit/tokenizer.h
+
+noitedit/tty.o noitedit/tty.lo: noitedit/tty.c noitedit/compat.h mtev_defines.h mtev_config.h \
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
 
 noitedit/vi.o noitedit/vi.lo: noitedit/vi.c noitedit/compat.h mtev_defines.h mtev_config.h \
-  noitedit/strlcpy.h noitedit/fgetln.h noitedit/sys.h noitedit/el.h \
-  eventer/eventer.h ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
-  ../src/utils/mtev_atomic.h eventer/eventer_POSIX_fd_opset.h \
-  eventer/eventer_SSL_fd_opset.h \
-  eventer/eventer_jobq.h ../src/utils/mtev_sem.h noitedit/tty.h \
-  noitedit/histedit.h noitedit/prompt.h noitedit/key.h \
-  noitedit/el_term.h noitedit/refresh.h noitedit/chared.h \
-  noitedit/common.h noitedit/vi.h noitedit/emacs.h noitedit/search.h \
-  noitedit/fcns.h noitedit/hist.h noitedit/map.h noitedit/parse.h \
-  noitedit/sig.h noitedit/help.h
+  noitedit/strlcpy.h mtev_config.h \
+  noitedit/fgetln.h noitedit/sys.h noitedit/el.h eventer/eventer.h \
+  ../src/utils/mtev_log.h ../src/utils/mtev_hash.h \
+  ../src/utils/mtev_atomic.h  \
+  ../src/utils/mtev_hooks.h \
+  ../src/utils/mtev_atomic.h ../src/utils/mtev_time.h \
+  ../src/utils/mtev_time.h eventer/eventer_POSIX_fd_opset.h \
+  eventer/eventer_SSL_fd_opset.h eventer/eventer_jobq.h \
+  ../src/utils/mtev_sem.h mtev_stats.h mtev_defines.h \
+  noitedit/tty.h \
+  noitedit/histedit.h noitedit/prompt.h noitedit/key.h noitedit/el_term.h \
+  noitedit/refresh.h noitedit/chared.h noitedit/common.h noitedit/vi.h \
+  noitedit/emacs.h noitedit/search.h noitedit/fcns.h noitedit/hist.h \
+  noitedit/map.h noitedit/parse.h noitedit/sig.h noitedit/help.h
 
 json-lib/mtev_arraylist.o json-lib/mtev_arraylist.lo: json-lib/mtev_arraylist.c mtev_config.h \
-  ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_arraylist.h
+  json-lib/mtev_bits.h json-lib/mtev_arraylist.h
 
-json-lib/mtev_debug.o json-lib/mtev_debug.lo: json-lib/mtev_debug.c mtev_config.h \
-  ../src/json-lib/mtev_debug.h
+json-lib/mtev_debug.o json-lib/mtev_debug.lo: json-lib/mtev_debug.c mtev_config.h json-lib/mtev_debug.h
 
 json-lib/mtev_json_object.o json-lib/mtev_json_object.lo: json-lib/mtev_json_object.c mtev_config.h \
-  ../src/json-lib/mtev_debug.h ../src/json-lib/mtev_printbuf.h \
-  ../src/json-lib/mtev_linkhash.h ../src/json-lib/mtev_arraylist.h \
-  ../src/json-lib/mtev_json_object.h \
-  ../src/json-lib/mtev_json_object_private.h
+  json-lib/mtev_debug.h json-lib/mtev_printbuf.h json-lib/mtev_linkhash.h \
+  json-lib/mtev_arraylist.h json-lib/mtev_json_object.h \
+  json-lib/mtev_json_object_private.h
 
 json-lib/mtev_json_tokener.o json-lib/mtev_json_tokener.lo: json-lib/mtev_json_tokener.c mtev_config.h \
-  ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_debug.h \
-  ../src/json-lib/mtev_printbuf.h ../src/json-lib/mtev_arraylist.h \
-  ../src/json-lib/mtev_json_object.h ../src/json-lib/mtev_json_tokener.h
+  json-lib/mtev_bits.h json-lib/mtev_debug.h json-lib/mtev_printbuf.h \
+  json-lib/mtev_arraylist.h json-lib/mtev_json_object.h \
+  json-lib/mtev_json_tokener.h
 
 json-lib/mtev_json_util.o json-lib/mtev_json_util.lo: json-lib/mtev_json_util.c mtev_config.h \
-  ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_debug.h \
-  ../src/json-lib/mtev_printbuf.h ../src/json-lib/mtev_json_object.h \
-  ../src/json-lib/mtev_json_tokener.h ../src/json-lib/mtev_json_util.h
+  json-lib/mtev_bits.h json-lib/mtev_debug.h json-lib/mtev_printbuf.h \
+  json-lib/mtev_json_object.h json-lib/mtev_json_tokener.h \
+  json-lib/mtev_json_util.h
 
-json-lib/mtev_linkhash.o json-lib/mtev_linkhash.lo: json-lib/mtev_linkhash.c ../src/json-lib/mtev_linkhash.h
+json-lib/mtev_linkhash.o json-lib/mtev_linkhash.lo: json-lib/mtev_linkhash.c json-lib/mtev_linkhash.h
 
 json-lib/mtev_printbuf.o json-lib/mtev_printbuf.lo: json-lib/mtev_printbuf.c mtev_config.h \
-  ../src/json-lib/mtev_bits.h ../src/json-lib/mtev_debug.h \
-  ../src/json-lib/mtev_printbuf.h
+  json-lib/mtev_bits.h json-lib/mtev_debug.h json-lib/mtev_printbuf.h
 
 libmtev-objs/eventer/eventer_kqueue_impl.o libmtev-objs/eventer/eventer_kqueue_impl.lo: eventer/eventer_kqueue_impl.o
 

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -226,7 +226,7 @@ eventer_jobq_maybe_spawn(eventer_jobq_t *jobq) {
           jobq->queue_name, jobq->concurrency);
     pthread_attr_init(&tattr);
     pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED);
-    mtev_thread_create(&tid, &tattr, eventer_jobq_consumer_pthreadentry, jobq);
+    pthread_create(&tid, &tattr, eventer_jobq_consumer_pthreadentry, jobq);
   }
   mtevL(eventer_deb, "jobq_queue[%s] pending cancels [%d/%d]\n",
         jobq->queue_name, jobq->pending_cancels,
@@ -452,8 +452,6 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
     pthread_setspecific(jobq->activejob, job);
     mtevL(eventer_deb, "%p jobq[%s] -> running job [%p]\n", pthread_self_ptr(),
           jobq->queue_name, job);
-
-    mtev_time_maintain();
 
     /* Mark our commencement */
     job->start_hrtime = mtev_sys_gethrtime();

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -325,9 +325,8 @@ static int eventer_ports_impl_loop() {
     int ret;
     port_event_t pevents[MAX_PORT_EVENTS];
 
-    mtev_time_maintain();
-
     gettimeofday(&__now, NULL);
+
     if(compare_timeval(eventer_max_sleeptime, __dyna_sleep) < 0)
       __dyna_sleep = eventer_max_sleeptime;
  

--- a/src/mtev_console_state.c
+++ b/src/mtev_console_state.c
@@ -165,7 +165,11 @@ mtev_console_coreclocks(mtev_console_closure_t ncct, int argc, char **argv,
 static int
 mtev_console_time_status(mtev_console_closure_t ncct, int argc, char **argv,
                          mtev_console_state_t *dstate, void *onoff) {
-  nc_printf(ncct, "rdtsc is current %s\n", mtev_time_fast_mode() ? "active" : "inactive");
+  const char *reason;
+  mtev_boolean status;
+  status = mtev_time_fast_mode(&reason);
+  nc_printf(ncct, "rdtsc is current %s\n", status ? "active" : "inactive");
+  if(reason) nc_printf(ncct, "Reason: %s\n", reason);
   return 0;
 }
 

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -191,6 +191,11 @@ mtev_main(const char *appname,
 
   mtev_init_globals();
 
+  char *require_invariant_tsc = getenv("MTEV_RDTSC_REQUIRE_INVARIANT");
+  if (require_invariant_tsc && strcmp(require_invariant_tsc, "0") == 0) {
+    mtev_time_toggle_require_invariant_tsc(mtev_false);
+  }
+
   char *disable_rdtsc = getenv("MTEV_RDTSC_DISABLE");
   if (disable_rdtsc && strcmp(disable_rdtsc, "1") == 0) {
     mtev_time_toggle_tsc(mtev_false);
@@ -200,6 +205,8 @@ mtev_main(const char *appname,
   if (disable_binding && strcmp(disable_binding, "1") == 0) {
     mtev_thread_disable_binding();
   }
+
+  mtev_time_start_tsc();
 
   /* First initialize logging, so we can log errors */
   mtev_log_init(debug);

--- a/src/mtev_thread.h
+++ b/src/mtev_thread.h
@@ -69,6 +69,20 @@ API_EXPORT(void)
   mtev_thread_init();
 
 /**
+ * attempt to schedule as a real-time process within the system.
+ * nqt is the request scheduling quantum in nanoseconds. If the OS
+ * does not support setting the quantum, the arugment is ignored.
+ */
+API_EXPORT(mtev_boolean)
+  mtev_thread_realtime(uint64_t nqt);
+
+/**
+ * attempt to set the current thread's priority in its scheduling class
+ */
+API_EXPORT(mtev_boolean)
+  mtev_thread_prio(int prio);
+
+/**
  * Switches off and disallows binding of threads to cores. If you call this on startup,
  * mtev_thread_init and mtev_thread_create will not bind the current LWP to the next core
  * in sequence.  They will silently noop.

--- a/src/utils/mtev_str.c
+++ b/src/utils/mtev_str.c
@@ -37,6 +37,8 @@
 
 #ifndef HAVE_STRNSTRN
 
+#define GROWTH_FACTOR(a) (((a) + ((a) >> 1))+1)
+
 #define KMPPATSIZE 256
 static void kmp_precompute(const char *pattern, int pattern_len,
                            int *compile_buf) {
@@ -89,12 +91,6 @@ mtev__strndup(const char *src, size_t len) {
 void
 mtev_prepend_str(mtev_prependable_str_buff_t *buff, const char* str,
     uint str_len) {
-#define GROWTH_FACTOR(a) (((a) + ((a) >> 1))+1)
-  if (buff->buff == NULL) {
-    buff->buff_len = GROWTH_FACTOR(str_len);
-    buff->buff = calloc(1, buff->buff_len);
-    buff->string = buff->buff + buff->buff_len;
-  }
   if (buff->string - buff->buff < str_len) {
     int bytes_stored = buff->buff_len - (buff->string - buff->buff);
     int new_buff_len = GROWTH_FACTOR(buff->buff_len + str_len);
@@ -105,16 +101,25 @@ mtev_prepend_str(mtev_prependable_str_buff_t *buff, const char* str,
     buff->buff = tmp;
     buff->string = buff->buff + buff->buff_len - bytes_stored;
   }
-#undef GROWTH_FACTOR
 
   buff->string -= str_len;
   memcpy(buff->string, str, str_len);
 }
 
 mtev_prependable_str_buff_t *
-mtev_prepend_str_alloc() {
+mtev_prepend_str_alloc_sized(u_int initial_len) {
   mtev_prependable_str_buff_t* buff = calloc(1, sizeof(mtev_prependable_str_buff_t));
+
+  buff->buff_len = initial_len;
+  buff->buff = calloc(1, buff->buff_len);
+  buff->string = buff->buff + buff->buff_len;
+
   return buff;
+}
+
+mtev_prependable_str_buff_t *
+mtev_prepend_str_alloc() {
+  return mtev_prepend_str_alloc_sized(8);
 }
 
 void
@@ -131,6 +136,63 @@ mtev_prepend_strlen(mtev_prependable_str_buff_t *buff) {
     return buff->buff + buff->buff_len - buff->string;
   }
   return 0;
+}
+
+void mtev_append_str_buff(mtev_str_buff_t *buff, const char* str, uint str_len) {
+  if (buff->end - buff->string - buff->buff_len < str_len) {
+    int bytes_stored = buff->end - buff->string;
+    int new_buff_len = GROWTH_FACTOR(buff->buff_len + str_len);
+    char* tmp = calloc(1, new_buff_len);
+    buff->buff_len = new_buff_len;
+    memcpy(tmp, buff->string, bytes_stored);
+    free(buff->string);
+    buff->string = tmp;
+    buff->end = buff->string + bytes_stored;
+  }
+
+  memcpy(buff->end, str, str_len);
+  buff->end += str_len;
+}
+
+mtev_str_buff_t *
+mtev_str_buff_alloc_sized(u_int initial_len) {
+  mtev_str_buff_t* buff = calloc(1, sizeof(mtev_str_buff_t));
+
+  buff->buff_len = initial_len;
+  buff->string = calloc(1, buff->buff_len);
+  buff->end = buff->string;
+
+  return buff;
+}
+
+mtev_str_buff_t *
+mtev_str_buff_alloc() {
+  return mtev_str_buff_alloc_sized(8);
+}
+
+void
+mtev_str_buff_free(mtev_str_buff_t *buff) {
+  if(buff->string) {
+    free(buff->string);
+  }
+  free(buff);
+}
+
+int
+mtev_str_buff_len(mtev_str_buff_t *buff) {
+  if(buff != NULL) {
+    return buff->end - buff->string;
+  }
+  return 0;
+}
+
+char*
+mtev_str_buff_to_string(mtev_str_buff_t **buff) {
+  char *string = (*buff)->string;
+  (*buff)->string = NULL;
+  mtev_str_buff_free(*buff);
+  *buff = NULL;
+  return string;
 }
 
 #endif

--- a/src/utils/mtev_str.h
+++ b/src/utils/mtev_str.h
@@ -42,18 +42,31 @@ typedef struct mtev_prependable_str_buff{
   uint buff_len;
 } mtev_prependable_str_buff_t;
 
+typedef struct mtev_str_buff{
+  char *string;
+  char *end;
+  uint buff_len;
+} mtev_str_buff_t;
+
 #ifndef HAVE_STRNSTRN
 API_EXPORT(const char *) strnstrn(const char *, int, const char *, int);
 #endif
 
 API_EXPORT(char *) mtev__strndup(const char *src, size_t len);
 
-API_EXPORT(void) mtev_prepend_str(mtev_prependable_str_buff_t *buff, const char* str, uint str_len);
 
 API_EXPORT(mtev_prependable_str_buff_t *) mtev_prepend_str_alloc();
-
+API_EXPORT(mtev_prependable_str_buff_t *) mtev_prepend_str_alloc_sized();
+API_EXPORT(void) mtev_prepend_str(mtev_prependable_str_buff_t *buff, const char* str, uint str_len);
 API_EXPORT(void) mtev_prepend_str_free(mtev_prependable_str_buff_t *buff);
-
 API_EXPORT(int) mtev_prepend_strlen(mtev_prependable_str_buff_t *buff);
+
+API_EXPORT(mtev_str_buff_t *) mtev_str_buff_alloc();
+API_EXPORT(mtev_str_buff_t *) mtev_str_buff_alloc_sized();
+API_EXPORT(void) mtev_append_str_buff(mtev_str_buff_t *buff, const char* str, uint str_len);
+API_EXPORT(void) mtev_str_buff_free(mtev_str_buff_t *buff);
+API_EXPORT(int) mtev_str_buff_len(mtev_str_buff_t *buff);
+API_EXPORT(char*) mtev_str_buff_to_string(mtev_str_buff_t **buff);
+
 
 #endif

--- a/src/utils/mtev_time.h
+++ b/src/utils/mtev_time.h
@@ -123,6 +123,6 @@ API_EXPORT(mtev_boolean)
  * returns whether mtev is currently operating in fast mode
  */
 API_EXPORT(mtev_boolean)
-  mtev_time_fast_mode();
+  mtev_time_fast_mode(const char **reason);
 
 #endif

--- a/test/utils/str_buff_spec.lua
+++ b/test/utils/str_buff_spec.lua
@@ -1,0 +1,49 @@
+ffi.cdef([=[
+typedef struct mtev_str_buff{
+  char *string;
+  char *end;
+  uint buff_len;
+} mtev_str_buff_t;
+
+mtev_str_buff_t * mtev_str_buff_alloc();
+mtev_str_buff_t * mtev_str_buff_alloc_sized();
+void mtev_append_str_buff(mtev_str_buff_t *buff, const char* str, uint str_len);
+void mtev_str_buff_free(mtev_str_buff_t *buff);
+int mtev_str_buff_len(mtev_str_buff_t *buff);
+]=])
+
+describe("alloc_and_free", function()
+  it("should alloc and dealloc", function()
+    local str = mtev.mtev_str_alloc()
+    assert.is.equal(str.buff_len, 8, "default buff len")
+    assert.is.equal(0, mtev.mtev_strlen(str), "empty")
+    mtev.mtev_str_free(str)
+  end)
+
+  it("should store strings", function()
+    local str = mtev.mtev_str_alloc()
+    mtev.mtev_append_str(str, charstar("Hello "), 6)
+    assert.is.equal("Hello ", ffi.string(str.string), "contains hello")
+    assert.is.equal(str.buff_len, 8, "size")
+    mtev.mtev_append_str(str, charstar("World"), 5)
+    assert.is.equal("Hello World", ffi.string(str.string), "contains hello world")
+    assert.is.equal(str.buff_len, 22, "grew")
+    mtev.mtev_append_str(str, charstar("!"), 1)
+    assert.is.equal("Hello World!", ffi.string(str.string), "contains hello world!")
+    assert.is.equal(str.buff_len, 22, "did not grow")
+    mtev.mtev_str_free(str)
+  end)
+
+  it("should dealloc when cast to string", function()
+    local str_buff_ptr = ffi.new("mtev_str_buff_t[?]", 1)
+    local str_buff = mtev.mtev_str_alloc()
+    str_buff_ptr[1] = str_buff
+    mtev.mtev_append_str(str_buff, charstar("Hello World!"), 6)
+    assert.is.equal("Hello World!", ffi.string(str_buff.string), "buff contains hello world!")
+    assert.is.equal(str_buff, str_buff_ptr[1], "freed the buffer")
+    local str = mtev.mtev_str_buff_to_string(str_buff) 
+    assert.is.equal(nil, str_buff_ptr[1], "freed the buffer")
+    assert.is.equal("Hello World!", ffi.string(str), "extracted string contains hello world!")
+    mtev.free(str)
+  end)
+end)

--- a/test/utils/str_prepend_spec.lua
+++ b/test/utils/str_prepend_spec.lua
@@ -14,7 +14,7 @@ int mtev_prepend_strlen(mtev_prependable_str_buff_t *buff);
 describe("alloc_and_free", function()
   it("should alloc and dealloc", function()
     local str = mtev.mtev_prepend_str_alloc()
-    assert.is.equal(nil, str.string, "empty")
+    assert.is.equal(str.buff_len, 8, "default buff len")
     assert.is.equal(0, mtev.mtev_prepend_strlen(str), "empty")
     mtev.mtev_prepend_str_free(str)
   end)


### PR DESCRIPTION
 * Use a single global rdtsc function when found.
 * Store skew and tpn together in the coreclock.
 * Calculate hrtime to gettimeofday skew: mtev_gettimeofday.
 * Tracks the number of fast and slow calls.
 * Allow runtime toggling.
 * Automatic per-cpu killswitch if lack of maintenance is
   determined.
 * Add dedicated maintenance thread for tpn and skew upkeep.
 * Add console "mtev rdtsc <enable|disable>"
 * Add console "show mtev debug coreclocks"

Now all threads benefit if they find themselves on a cpu
that has been evaluated "accurately enough" and "recently
enough."  On illumos this is a 300ns -> 90ns speed up for
the common case.