### PR TITLE
LZ4F support on the response side

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1776,6 +1776,8 @@ mtev_http_session_drive(eventer_t e, int origmask, void *closure,
     if (ctx->is_websocket == mtev_false) {
       begin_span(ctx);
     }
+    /* we always respond with the same procotol */
+    ctx->res.protocol = ctx->req.protocol;
     LIBMTEV_HTTP_REQUEST_FINISH(CTXFD(ctx), ctx);
   }
 
@@ -1906,6 +1908,8 @@ mtev_http_response_status_set(mtev_http_session_ctx *ctx,
   check_realloc_response(&ctx->res);
   if(ctx->res.output_started == mtev_true) return mtev_false;
   ctx->res.protocol = ctx->req.protocol;
+  mtevL(http_debug, "mtev_http_response_status_set (%d) protocol: %d, code: %d, reason: %s\n",
+        eventer_get_fd(ctx->conn.e), ctx->res.protocol, code, reason);
   if(code < 100 || code > 999) return mtev_false;
   ctx->res.status_code = code;
   if(ctx->res.status_reason) free(ctx->res.status_reason);
@@ -2103,6 +2107,25 @@ _http_construct_leader(mtev_http_session_ctx *ctx) {
   if(tlen < 0) return -1;
   len = b->size = tlen;
 
+  /*
+    consult the incoming request options to determine our response encoding.
+    give preference to gzip to mimic old behavior
+
+    Only use compression on Chunked encoding under http 1.1 for now
+   */
+
+  if(ctx->res.protocol == MTEV_HTTP11 && (ctx->res.output_options & MTEV_HTTP_CHUNKED)) {
+    if (ctx->req.opts & MTEV_HTTP_GZIP) {
+      mtev_http_response_option_set(ctx, MTEV_HTTP_GZIP);
+    }
+    else if (ctx->req.opts & MTEV_HTTP_DEFLATE) {
+      mtev_http_response_option_set(ctx, MTEV_HTTP_DEFLATE);
+    }
+    else if (ctx->req.opts & MTEV_HTTP_LZ4F) {
+      mtev_http_response_option_set(ctx, MTEV_HTTP_LZ4F);
+    }
+  }
+
 #define CTX_LEADER_APPEND(s, slen) do { \
   if(b->size + slen > DEFAULT_BCHAINSIZE) { \
     b->next = ALLOC_BCHAIN(DEFAULT_BCHAINSIZE); \
@@ -2205,6 +2228,7 @@ _http_encode_chain(mtev_http_response *res,
     if (err != 0) {
       return mtev_false;
     }
+
     if (olen == 0) {
       if (done) *done = mtev_true;
     }
@@ -2282,7 +2306,7 @@ mtev_http_process_output_bchain(mtev_http_session_ctx *ctx,
 }
 void
 raw_finalize_encoding(mtev_http_response *res) {
-  if(res->output_options & MTEV_HTTP_GZIP) {
+  if(res->output_options & (MTEV_HTTP_GZIP | MTEV_HTTP_LZ4F)) {
     mtev_boolean finished = mtev_false;
     struct bchain *r = res->output_raw_last;
     mtevAssert((r == NULL && res->output_raw == NULL) ||
@@ -2462,6 +2486,7 @@ mtev_http_response_flush_asynch(mtev_http_session_ctx *ctx,
 
 mtev_boolean
 mtev_http_response_end(mtev_http_session_ctx *ctx) {
+  mtevL(http_debug, " -> mtev_http_response_end(%d)\n", eventer_get_fd(ctx->conn.e));
   if(!mtev_http_response_flush(ctx, mtev_true)) {
     return mtev_false;
   }

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -235,7 +235,6 @@ API_EXPORT(void)
   mtev_http_response_header_set(ctx, "Content-Type", type); \
   if(mtev_http_response_option_set(ctx, MTEV_HTTP_CHUNKED) == mtev_false) \
     mtev_http_response_option_set(ctx, MTEV_HTTP_CLOSE); \
-  mtev_http_response_option_set(ctx, MTEV_HTTP_GZIP); \
 } while(0)
 
 API_EXPORT(void)

--- a/src/utils/mtev_compress.c
+++ b/src/utils/mtev_compress.c
@@ -13,6 +13,7 @@ struct mtev_stream_compress_ctx
 {
   mtev_compress_type type;
   mtev_boolean begun;
+  mtev_boolean flushed;
   LZ4F_compressionContext_t lz4_compress_ctx;
   z_stream zlib_compress_ctx;
 };
@@ -24,12 +25,19 @@ struct mtev_stream_decompress_ctx
   z_stream zlib_decompress_ctx;
 };
 
+struct mtev_decompress_curl_helper
+{
+  curl_write_callback write_function;
+  void *write_closure;
+  mtev_stream_decompress_ctx_t decompress_ctx;
+};
+
 size_t
 mtev_compress_bound(mtev_compress_type type, size_t source_len)
 {
   switch(type) {
   case MTEV_COMPRESS_LZ4F:
-    return LZ4F_compressBound(source_len, NULL);
+    return LZ4F_compressBound(source_len, NULL) + 15;
   case MTEV_COMPRESS_GZIP:
     return deflateBound(NULL, source_len);
   case MTEV_COMPRESS_DEFLATE:
@@ -40,7 +48,7 @@ mtev_compress_bound(mtev_compress_type type, size_t source_len)
   return 0;
 }
 
-int 
+int
 mtev_compress_gzip(const char *data, size_t len, unsigned char **compressed, size_t *compressed_len)
 {
   z_stream stream;
@@ -52,7 +60,7 @@ mtev_compress_gzip(const char *data, size_t len, unsigned char **compressed, siz
     mtevL(mtev_error, "mtev_http_gzip -> deflateInit2: %d\n", err);
     return err;
   }
-  
+
   stream.next_in = (Bytef *)data;
   stream.avail_in = len;
   max_compressed_len = deflateBound(&stream, len);
@@ -74,7 +82,7 @@ mtev_compress_gzip(const char *data, size_t len, unsigned char **compressed, siz
   return Z_OK;
 }
 
-int 
+int
 mtev_compress_lz4f(const char *data, size_t len, unsigned char **compressed, size_t *compressed_len)
 {
   LZ4F_compressionContext_t ctx;
@@ -122,8 +130,8 @@ mtev_compress_lz4f(const char *data, size_t len, unsigned char **compressed, siz
   return 0;
 }
 
-static int 
-_mtev_compress_deflate(const char *data, size_t len, 
+static int
+_mtev_compress_deflate(const char *data, size_t len,
                        unsigned char *compressed, size_t *compressed_len)
 {
   int err = compress2(compressed, compressed_len, (Bytef *)data, len, 9);
@@ -134,7 +142,7 @@ _mtev_compress_deflate(const char *data, size_t len,
   return 0;
 }
 
-int 
+int
 mtev_compress_deflate(const char *data, size_t len, unsigned char **compressed, size_t *compressed_len)
 {
   size_t max_compressed_len;
@@ -150,7 +158,7 @@ mtev_compress_deflate(const char *data, size_t len, unsigned char **compressed, 
 
 
 int
-mtev_compress(mtev_compress_type type, const char *data, size_t len, 
+mtev_compress(mtev_compress_type type, const char *data, size_t len,
               unsigned char **compressed, size_t *compressed_len)
 {
   switch(type) {
@@ -212,9 +220,9 @@ mtev_stream_compress_init(mtev_stream_compress_ctx_t *ctx, mtev_compress_type ty
       if (err != Z_OK) {
         mtevL(mtev_error, "mtev_stream_compress_init: Error creating gzip compression context: %d\n", err);
       }
-        
+
       return err;
-    }   
+    }
   case MTEV_COMPRESS_LZ4F:
     {
       LZ4F_errorCode_t err = LZ4F_createCompressionContext(&ctx->lz4_compress_ctx, LZ4F_VERSION);
@@ -249,7 +257,7 @@ mtev_stream_compress_lz4f(mtev_stream_compress_ctx_t *ctx, const char *source_da
     ctx->begun = mtev_true;
   }
 
-  size_t chunk = LZ4F_compressUpdate(ctx->lz4_compress_ctx, out + s, *out_len - s, 
+  size_t chunk = LZ4F_compressUpdate(ctx->lz4_compress_ctx, out + s, *out_len - s,
                                      source_data, *source_len, NULL);
   if (LZ4F_isError(chunk)) {
     mtevL(mtev_error, "mtev_stream_compress_lz4f: Error compressupdate: %s\n",
@@ -272,13 +280,13 @@ mtev_stream_compress_gzip(mtev_stream_compress_ctx_t *ctx, const char *source_da
   ctx->zlib_compress_ctx.avail_in = in_len;
   ctx->zlib_compress_ctx.next_out = out;
   ctx->zlib_compress_ctx.avail_out = *out_len;
-  
+
   size_t t = ctx->zlib_compress_ctx.total_out;
   int x = deflate(&ctx->zlib_compress_ctx, Z_NO_FLUSH);
   if (x != Z_OK) {
     mtevL(mtev_error, "mtev_stream_compress_gzip: error deflate stream: %d\n",
           x);
-    return -1;    
+    return -1;
   }
   /* order of operations matters here */
   *source_len = ctx->zlib_compress_ctx.avail_in;
@@ -286,8 +294,8 @@ mtev_stream_compress_gzip(mtev_stream_compress_ctx_t *ctx, const char *source_da
   return 0;
 }
 
-int  
-mtev_stream_compress(mtev_stream_compress_ctx_t *ctx, const char *source_data, 
+int
+mtev_stream_compress(mtev_stream_compress_ctx_t *ctx, const char *source_data,
                      size_t *len, unsigned char *out, size_t *out_len)
 {
   switch (ctx->type) {
@@ -319,25 +327,40 @@ mtev_stream_compress(mtev_stream_compress_ctx_t *ctx, const char *source_data,
 }
 
 static int
-mtev_stream_compress_flush_lz4f(mtev_stream_compress_ctx_t *ctx, 
+mtev_stream_compress_flush_lz4f(mtev_stream_compress_ctx_t *ctx,
                                 unsigned char *out, size_t *out_len)
 {
   if (ctx->begun == mtev_false) {
     return -1;
   }
-  
+
+  if (ctx->flushed == mtev_true) {
+    *out_len = 0;
+    return 0;
+  }
+
   size_t s = LZ4F_flush(ctx->lz4_compress_ctx, out, *out_len, NULL);
   if (LZ4F_isError(s)) {
     mtevL(mtev_error, "mtev_stream_compress_flush_lz4f: flush failed %s\n",
           LZ4F_getErrorName(s));
     return -1;
   }
+
+  if (s == 0) {
+    s = LZ4F_compressEnd(ctx->lz4_compress_ctx, out, *out_len, NULL);
+    if (LZ4F_isError(s)) {
+      mtevL(mtev_error, "mtev_stream_compress_flush_lz4f: flush failed %s\n",
+            LZ4F_getErrorName(s));
+      return -1;
+    }
+    ctx->flushed = mtev_true;
+  }
   *out_len = s;
   return 0;
 }
 
 static int
-mtev_stream_compress_flush_gzip(mtev_stream_compress_ctx_t *ctx, 
+mtev_stream_compress_flush_gzip(mtev_stream_compress_ctx_t *ctx,
                                 unsigned char *out, size_t *out_len)
 {
   if (ctx->begun == mtev_false) {
@@ -346,7 +369,7 @@ mtev_stream_compress_flush_gzip(mtev_stream_compress_ctx_t *ctx,
 
   size_t loop_out = 0;
   int x = 0;
-  
+
   while (x != Z_STREAM_END && *out_len - loop_out > 0) {
     size_t total_out_pre_flush = ctx->zlib_compress_ctx.total_out;
     ctx->zlib_compress_ctx.next_out = out + loop_out;
@@ -356,14 +379,14 @@ mtev_stream_compress_flush_gzip(mtev_stream_compress_ctx_t *ctx,
       mtevL(mtev_error, "mtev_stream_compress_flush_gzip: error flushing: %d\n", x);
       return x;
     }
-    loop_out += ctx->zlib_compress_ctx.total_out - total_out_pre_flush;    
+    loop_out += ctx->zlib_compress_ctx.total_out - total_out_pre_flush;
   }
   *out_len = loop_out;
   return 0;
 }
 
 int
-mtev_stream_compress_flush(mtev_stream_compress_ctx_t *ctx, 
+mtev_stream_compress_flush(mtev_stream_compress_ctx_t *ctx,
                            unsigned char *out, size_t *out_len)
 {
   switch(ctx->type) {
@@ -380,33 +403,27 @@ mtev_stream_compress_flush(mtev_stream_compress_ctx_t *ctx,
   return -1;
 }
 
-int
+static int
 mtev_stream_compress_finish_lz4f(mtev_stream_compress_ctx_t *ctx)
 {
-  size_t s = LZ4F_compressEnd(ctx->lz4_compress_ctx, NULL, 0, NULL);
-  if (LZ4F_isError(s)) {
-    mtevL(mtev_error, "mtev_stream_compress_finish_lz4f: finish failed %s\n",
-          LZ4F_getErrorName(s));
-    return -1;
-  }
   LZ4F_freeCompressionContext(ctx->lz4_compress_ctx);
   return 0;
 }
 
-int 
+static int
 mtev_stream_compress_finish_gzip(mtev_stream_compress_ctx_t *ctx)
 {
   int x;
   ctx->zlib_compress_ctx.next_out = NULL;
   ctx->zlib_compress_ctx.avail_out = 0;
   ctx->zlib_compress_ctx.next_in = NULL;
-  ctx->zlib_compress_ctx.avail_in = 0; 
+  ctx->zlib_compress_ctx.avail_in = 0;
   x = deflateEnd(&ctx->zlib_compress_ctx);
   return x;
 }
 
 int
-mtev_stream_compress_finish(mtev_stream_compress_ctx_t *ctx) 
+mtev_stream_compress_finish(mtev_stream_compress_ctx_t *ctx)
 {
   switch(ctx->type) {
   case MTEV_COMPRESS_LZ4F:
@@ -423,14 +440,14 @@ mtev_stream_compress_finish(mtev_stream_compress_ctx_t *ctx)
 }
 
 int
-mtev_stream_decompress_init(mtev_stream_decompress_ctx_t *ctx, 
+mtev_stream_decompress_init(mtev_stream_decompress_ctx_t *ctx,
                             mtev_compress_type type)
 {
   ctx->type = type;
   switch(ctx->type) {
   case MTEV_COMPRESS_LZ4F:
     {
-      LZ4F_errorCode_t err = LZ4F_createDecompressionContext(&ctx->lz4_decompress_ctx, 
+      LZ4F_errorCode_t err = LZ4F_createDecompressionContext(&ctx->lz4_decompress_ctx,
                                                              LZ4F_VERSION);
       if (LZ4F_isError(err)) {
         mtevL(mtev_error, "mtev_stream_decompress_init: error create decompression context for lz4f: %s\n", LZ4F_getErrorName(err));
@@ -445,7 +462,7 @@ mtev_stream_decompress_init(mtev_stream_decompress_ctx_t *ctx,
         mtevL(mtev_error, "mtev_stream_decompress_init: gzip error initing the zstream: %s\n",
             ctx->zlib_decompress_ctx.msg);
         return -1;
-      }      
+      }
       return 0;
     }
   default:
@@ -455,7 +472,7 @@ mtev_stream_decompress_init(mtev_stream_decompress_ctx_t *ctx,
 }
 
 static int
-mtev_stream_decompress_lz4f(mtev_stream_decompress_ctx_t *ctx, 
+mtev_stream_decompress_lz4f(mtev_stream_decompress_ctx_t *ctx,
                             const unsigned char *compressed,
                             size_t *compressed_len,
                             unsigned char *decompressed,
@@ -476,7 +493,7 @@ mtev_stream_decompress_lz4f(mtev_stream_decompress_ctx_t *ctx,
     mtevL(mtev_error, "mtev_stream_decompress_lz4f: error decompressing: %s\n",
           LZ4F_getErrorName(s));
     return -1;
-  }  
+  }
 
   *compressed_len = in_size;
   *decompressed_len = out_size;
@@ -484,7 +501,7 @@ mtev_stream_decompress_lz4f(mtev_stream_decompress_ctx_t *ctx,
 }
 
 static int
-mtev_stream_decompress_gzip(mtev_stream_decompress_ctx_t *ctx, 
+mtev_stream_decompress_gzip(mtev_stream_decompress_ctx_t *ctx,
                             const unsigned char *compressed,
                             size_t *compressed_len,
                             unsigned char *decompressed,
@@ -497,7 +514,7 @@ mtev_stream_decompress_gzip(mtev_stream_decompress_ctx_t *ctx,
   ctx->zlib_decompress_ctx.avail_in = *compressed_len;
   ctx->zlib_decompress_ctx.next_out = decompressed;
   ctx->zlib_decompress_ctx.avail_out = *decompressed_len;
-  
+
   int x = inflate(&ctx->zlib_decompress_ctx, 0);
   if (x != Z_OK && x != Z_STREAM_END) {
     mtevL(mtev_error, "mtev_stream_decompress_gzip: zlib error decompressing: %s\n",
@@ -511,7 +528,7 @@ mtev_stream_decompress_gzip(mtev_stream_decompress_ctx_t *ctx,
 
 
 int
-mtev_stream_decompress(mtev_stream_decompress_ctx_t *ctx, 
+mtev_stream_decompress(mtev_stream_decompress_ctx_t *ctx,
                          const unsigned char *compressed,
                          size_t *compressed_len,
                          unsigned char *decompressed,
@@ -544,4 +561,50 @@ mtev_stream_decompress_finish(mtev_stream_decompress_ctx_t *ctx)
     return 0;
   };
   return 0;
+}
+
+mtev_decompress_curl_helper_t *
+mtev_decompress_create_curl_helper(curl_write_callback write_function, void *closure, mtev_compress_type type)
+{
+  mtev_decompress_curl_helper_t *ch = malloc(sizeof(mtev_decompress_curl_helper_t));
+  ch->write_function = write_function;
+  ch->write_closure = closure;
+  mtev_stream_decompress_init(&ch->decompress_ctx, type);
+  return ch;
+}
+
+void
+mtev_decompress_destroy_curl_helper(mtev_decompress_curl_helper_t *ch)
+{
+  mtev_stream_decompress_finish(&ch->decompress_ctx);
+  free(ch);
+}
+
+size_t
+mtev_curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+{
+  unsigned char decompressed[8192];
+  mtev_decompress_curl_helper_t *ch = (mtev_decompress_curl_helper_t *)userdata;
+  size_t data_len = size * nmemb;
+  size_t read_compressed = 0;
+
+  while (read_compressed < data_len) {
+    size_t x = data_len - read_compressed;
+    size_t decompressed_len = sizeof(decompressed);
+
+    if (mtev_stream_decompress(&ch->decompress_ctx, (const unsigned char *)(ptr + read_compressed), &x, decompressed, &decompressed_len) == -1) {
+      mtevL(mtev_error, "Error decompressing in mtev_curl_write_callback\n");
+      return -1;
+    }
+    read_compressed += x;
+
+    /* pass along to ch->write_function */
+    size_t pos = 0;
+    while (decompressed_len > 0) {
+      size_t read = ch->write_function((char *)(decompressed + pos), 1, decompressed_len, ch->write_closure);
+      decompressed_len -= read;
+      pos += read;
+    }
+  }
+  return data_len;
 }

--- a/src/utils/mtev_compress.h
+++ b/src/utils/mtev_compress.h
@@ -41,8 +41,10 @@ typedef enum {
   MTEV_COMPRESS_DEFLATE
 } mtev_compress_type;
 
+typedef size_t (*curl_write_callback)(char *ptr, size_t size, size_t nmemb, void *userdata);
 typedef struct mtev_stream_compress_ctx mtev_stream_compress_ctx_t;
 typedef struct mtev_stream_decompress_ctx mtev_stream_decompress_ctx_t;
+typedef struct mtev_decompress_curl_helper mtev_decompress_curl_helper_t;
 
 /**
  * @return worst case destination size for source_len
@@ -168,7 +170,7 @@ API_EXPORT(int)
  * @return 0 on success, non-zero on error
  */
 API_EXPORT(int)
-  mtev_stream_compress_finish(mtev_stream_compress_ctx_t *ctx);
+mtev_stream_compress_finish(mtev_stream_compress_ctx_t *ctx);
 
 /**
  * initialize a streaming decompression session for type
@@ -204,6 +206,17 @@ API_EXPORT(int)
 API_EXPORT(int)
   mtev_stream_decompress_finish(mtev_stream_decompress_ctx_t *ctx);
 
+API_EXPORT(mtev_decompress_curl_helper_t *)
+mtev_decompress_create_curl_helper(curl_write_callback write_function, void *closure, mtev_compress_type type);
 
+API_EXPORT(void)
+  mtev_decompress_destroy_curl_helper(mtev_decompress_curl_helper_t *ch);
+
+/*!
+  \fn size_t mtev_curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
+  \brief Pass this to CURLOPT_WRITEFUNCTION and use an mtev_decompress_curl_helper_t as the CURLOPT_WRITEDATA
+*/
+API_EXPORT(size_t)
+  mtev_curl_write_callback(char *ptr, size_t size, size_t nmemb, void *userdata);
 
 #endif


### PR DESCRIPTION
* add a curl helper you can hand to CURLOPT_WRITEFUNCTION that can decompress LZ4F responses
* fix LZ4F handling so it actually works on the response side