### PR TITLE
Introduce mtev_hash_adv (obsolete mtev_hash_next{,_str})

### DIFF
--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -616,14 +616,11 @@ void eventer_jobq_decrease_concurrency(eventer_jobq_t *jobq) {
 }
 void eventer_jobq_process_each(void (*func)(eventer_jobq_t *, void *),
                                void *closure) {
-  const char *key;
-  int klen;
-  void *vjobq;
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
 
   pthread_mutex_lock(&all_queues_lock);
-  while(mtev_hash_next(&all_queues, &iter, &key, &klen, &vjobq)) {
-    func((eventer_jobq_t *)vjobq, closure);
+  while(mtev_hash_adv(&all_queues, &iter)) {
+    func((eventer_jobq_t *)iter.value.ptr, closure);
   }
   pthread_mutex_unlock(&all_queues_lock);
 }

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -3748,28 +3748,22 @@ mtev_lua_serialize(lua_State *L, int index){
 
 void
 mtev_lua_deserialize_table(lua_State *L, mtev_lua_table_t *table){
-  void *vdata;
-  lua_data_t *data;
-  const char *key;
   lua_Number number_key;
-  int klen;
   mtev_hash_iter int_iter = MTEV_HASH_ITER_ZERO;
   mtev_hash_iter str_iter = MTEV_HASH_ITER_ZERO;
 
   lua_createtable(L, 0, mtev_hash_size(&table->string_keys) + mtev_hash_size(&table->int_keys));
 
-  while(mtev_hash_next(&table->int_keys, &int_iter, &key, &klen, &vdata)) {
-    number_key = *(lua_Number*)key;
-    data = vdata;
+  while(mtev_hash_adv(&table->int_keys, &int_iter)) {
+    number_key = *(lua_Number*)int_iter.key.ptr;
     lua_pushnumber(L, number_key);
-    mtev_lua_deserialize(L, data);
+    mtev_lua_deserialize(L, (lua_data_t *)int_iter.value.ptr);
     lua_settable(L, -3);
   }
 
-  while(mtev_hash_next(&table->string_keys, &str_iter, &key, &klen, &vdata)) {
-    data = vdata;
-    lua_pushstring(L, key);
-    mtev_lua_deserialize(L, data);
+  while(mtev_hash_adv(&table->string_keys, &str_iter)) {
+    lua_pushstring(L, str_iter.key.str);
+    mtev_lua_deserialize(L, (lua_data_t *)str_iter.value.ptr);
     lua_settable(L, -3);
   }
 }

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -296,9 +296,8 @@ static int
 mtev_lua_web_driver_config(mtev_dso_generic_t *self, mtev_hash_table *o) {
   lua_web_conf_t *conf = get_config(self);
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
-  void *vstr;
-  int klen, i;
-  const char *key, *bstr;
+  int i;
+  const char *bstr;
   conf->script_dir = NULL;
   conf->cpath = NULL;
   (void)mtev_hash_retr_str(o, "directory", strlen("directory"), &conf->script_dir);
@@ -308,11 +307,10 @@ mtev_lua_web_driver_config(mtev_dso_generic_t *self, mtev_hash_table *o) {
 
   conf->mounts = calloc(1+mtev_hash_size(o), sizeof(*conf->mounts));
   i = 0;
-  while(mtev_hash_next(o, &iter, &key, &klen, &vstr)) {
-    const char *str = vstr;
-    if(!strncmp(key, "mount_", strlen("mount_"))) {
+  while(mtev_hash_adv(o, &iter)) {
+    if(!strncmp(iter.key.str, "mount_", strlen("mount_"))) {
       /* <module>:<method>:<mount>[:<expr>] */
-      char *copy = strdup(str);
+      char *copy = strdup(iter.value.str);
       char *module, *method, *mount = NULL, *expr = NULL;
       module = copy;
       method = strchr(module, ':');
@@ -326,7 +324,7 @@ mtev_lua_web_driver_config(mtev_dso_generic_t *self, mtev_hash_table *o) {
         }
       }
       if(!module || !method || !mount) {
-        mtevL(mtev_error, "Invalid lua_web mount syntax in '%s'\n", key);
+        mtevL(mtev_error, "Invalid lua_web mount syntax in '%s'\n", iter.key.str);
         return -1;
       }
       conf->mounts[i].module = strdup(module); 

--- a/src/modules/mtev_fq.c
+++ b/src/modules/mtev_fq.c
@@ -315,16 +315,10 @@ fq_driver_init(mtev_dso_generic_t *img) {
 
 static int
 fq_driver_config(mtev_dso_generic_t *img, mtev_hash_table *options) {
-
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
-  const char *key;
-  int klen;
-  void *data;
-
-  while(mtev_hash_next(options, &iter, &key, &klen, &data)) {
-    mtevL(mtev_error, "%s %s!\n", key, (char *)data);
+  while(mtev_hash_adv(options, &iter)) {
+    mtevL(mtev_error, "%s %s!\n", iter.key.str, iter.value.str);
   }
-
   return 0;
 }
 #include "fq.xmlh"

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -88,9 +88,7 @@ mtev_dso_loader_t * mtev_loader_lookup(const char *name) {
 int
 mtev_dso_list(mtev_hash_table *t, const char ***f) {
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
-  const char *name;
-  int klen, i = 0;
-  void *vhdr;
+  int i = 0;
 
   if(mtev_hash_size(t) == 0) {
     *f = NULL;
@@ -98,9 +96,8 @@ mtev_dso_list(mtev_hash_table *t, const char ***f) {
   }
 
   *f = calloc(mtev_hash_size(t), sizeof(**f));
-  while(mtev_hash_next(t, &iter, (const char **)&name, &klen,
-                       &vhdr)) {
-    (*f)[i++] = name;
+  while(mtev_hash_adv(t, &iter)) {
+    (*f)[i++] = iter.key.str;
   }
   return i;
 }

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1743,8 +1743,7 @@ _http_construct_leader(mtev_http_session_ctx *ctx) {
   int len = 0, tlen, kcnt;
   struct bchain *b;
   const char *protocol_str;
-  const char *key, *value;
-  int klen, i;
+  int i;
   const char **keys;
   mtev_boolean cl_present = mtev_false;
 
@@ -1777,11 +1776,10 @@ _http_construct_leader(mtev_http_session_ctx *ctx) {
     mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
     i = 0;
     keys = alloca(sizeof(*keys)*(mtev_hash_size(&ctx->res.headers)));
-    while(mtev_hash_next_str(&ctx->res.headers, &iter,
-                             &key, &klen, &value)) {
-      keys[i++] = key;
-      if(klen == strlen(HEADER_CONTENT_LENGTH) &&
-         !strncasecmp(key, HEADER_CONTENT_LENGTH, strlen(HEADER_CONTENT_LENGTH))) {
+    while(mtev_hash_adv(&ctx->res.headers, &iter)) {
+      keys[i++] = iter.key.str;
+      if(iter.klen == strlen(HEADER_CONTENT_LENGTH) &&
+         !strncasecmp(iter.key.str, HEADER_CONTENT_LENGTH, strlen(HEADER_CONTENT_LENGTH))) {
         cl_present = mtev_true;
       }
     }
@@ -1803,8 +1801,8 @@ _http_construct_leader(mtev_http_session_ctx *ctx) {
   kcnt = i;
   for(i=0;i<kcnt;i++) {
     int vlen;
-    key = keys[i];
-    klen = strlen(key);
+    const char *key = keys[i], *value;
+    int klen = strlen(key);
     (void)mtev_hash_retr_str(&ctx->res.headers, key, klen, &value);
     vlen = strlen(value);
     CTX_LEADER_APPEND(key, klen);

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -102,9 +102,7 @@ configure_eventer(const char *appname) {
   table = mtev_conf_get_hash(NULL, appscratch);
   if(table) {
     mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
-    const char *key, *value;
-    int klen;
-    while(mtev_hash_next_str(table, &iter, &key, &klen, &value)) {
+    while(mtev_hash_adv(table, &iter)) {
       int subrv;
       /* We want to set a sane default if the user doesn't provide an
        * rlim_nofiles value... however, we have to try to set the user
@@ -113,11 +111,11 @@ configure_eventer(const char *appname) {
        * lower than the user specified one, we can't raise it. Ergo -
        * try to set from the config first, then set a default if one
        * isn't specified */
-      if ((strlen(key) == strlen("rlim_nofiles")) &&
-          (strncmp(key, "rlim_nofiles", strlen(key)) == 0) ) {
+      if ((strlen(iter.key.str) == strlen("rlim_nofiles")) &&
+          (strncmp(iter.key.str, "rlim_nofiles", strlen(iter.key.str)) == 0) ) {
         rlim_found = mtev_true;
       }
-      if((subrv = eventer_propset(key, value)) != 0)
+      if((subrv = eventer_propset(iter.key.str, iter.value.str)) != 0)
         rv = subrv;
     }
     mtev_hash_destroy(table, free, free);

--- a/src/utils/mtev_hash.h
+++ b/src/utils/mtev_hash.h
@@ -69,7 +69,18 @@ typedef struct mtev_hash_table {
   } u CK_CC_CACHELINE;
 } mtev_hash_table;
 
-typedef ck_hs_iterator_t mtev_hash_iter;
+typedef struct mtev_hash_iter {
+  ck_hs_iterator_t iter;
+  union {
+    const char *str;
+    void *ptr;
+  } key;
+  union {
+    const char *str;
+    void *ptr;
+  } value;
+  int klen;
+} mtev_hash_iter;
 
 /* mdb support relies on this being exposed */
 typedef struct ck_key {
@@ -87,7 +98,7 @@ CK_CC_CONTAINER(ck_key_t, struct ck_hash_attr, key,
                 index_attribute_container)
 
 #define MTEV_HASH_EMPTY { {{ NULL, NULL, 0, 0, NULL, NULL}} }
-#define MTEV_HASH_ITER_ZERO CK_HS_ITERATOR_INITIALIZER
+#define MTEV_HASH_ITER_ZERO { CK_HS_ITERATOR_INITIALIZER }
 #define MTEV_HASH_DEFAULT_SIZE (1<<7)
 
 /**
@@ -136,14 +147,14 @@ void mtev_hash_merge_as_dict(mtev_hash_table *dst, mtev_hash_table *src);
    To use:
      mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
 
-     const char *k;
-     int klen;
-     void *data;
-
-     while(mtev_hash_next(h, &iter, &k, &klen, &data)) {
-       .... use k, klen and data ....
+     while(mtev_hash_adv(h, &iter)) {
+       .... use iter.key.{str,ptr}, iter.klen and iter.value.{str,ptr} ....
      }
 */
+int mtev_hash_adv(mtev_hash_table *h, mtev_hash_iter *iter);
+
+/* These are older, more painful APIs... use mtev_hash_adv */
+/* Note that neither of these sets the key, value, or klen in iter */
 int mtev_hash_next(mtev_hash_table *h, mtev_hash_iter *iter,
                    const char **k, int *klen, void **data);
 int mtev_hash_next_str(mtev_hash_table *h, mtev_hash_iter *iter,


### PR DESCRIPTION
It has been, but will no longer be, tragic that each attempt
to use an iterator over an mtev_hash required the stack declarations
of at least a const char *key, an int klen, and a void *value.
This commit adds those requirements into the iterator type itself
and preserves backward compatibility.  All old calls will only access
within the boundaries of its original size so while the the ABI of the
iterator changed, it remains safe and backward compatible.