### PR TITLE
Avoid the syscalls valgrind doesn't support.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -339,6 +339,9 @@ AS_IF([test "x$enable_wslay" = "xyes"], [
 
 AC_CHECK_FUNCS(posix_madvise madvise)
 
+# Let us avoid some things that displease valgrind
+AC_CHECK_HEADERS(valgrind/valgrind.h)
+
 AC_CHECK_HEADERS(priv.h)
 AC_CHECK_FUNCS(setppriv)
 

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -46,6 +46,10 @@
 #include <netinet/in.h>
 #include <hwloc.h>
 
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
+
 static struct timeval *eventer_impl_epoch = NULL;
 static int PARALLELISM_MULTIPLIER = 4;
 static int EVENTER_DEBUGGING = 0;
@@ -493,7 +497,13 @@ static void hw_topo_free(hwloc_topology_t *topo) {
 }
 
 static hwloc_topology_t *hw_topo_alloc() {
+#ifdef __sun
+#ifdef RUNNING_ON_VALGRIND
+  if(RUNNING_ON_VALGRIND != 0) return NULL;
+#endif
+#endif
   hwloc_topology_t *topo = calloc(1, sizeof(*topo));
+  if(!topo) return NULL;
   if(hwloc_topology_init(topo)) goto out;
   if(hwloc_topology_load(*topo)) goto destroy_out;
 

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -46,6 +46,10 @@
 #include <lz4frame.h>
 
 
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
+
 #include "mtev_log.h"
 #include "mtev_main.h"
 #include "mtev_conf.h"
@@ -222,6 +226,14 @@ mtev_main(const char *appname,
   if (require_invariant_tsc && strcmp(require_invariant_tsc, "0") == 0) {
     mtev_time_toggle_require_invariant_tsc(mtev_false);
   }
+
+#ifdef __sun
+#ifdef RUNNING_ON_VALGRIND
+  if(RUNNING_ON_VALGRIND != 0) {
+    mtev_time_toggle_require_invariant_tsc(mtev_false);
+  }
+#endif
+#endif
 
   char *disable_rdtsc = getenv("MTEV_RDTSC_DISABLE");
   if (disable_rdtsc && strcmp(disable_rdtsc, "1") == 0) {

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -35,6 +35,10 @@
 #include <unistd.h>
 #include <errno.h>
 
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
+
 #if defined(__MACH__)
 #include <mach/mach_init.h>
 #include <mach/thread_policy.h>
@@ -75,6 +79,12 @@ mtev_boolean
 mtev_thread_bind_to_cpu(int cpu)
 {
 #ifdef __sun 
+#ifdef RUNNING_ON_VALGRIND
+  if (RUNNING_ON_VALGRIND != 0) {
+    mtevL(mtev_error, "Warning: Binding prevented under valgrind\n");
+    return mtev_thread_is_bound;
+  }
+#endif
   if (processor_bind(P_LWPID, P_MYID, cpu, 0)) {
     mtevL(mtev_error, "Warning: Binding thread to cpu %d failed\n", cpu);
   }
@@ -115,6 +125,12 @@ mtev_boolean
 mtev_thread_unbind_from_cpu(void)
 {
 #ifdef __sun 
+#ifdef RUNNING_ON_VALGRIND
+  if (RUNNING_ON_VALGRIND != 0) {
+    mtevL(mtev_error, "Warning: Unbinding prevented under valgrind\n");
+    return mtev_thread_is_bound;
+  }
+#endif
   if (processor_bind(P_LWPID, P_MYID, PBIND_NONE, 0)) {
     mtevL(mtev_error, "Warning: Unbinding thread from cpus failed\n");
   }

--- a/src/utils/mtev_time.c
+++ b/src/utils/mtev_time.c
@@ -43,6 +43,9 @@
 #include "mtev_thread.h"
 #include "mtev_log.h"
 
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#include <valgrind/valgrind.h>
+#endif
 /* 
  * don't allow rdtsc on mach systems as there is only currently experimental support 
  * for affining threads to cores on mach systems
@@ -602,6 +605,14 @@ mtev_time_tsc_maintenance(void *unused) {
 void  
 mtev_time_start_tsc()
 {
+#ifdef __sun
+#ifdef RUNNING_ON_VALGRIND
+  if(!RUNNING_ON_VALGRIND) {
+    mtevL(mtev_debug, "mtev_time_start_tsc() -> disabled under valgrind.\n");
+    return;
+  }
+#endif
+#endif
 #ifdef ENABLE_RDTSC
   long nrcpus = sysconf(_SC_NPROCESSORS_ONLN);
   if(nrcpus > NCPUS) {


### PR DESCRIPTION
On Illumos, Valgrind doesn't support a handful of syscalls.
This change detects when we run under valgrind and either skips
silently of fails explicitly to the caller as appropriate.