### PR TITLE
fix potential use-after-free in eventer cross-thread triggers.

### DIFF
--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -861,11 +861,13 @@ void eventer_cross_thread_trigger(eventer_t e, int mask) {
   mtevAssert(0 == (ctt->mask & EVENTER_CROSS_THREAD_TRIGGER));
   ctt->mask |= EVENTER_CROSS_THREAD_TRIGGER;
   mtevL(eventer_deb, "queueing fd:%d from t@%d to t@%d\n", e->fd, (int)(intptr_t)pthread_self(), (int)(intptr_t)e->thr_owner);
+  eventer_ref(e);
   pthread_mutex_lock(&t->cross_lock);
   ctt->next = t->cross;
   t->cross = ctt;
   pthread_mutex_unlock(&t->cross_lock);
   eventer_wakeup(e);
+  eventer_deref(e);
 }
 void eventer_cross_thread_process() {
   struct eventer_impl_data *t;


### PR DESCRIPTION
CTT's _first_ add the eventer_t to a cross-thread-trigger list,
_then_ call eventer_wakeup(event). If the event is handled across
threads before the wakeup, then the event might be free'd before
eventer_wakeup has a chance to fully examine it. Protect against
this by refcnt'ing the eventer_t around the transaction.