### PR TITLE
Fix --disable-wslay configuration option.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -318,15 +318,15 @@ AS_IF([test "x$enable_fq" != "xno"], [
 ])
 
 AC_ARG_ENABLE([wslay],
-    AS_HELP_STRING([--enable-wslay], [Enable websockets using libwslay]), [enable_wslay=yes])
+    AS_HELP_STRING([--enable-wslay], [Enable websockets using libwslay]))
 
 AS_IF([test "x$enable_wslay" = "xyes"], [
-  AC_CHECK_LIB(wslay, wslay_event_context_server_init, 
-[
-AC_DEFINE(HAVE_WSLAY, [1], [have libwslay])
-LIBS="-lwslay $LIBS"
-], 
-      [AC_MSG_ERROR([*** can't build websocket support, no -lwslay ***])])
+  AC_CHECK_LIB(wslay, wslay_event_context_server_init, [
+    AC_DEFINE(HAVE_WSLAY, [1], [have libwslay])
+    LIBS="-lwslay $LIBS"
+  ], [
+    AC_MSG_ERROR([*** can't build websocket support, no -lwslay ***])
+  ])
 ])
 
 AC_CHECK_FUNCS(posix_madvise madvise)


### PR DESCRIPTION
libwslay was being enabled unconditionally even if `--disable-wslay` was
specified. Fix the configure check for the option and make the subsequent
checks a little more readable. The build appears to correctly support
turning off libwslay.