### PR TITLE
prevent race condition between wslay_event_send and wslay_event_queue_msg

### DIFF
--- a/src/mtev_websocket_client.c
+++ b/src/mtev_websocket_client.c
@@ -311,10 +311,13 @@ abort_drive:
     goto abort_drive;
   }
 
+  pthread_mutex_lock(&client->lock);
   if (wslay_event_send(client->wslay_ctx) != 0) {
     mtevL(client_deb, "Websocket client's wslay_event_send failed, aborting drive\n");
+    pthread_mutex_unlock(&client->lock);
     goto abort_drive;
   }
+  pthread_mutex_unlock(&client->lock);
 
   return client->wanted_eventer_mask | EVENTER_EXCEPTION | EVENTER_WRITE;
 }


### PR DESCRIPTION
This change uses existing locks to make calls to `wslay_event_send` and `wslay_event_queue_msg` mutually exclusive.

Wslay in general does not appear thread-safe. Specific to our usage of it, `wslay_event_send` and `wslay_event_queue_msg` both manipulate the same internal queue in a given `wslay_event_context_ptr`. There are several potential failures from this, although in testing I only saw one: if a push(in `wslay_event_queue_msg`) and pop(in `wslay_event_send`) operation are interleaved in a certain manner, wslay will interpret the queue as empty from that point forward and thus stop writing frames even as more and more messages are successfully enqueue'd to send(which according to wslay docs should cause wslay to attempt more writes). There is no error provided, neither to our network peer nor in return values from wslay calls, nor is the `wslay_event_context_ptr` considered closed or write-disabled.