### PR TITLE
fix signed/unsigned comparison issue.

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -453,7 +453,7 @@ _fixup_bchain(struct bchain *b) {
   /* make sure lines (CRLF terminated) don't cross chain boundaries */
   while(b) {
     struct bchain *f;
-    int start_in_b, end_in_f;
+    ssize_t start_in_b, end_in_f;
     size_t new_size;
     const char *str_in_f;
 
@@ -464,7 +464,7 @@ _fixup_bchain(struct bchain *b) {
         continue;
       }
       start_in_b = b->start + b->size - 3; /* we already checked -2 */
-      while(start_in_b >= b->start) {
+      while(start_in_b >= (ssize_t) b->start) {
         if(b->buff[start_in_b] == '\r' && b->buff[start_in_b+1] == '\n') {
           start_in_b += 2;
           break;


### PR DESCRIPTION
There's a scenario where an integer can be <0, then promoted to
an unsigned type to check if it's less than an unsigned value.
when the check passes (since unsigned -1 is ~0, aka some INT_MAX
variant) we then index an array from -1, potentially causing a
SEGV. Fix by coercing the unsigned side to signed before the
comparison.