### PR TITLE
fix for having multiple connections to the mtev console at once.

### DIFF
--- a/src/mtev_console.c
+++ b/src/mtev_console.c
@@ -549,6 +549,7 @@ socket_error:
     return newmask | EVENTER_EXCEPTION;
   }
 
+  el_multi_set_el(ncct->el);
   for(keep_going=1 ; keep_going ; ) {
     int len, plen;
     char sbuf[4096];


### PR DESCRIPTION
The EditLine state is passed around on the stack, and stored in
a TLS variable. The stack copy and the TLS copy need to agree,
but we weren't enforcing that. Fix by updating the TLS copy on
entry to the console handling function.