### PR TITLE
Make Linux epoll impl more resilient to confused add/del/mod.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ test/maybe_alloc_test
 test/test_harness
 test/sort_test
 test/test_detail.xml
+test/pool-shift-async/test

--- a/src/eventer/eventer_POSIX_fd_opset.c
+++ b/src/eventer/eventer_POSIX_fd_opset.c
@@ -79,6 +79,7 @@ POSIX_close(int fd,
   LIBMTEV_EVENTER_CLOSE_ENTRY(fd, *mask, closure);
   rv = close(fd);
   LIBMTEV_EVENTER_CLOSE_RETURN(fd, *mask, closure, rv);
+  mtevL(eventer_deb, "POSIX_close(%d) -> %d\n", fd, rv);
   return rv;
 }
 

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -41,8 +41,11 @@ LUA_FILES=mtevbusted/init.lua mtevbusted/cli.lua mtevbusted/api.lua mtevbusted/c
 
 all:	check
 
-TESTS=hash_test uuid_test time_test hll_test maybe_alloc_test
+TESTS=hash_test uuid_test time_test hll_test maybe_alloc_test pool-shift-async/test
 
+pool-shift-async/test:	pool-shift-async/test.c
+	$(Q)$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS) -L../src $(LDFLAGS) -lmtev $(LIBMTEV_LIBS) -o $@ $<
+	
 hash_test: hash_test.c
 	$(Q)$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS) -L../src $(LDFLAGS) -lmtev $(LIBMTEV_LIBS) -o hash_test hash_test.c
 

--- a/test/pool-shift-async/test-script.sh
+++ b/test/pool-shift-async/test-script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+RV=2
+
+DIR=`dirname $0`
+cd $DIR
+./test -c ./test.conf >/dev/null 2>&1 &
+sleep 1
+OUT=`curl -s http://127.0.0.1:8888/test`
+if [[ "$OUT" == "Hello world" ]]; then
+	RV=0
+else
+	echo "Bad output $OUT"
+fi
+kill -9 %1
+
+exit $RV

--- a/test/pool-shift-async/test.c
+++ b/test/pool-shift-async/test.c
@@ -1,0 +1,127 @@
+#include <mtev_defines.h>
+#include <mtev_conf.h>
+#include <mtev_console.h>
+#include <mtev_dso.h>
+#include <mtev_listener.h>
+#include <mtev_main.h>
+#include <mtev_memory.h>
+#include <mtev_rest.h>
+#include <mtev_capabilities_listener.h>
+#include <mtev_events_rest.h>
+#include <mtev_stats.h>
+#include <eventer/eventer.h>
+#include <inttypes.h>
+
+#include <stdio.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#define APPNAME "example1"
+static char *config_file = NULL;
+static int debug = 1;
+static int foreground = 1;
+
+static int
+usage(const char *prog) {
+	fprintf(stderr, "%s <-c conffile>\n\n", prog);
+  fprintf(stderr, "\t-c conffile\tthe configuration file to load\n");
+  return 2;
+}
+static void
+parse_cli_args(int argc, char * const *argv) {
+  int c;
+  while((c = getopt(argc, argv, "c:")) != EOF) {
+    switch(c) {
+      case 'c':
+        config_file = optarg;
+        break;
+    }
+  }
+}
+
+static int
+doasynchstuff(eventer_t e, int mask, void *closure, struct timeval *now) {
+  mtev_http_rest_closure_t *restc = closure;
+  if(mask == EVENTER_ASYNCH_WORK) {
+    mtevL(mtev_debug, "here asynch\n");
+  }
+  if(mask == EVENTER_ASYNCH) {
+    mtevL(mtev_debug, "here asynch complete\n");
+    eventer_t e = mtev_http_connection_event(mtev_http_session_connection(restc->http_ctx));
+    eventer_trigger(e, EVENTER_READ|EVENTER_WRITE);
+  }
+  return 0;
+}
+static int
+test_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  mtevL(mtev_debug, "-> test_complete()\n");
+  mtev_http_response_ok(restc->http_ctx, "text/plain");
+  mtev_http_response_append_str(restc->http_ctx, "Hello world\n");
+  mtev_http_response_end(restc->http_ctx);
+  return 0;
+}
+static int
+test(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  mtevL(mtev_debug, "-> test()\n");
+  restc->fastpath = test_complete;
+
+  eventer_t conne = mtev_http_connection_event_float(mtev_http_session_connection(restc->http_ctx));
+  if(conne) eventer_remove_fd(conne->fd);
+
+  eventer_t e = eventer_alloc();
+  e->callback = doasynchstuff;
+  e->closure = restc;
+  e->mask = EVENTER_ASYNCH;
+  eventer_add(e);
+
+  /* Allow the asynch event to fire before we finish and return */
+  usleep(1000);
+
+  mtevL(mtev_debug, "<- test()\n");
+  return 0;
+}
+
+static int
+child_main() {
+  /* reload out config, to make sure we have the most current */
+
+  if(mtev_conf_load(NULL) == -1) {
+    mtevL(mtev_debug, "Cannot load config: '%s'\n", config_file);
+    exit(2);
+  }
+  eventer_init();
+  mtev_console_init(APPNAME);
+  mtev_http_rest_init();
+  mtev_capabilities_listener_init();
+  mtev_events_rest_init();
+  mtev_stats_rest_init();
+  mtev_listener_init(APPNAME);
+  mtev_dso_init();
+  mtev_dso_post_init();
+
+  mtev_conf_write_log();
+  mtev_conf_watch_and_journal_watchdog(mtev_conf_write_log, NULL);
+
+  mtev_rest_mountpoint_t *mp;
+  mp = mtev_http_rest_new_rule(
+    "GET", "/", "^test$", test
+  );
+  eventer_pool_t *other = eventer_pool("other");
+  assert(other);
+  mtev_rest_mountpoint_set_eventer_pool(mp, other);
+
+  /* Lastly, spin up the event loop */
+  eventer_loop();
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  parse_cli_args(argc, argv);
+  if(!config_file) exit(usage(argv[0]));
+  
+  mtev_memory_init();
+  mtev_main(APPNAME, config_file, debug, foreground,
+            MTEV_LOCK_OP_LOCK, NULL, NULL, NULL,
+            child_main);
+  return 0;
+}

