### PR TITLE
Rework stack traces.

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -110,6 +110,7 @@ MAPPEDHEADERS=utils/mtev_atomic.h utils/mtev_b32.h utils/mtev_b64.h \
    utils/mtev_watchdog.h utils/mtev_uuid_parse.h                    \
    utils/mtev_perftimer.h utils/mtev_zipkin.h                       \
    utils/mtev_hyperloglog.h json-lib/mtev_arraylist.h               \
+   utils/mtev_stacktrace.h                                          \
    json-lib/mtev_bits.h json-lib/mtev_debug.h                       \
    json-lib/mtev_json_object.h json-lib/mtev_json_tokener.h         \
    json-lib/mtev_json_util.h json-lib/mtev_json.h                   \
@@ -144,7 +145,9 @@ MTEV_UTILS_OBJS=utils/mtev_b32.hlo utils/mtev_b64.hlo                 \
   utils/mtev_skiplist.hlo utils/mtev_sort.hlo utils/mtev_str.lo       \
   utils/mtev_watchdog.lo utils/mtev_zipkin.lo utils/mtev_memory.lo    \
   utils/mtev_cht.hlo utils/mtev_uuid_parse.hlo                        \
-  utils/mtev_perftimer.lo utils/mtev_hyperloglog.hlo $(ATOMIC_OBJS)
+  utils/mtev_perftimer.lo utils/mtev_hyperloglog.hlo                  \
+  utils/mtev_stacktrace.lo
+  $(ATOMIC_OBJS)
 
 LIBMTEV_OBJS=mtev_main.lo mtev_listener.lo mtev_cluster.lo            \
    mtev_console.lo mtev_console_state.lo mtev_console_telnet.lo       \

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -357,6 +357,7 @@ mtev_main(const char *appname,
   if(foreground == 1) {
     mtev_time_start_tsc();
     mtevL(mtev_notice, "%s booting [unmanaged]\n", appname);
+    mtev_setup_crash_signals(mtev_self_diagnose);
     int rv = passed_child_main();
     mtev_lockfile_release(lockfd);
     return rv;

--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "mtev_defines.h"
+#include "mtev_log.h"
+#include "mtev_stacktrace.h"
+#include <execinfo.h>
+#if defined(__sun__)
+#include <ucontext.h>
+#include <sys/lwp.h>
+#endif
+#if defined(__MACH__) && defined(__APPLE__)
+#include <libproc.h>
+#endif
+
+#if defined(__sun__)
+int mtev_simple_stack_print(uintptr_t pc, int sig, void *usrarg) {
+  lwpid_t self;
+  mtev_log_stream_t ls = usrarg;
+  char addrline[128];
+  self = _lwp_self();
+  addrtosymstr((void *)pc, addrline, sizeof(addrline));
+  mtevL(ls, "t@%d> %s\n", self, addrline);
+  return 0;
+}
+#else
+static int _global_stack_trace_fd = -1;
+#endif
+
+void mtev_stacktrace(mtev_log_stream_t ls) {
+#if defined(__sun__)
+  ucontext_t ucp;
+  getcontext(&ucp);
+  walkcontext(&ucp, mtev_simple_stack_print, ls);
+#else
+  if(_global_stack_trace_fd < 0) {
+    /* Last ditch effort to open this up */
+    /* This is Async-Signal-Safe (at least on Illumos) */
+    char tmpfilename[MAXPATHLEN];
+    snprintf(tmpfilename, sizeof(tmpfilename), "/var/tmp/mtev_%d_XXXXXX", (int)getpid());
+    _global_stack_trace_fd = mkstemp(tmpfilename);
+    if(_global_stack_trace_fd >= 0) unlink(tmpfilename);
+  }
+  if(_global_stack_trace_fd >= 0) {
+    struct stat sb;
+    char stackbuff[4096];
+    void* callstack[128];
+    int unused __attribute__((unused));
+    int i, frames = backtrace(callstack, 128);
+    lseek(_global_stack_trace_fd, 0, SEEK_SET);
+    unused = ftruncate(_global_stack_trace_fd, 0);
+    backtrace_symbols_fd(callstack, frames, _global_stack_trace_fd);
+    memset(&sb, 0, sizeof(sb));
+    while((i = fstat(_global_stack_trace_fd, &sb)) == -1 && errno == EINTR);
+    if(i != 0 || sb.st_size == 0) mtevL(ls, "error writing stacktrace\n");
+    lseek(_global_stack_trace_fd, SEEK_SET, 0);
+    i = read(_global_stack_trace_fd, stackbuff, MIN(sizeof(stackbuff), sb.st_size));
+    mtevL(ls, "STACKTRACE:\n%.*s\n", i, stackbuff);
+  }
+  else {
+    mtevL(ls, "stacktrace unavailable\n");
+  }
+#endif
+}

--- a/src/utils/mtev_stacktrace.h
+++ b/src/utils/mtev_stacktrace.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names of its contributors
+ *      may be used to endorse or promote products derived from this
+ *      software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MTEV_STACKTRACE_H
+#define _MTEV_STACKTRACE_H
+
+#include "mtev_defines.h"
+#include "mtev_log.h"
+
+API_EXPORT(void)
+  mtev_stacktrace(mtev_log_stream_t ls);
+
+#if defined(__sun__)
+API_EXPORT(int)
+  mtev_simple_stack_print(uintptr_t pc, int sig, void *usrarg);
+#endif
+
+#endif

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -35,10 +35,12 @@
 #define _MTEV_WATCHDOG_H
 
 #include <time.h>
+#include <signal.h>
 #include "mtev_config.h"
 #include "mtev_defines.h"
 #include "mtev_log.h"
 #include "eventer/eventer.h"
+#include "mtev_stacktrace.h"
 
 /*! \fn int mtev_watchdog_prefork_init()
     \brief Prepare the program to split into a child/parent-monitor relationship.
@@ -176,6 +178,9 @@ API_EXPORT(void)
   mtev_watchdog_on_crash_close_remove_fd(int fd);
 
 API_EXPORT(void)
-  mtev_stacktrace(mtev_log_stream_t ls);
+  mtev_self_diagnose(int sig, siginfo_t *si, void *uc);
 
+API_EXPORT(int)
+  mtev_setup_crash_signals(void (*)(int, siginfo_t *, void *));
+  
 #endif


### PR DESCRIPTION
Refactor setup and calling code, separate into separate source file.
mtev_main will now setup sefl-diagnosis for foreground operated processes.