### PR TITLE
Implement eventer_add_asynch_dep(...)

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -750,6 +750,18 @@ API_EXPORT(int) eventer_impl_setrlimit(void);
 */
 API_EXPORT(void) eventer_add_asynch(eventer_jobq_t *q, eventer_t e);
 
+/*! \fn void eventer_add_asynch_dep(eventer_t e)
+    \brief Add an asynchronous event to a specific job queue dependent on the current job.
+    \param q a job queue
+    \param e an event object
+
+    This adds the `e` event to the job queue `q`.  `e` must have a mask
+    of `EVENETER_ASYNCH`.  This should be called from within a asynch callback
+    during a mask of `EVENTER_ASYNCH_WORK` and the new job will be a child
+    of the currently executing job.
+*/
+API_EXPORT(void) eventer_add_asynch_dep(eventer_jobq_t *q, eventer_t e);
+
 /*! \fn void eventer_add_timed(eventer_t e)
     \brief Add a timed event to the eventer system.
     \param e an event object

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -76,6 +76,8 @@ struct _eventer_job_t {
   uint32_t                inflight;
   uint32_t                has_cleanedup;
   void                  (*cleanup)(struct _eventer_job_t *);
+  uint32_t                dependents;
+  struct _eventer_job_t  *waiting;
   struct _eventer_job_t  *next;
   struct _eventer_jobq_t *jobq;
 };

--- a/src/eventer/eventer_jobq.h
+++ b/src/eventer/eventer_jobq.h
@@ -60,8 +60,9 @@ eventer_jobq_t *eventer_jobq_create(const char *queue_name);
 eventer_jobq_t *eventer_jobq_create_backq(const char *queue_name);
 eventer_jobq_t *eventer_jobq_create_ms(const char *queue_name,
                                        eventer_jobq_memory_safety_t);
+eventer_job_t *eventer_jobq_inflight(void);
 eventer_jobq_t *eventer_jobq_retrieve(const char *name);
-void eventer_jobq_enqueue(eventer_jobq_t *jobq, eventer_job_t *job);
+void eventer_jobq_enqueue(eventer_jobq_t *jobq, eventer_job_t *job, eventer_job_t *parent);
 eventer_job_t *eventer_jobq_dequeue(eventer_jobq_t *jobq);
 eventer_job_t *eventer_jobq_dequeue_nowait(eventer_jobq_t *jobq);
 void eventer_jobq_destroy(eventer_jobq_t *jobq);

--- a/src/examples/zipkin.conf
+++ b/src/examples/zipkin.conf
@@ -58,7 +58,7 @@
       </listener>
       <!-- <listener address="*" port="32323" ssl="on"/> -->
     </consoles>
-    <listener type="http_rest_api" address="*" port="8888" ssl="off">
+    <listener type="http_rest_api" address="*" port="8888" ssl="off" fanout="on">
       <config>
         <document_root>/path/to/docroot</document_root>
       </config>


### PR DESCRIPTION
This new function can be called from an asynchronous job to
delay the completion of the current executing job until the
new added deap has past its cleanup phase.