### PR TITLE
Implicitly create logs when searching for them.

### DIFF
--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1325,7 +1325,7 @@ mtev_log_final_resolve() {
   return mtev_true;
 }
 
-mtev_log_stream_t
+static mtev_log_stream_t
 mtev_log_stream_new_internal(const char *name, const char *type, const char *path,
                     void *ctx, mtev_hash_table *config, mtev_log_stream_t saved) {
   mtev_log_stream_t ls;

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1326,9 +1326,9 @@ mtev_log_final_resolve() {
 }
 
 mtev_log_stream_t
-mtev_log_stream_new(const char *name, const char *type, const char *path,
-                    void *ctx, mtev_hash_table *config) {
-  mtev_log_stream_t ls, saved;
+mtev_log_stream_new_internal(const char *name, const char *type, const char *path,
+                    void *ctx, mtev_hash_table *config, mtev_log_stream_t saved) {
+  mtev_log_stream_t ls;
   struct _mtev_log_stream tmpbuf;
   void *vops = NULL;
 
@@ -1346,7 +1346,6 @@ mtev_log_stream_new(const char *name, const char *type, const char *path,
  
   if(ls->ops && ls->ops->openop(ls)) goto freebail;
 
-  saved = mtev_log_stream_find(name);
   if(saved) {
     pthread_rwlock_t *lock = saved->lock;
     memcpy(&tmpbuf, saved, sizeof(*saved));
@@ -1389,12 +1388,22 @@ mtev_log_stream_new(const char *name, const char *type, const char *path,
 }
 
 mtev_log_stream_t
+mtev_log_stream_new(const char *name, const char *type, const char *path,
+                    void *ctx, mtev_hash_table *config) {
+  return mtev_log_stream_new_internal(name,type,path,ctx,config,
+                                      mtev_log_stream_find(name));
+}
+
+mtev_log_stream_t
 mtev_log_stream_find(const char *name) {
   void *vls;
+  mtev_log_stream_t newls;
   if(mtev_hash_retrieve(&mtev_loggers, name, strlen(name), &vls)) {
     return (mtev_log_stream_t)vls;
   }
-  return NULL;
+  newls = mtev_log_stream_new_internal(name, NULL, NULL, NULL, NULL, NULL);
+  newls->flags = 0;
+  return newls;
 }
 
 void

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -44,9 +44,11 @@
 #include "mtev_time.h"
 
 #ifdef mtev_log_impl
-typedef struct _mtev_log_stream * mtev_log_stream_t;
+typedef struct _mtev_log_stream mtev_log_stream_t;
+#define mtev_log_stream_t mtev_log_stream_t *
 #else
-typedef void * mtev_log_stream_t;
+typedef void * mtev_log_stream_public_t;
+#define mtev_log_stream_t mtev_log_stream_public_t
 #endif
 
 struct _mtev_log_stream_outlet_list {


### PR DESCRIPTION
Now if you ask for a specific log, it will always come back.  This
also plays some type trickery with #define so that mdb can easily
print mtev_log_stream_t objects: `::mtev_log | ::pring mtev_log_stream_t`