--- a/test/pool-shift-async/test.conf
+++ b/test/pool-shift-async/test.conf
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<example1 lockfile="/var/tmp/example.lock">
+  <!--
+  <watchdog glider="/opt/local/bin/bt"
+            tracedir="/var/cores/example"/>
+  -->
+  <eventer>
+    <config>
+      <concurrency>4</concurrency>
+      <loop_other>2,1</loop_other>
+      <default_queue_threads>2</default_queue_threads>
+      <default_ca_chain>/etc/default-ca-chain.crt</default_ca_chain>
+      <ssl_dhparam2048_file/>
+    </config>
+  </eventer>
+  <logs>
+    <log name="internal" type="memory" path="10000,100000"/>
+    <console_output>
+      <outlet name="stderr"/>
+      <outlet name="internal"/>
+      <log name="error"/>
+    </console_output>
+    <components>
+      <error>
+        <outlet name="error"/>
+        <log name="error/example"/>
+      </error>
+      <debug>
+        <outlet name="debug"/>
+        <log name="debug/eventer" disabled="false"/>
+        <log name="debug/example" disabled="true"/>
+      </debug>
+    </components>
+  </logs>
+  <modules directory="/path/to/modules">
+  </modules>
+  <listeners>
+    <sslconfig>
+      <optional_no_ca>false</optional_no_ca>
+      <certificate_file>/path/to/server.crt</certificate_file>
+      <key_file>/path/to/server.key</key_file>
+      <ca_chain>/path/to/ca.crt</ca_chain>
+    </sslconfig>
+    <consoles type="mtev_console">
+      <listener address="*" port="32322">
+        <config>
+          <line_protocol>telnet</line_protocol>
+        </config>
+      </listener>
+      <!-- <listener address="*" port="32323" ssl="on"/> -->
+    </consoles>
+    <listener type="control_dispatch" address="*" port="8888" ssl="off">
+      <config>
+        <document_root>/var/tmp</document_root>
+      </config>
+    </listener>
+  </listeners>
+  <rest>
+    <acl>
+      <rule type="allow" />
+    </acl>
+  </rest>
+</example1>

--- a/test/run_standalone_tests.sh
+++ b/test/run_standalone_tests.sh
@@ -7,10 +7,14 @@ fi
 
 rv=0
 for cmd in $@; do
+	exe="./$cmd"
+	if [[ -x ./$cmd-script.sh ]]; then
+		exe="./$cmd-script.sh"
+	fi
 	if [[ "$VERBOSE" == "1" ]]; then
-		./$cmd
+		$exe
 	else
-		./$cmd >/dev/null 2>/dev/null
+		$exe >/dev/null 2>/dev/null
 	fi
 	STATUS=$?
 	RESULT="    #ok"


### PR DESCRIPTION
This change isn't ideal as I think it accommodates other bugs, but
it would appear that we can remove and fd and then re-trigger it
with a mask and an event in the master_fds.  This causes us to
attempt to add when we should modify (or mod when we should add).
This simply provides an explicit fallback if the approach we take
errors b/c it was backwards, we try the other operation.