### PR TITLE
Fix compiler args for test targets

### DIFF
--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -53,11 +53,11 @@ sort_test: sort_test.c
 
 .c.o:
 	@echo "- compiling $<"
-	$(Q)$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
+	$(Q)$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS) -c $<
 
 test_harness:       $(TESTHARNESS_OBJS)
 	@echo "- linking $@"
-	$(Q)$(CC) -L.. $(LDFLAGS) $(UNWINDLIB) -o $@ $(TESTHARNESS_OBJS) $(LIBS) -lmtev
+	$(Q)$(CC) -L../src $(LDFLAGS) $(UNWINDLIB) -o $@ $(TESTHARNESS_OBJS) $(LIBS) -lmtev
 
 busted:
 	@busted --version >/dev/null 2>/dev/null || \


### PR DESCRIPTION
We need to be able to build without an installation of the finished
code.