### PR TITLE
Fix log initialization startup sequence.

### DIFF
--- a/src/examples/lua2.conf
+++ b/src/examples/lua2.conf
@@ -26,13 +26,18 @@
   </modules>
   <logs>
     <log name="internal" type="memory" path="10000,100000"/>
-    <console_output>
+    <timeon>
       <outlet name="stderr"/>
       <outlet name="internal"/>
-      <log name="notice" disabled="true"/>
+      <log name="console" timestamps="true"/>
+    </timeon>
+    <console_output>
+      <outlet name="console"/>
+      <log name="notice" disabled="false"/>
+      <log name="error" disabled="false"/>
     </console_output>
     <test>
-      <outlet name="stderr"/>
+      <outlet name="console"/>
       <log name="test"/>
     </test>
     <components>
@@ -43,6 +48,7 @@
       <debug>
         <outlet name="debug"/>
         <log name="debug/example" disabled="true"/>
+        <log name="debug/eventer" disabled="true"/>
       </debug>
     </components>
   </logs>


### PR DESCRIPTION
During log init, we create the run-time dynamic instances
of "stderr", "debug", "error", and "notice," but previously
they didn't match their boot equivalents.  Fixing this allows
us to default the log creation state to enabled.