### PR TITLE
Enable SSL for mtev_websocket_client.c

### DIFF
--- a/src/mtev_websocket_client.c
+++ b/src/mtev_websocket_client.c
@@ -292,9 +292,9 @@ abort_drive:
       if(client->ready_callback) {
         if(!client->ready_callback(client, client->closure)) goto abort_drive;
       }
-    } else {
-      return EVENTER_READ | EVENTER_EXCEPTION;
     }
+
+    if(!client->did_handshake) return (client->sent_handshake ? EVENTER_READ : EVENTER_WRITE) | EVENTER_EXCEPTION;
   }
 
   if (wslay_event_want_read(client->wslay_ctx) == 0

--- a/src/mtev_websocket_client.h
+++ b/src/mtev_websocket_client.h
@@ -29,7 +29,8 @@ API_EXPORT(mtev_websocket_client_t *)
                             const char *path, const char *service,
                             mtev_websocket_client_callbacks *callbacks,
                             void *closure,
-                            eventer_pool_t *pool);
+                            eventer_pool_t *pool,
+                            mtev_hash_table *sslconfig);
 
 API_EXPORT(void)
   mtev_websocket_client_set_ready_callback(mtev_websocket_client_t *client,


### PR DESCRIPTION
Based on `mtev_connection_complete_connect` and `mtev_connection_ssl_upgrade` from `mtev_reverse_socket.c`.

Enabling SSL breaks connections to non-SSL endpoints: `eventer_SSL_connect` returns `EAGAIN` so we return the given mask and are never triggered again. I'm not sure how the eventer SSL code is (not?) supposed to handle a non-SSL connection, so I provided an alternate code path to avoid the SSL upgrade and opset switch by not providing an `sslconfig`.

I'm also at a loss as to how the `sslconfig` should be acquired, and would appreciate feedback on that. For now I've simply stuck in a new `mtev_hash_table` parameter for `mtev_websocket_client_new`.

That prototype is getting a bit lengthy now. I'm intending to make another PR this week to fix an outstanding bug/design problem in this file(that prevents freeing clients/causes invalid memory accesses and undefined behavior) that may require another parameter in `_new`, so I'll very likely add variants(e.g. `_new` would do no SSL on default pool, `_new_pool` accepts a pool, `_new_pool_ssl` accepts pool and sslconfig, rough concept, will refine it) then rather than in this PR.