### PR TITLE
Fix peer info on reused sessions.

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -409,6 +409,15 @@ eventer_ssl_set_peer_##type(eventer_ssl_ctx_t *ctx, \
 } \
 const char * \
 eventer_ssl_get_peer_##type(eventer_ssl_ctx_t *ctx) { \
+  if(ctx->type == NULL) { \
+    char buffer[1024]; \
+    X509 *peer = SSL_get_peer_certificate(ctx->ssl); \
+    if(peer != NULL) { \
+      X509_NAME_oneline(X509_get_##type##_name(peer), buffer, sizeof(buffer)-1); \
+      if(ctx->type) free(ctx->type); \
+      ctx->type = strdup(buffer); \
+    } \
+  } \
   return ctx->type; \
 }
 

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -404,6 +404,7 @@ eventer_ssl_set_peer_##type(eventer_ssl_ctx_t *ctx, \
   X509 *peer; \
   peer = X509_STORE_CTX_get_current_cert(x509ctx); \
   X509_NAME_oneline(X509_get_##type##_name(peer), buffer, sizeof(buffer)-1); \
+  buffer[sizeof(buffer)-1] = '\0'; \
   if(ctx->type) free(ctx->type); \
   ctx->type = strdup(buffer); \
 } \
@@ -414,6 +415,7 @@ eventer_ssl_get_peer_##type(eventer_ssl_ctx_t *ctx) { \
     X509 *peer = SSL_get_peer_certificate(ctx->ssl); \
     if(peer != NULL) { \
       X509_NAME_oneline(X509_get_##type##_name(peer), buffer, sizeof(buffer)-1); \
+      buffer[sizeof(buffer)-1] = '\0'; \
       if(ctx->type) free(ctx->type); \
       ctx->type = strdup(buffer); \
     } \


### PR DESCRIPTION
If we have a reused session from cache, verify is not performed again.
This caused subject and issuer to not be set.  We can fetch them from
the ctx->ssl, so add a fallback to do that if they are NULL.