### PR TITLE
Remove stale Java configure message.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -212,7 +212,6 @@ AC_SUBST(NOWHOLE_ARCHIVE)
 AC_SUBST(ATOMIC_OBJS)
 AC_SUBST(UNWINDLIB)
 AC_DEFINE_UNQUOTED(MODULEEXT, "$MODULEEXT", [module extension])
-AC_MSG_CHECKING([enable build/install of the Java IEP and Jezebel bits])
 
 LUA4MTEV=lua_mtev.$MODULEEXT
 if test "$ENABLE_LUA" = "no"; then


### PR DESCRIPTION
Java code was removed in the great culling, so this checking message
isn't needed any more.