### PR TITLE
add mtev_lru

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -113,6 +113,7 @@ MAPPEDHEADERS=utils/mtev_atomic.h utils/mtev_b32.h utils/mtev_b64.h \
     utils/mtev_perftimer.h utils/mtev_zipkin.h \
     utils/mtev_hyperloglog.h json-lib/mtev_arraylist.h \
     utils/mtev_stacktrace.h utils/mtev_maybe_alloc.h \
+	  util/mtev_lru.h \
     json-lib/mtev_bits.h json-lib/mtev_debug.h \
     json-lib/mtev_json_object.h json-lib/mtev_json_tokener.h \
     json-lib/mtev_json_util.h json-lib/mtev_json.h \
@@ -152,7 +153,7 @@ MTEV_UTILS_OBJS=utils/mtev_b32.hlo utils/mtev_b64.hlo \
     utils/mtev_str.lo utils/mtev_watchdog.lo utils/mtev_zipkin.lo \
     utils/mtev_memory.lo utils/mtev_cht.hlo utils/mtev_uuid_parse.hlo \
     utils/mtev_perftimer.lo utils/mtev_hyperloglog.hlo \
-    utils/mtev_stacktrace.lo $(ATOMIC_OBJS) \
+    utils/mtev_stacktrace.lo utils/mtev_lru.lo $(ATOMIC_OBJS) \
     utils/android-demangle/cp-demangle.lo
 
 LIBMTEV_OBJS=mtev_main.lo mtev_listener.lo mtev_cluster.lo \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -113,7 +113,7 @@ MAPPEDHEADERS=utils/mtev_atomic.h utils/mtev_b32.h utils/mtev_b64.h \
     utils/mtev_perftimer.h utils/mtev_zipkin.h \
     utils/mtev_hyperloglog.h json-lib/mtev_arraylist.h \
     utils/mtev_stacktrace.h utils/mtev_maybe_alloc.h \
-	  util/mtev_lru.h \
+	  utils/mtev_lru.h \
     json-lib/mtev_bits.h json-lib/mtev_debug.h \
     json-lib/mtev_json_object.h json-lib/mtev_json_tokener.h \
     json-lib/mtev_json_util.h json-lib/mtev_json.h \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -153,7 +153,8 @@ MTEV_UTILS_OBJS=utils/mtev_b32.hlo utils/mtev_b64.hlo \
     utils/mtev_str.lo utils/mtev_watchdog.lo utils/mtev_zipkin.lo \
     utils/mtev_memory.lo utils/mtev_cht.hlo utils/mtev_uuid_parse.hlo \
     utils/mtev_perftimer.lo utils/mtev_hyperloglog.hlo \
-    utils/mtev_stacktrace.lo utils/mtev_lru.lo $(ATOMIC_OBJS) \
+    utils/mtev_stacktrace.lo utils/mtev_lru.lo \
+	  utils/mtev_rand.hlo $(ATOMIC_OBJS) \
     utils/android-demangle/cp-demangle.lo
 
 LIBMTEV_OBJS=mtev_main.lo mtev_listener.lo mtev_cluster.lo \

--- a/src/mtev_net_heartbeat.c
+++ b/src/mtev_net_heartbeat.c
@@ -33,6 +33,7 @@
 #include "mtev_log.h"
 #include "mtev_conf.h"
 #include "mtev_net_heartbeat.h"
+#include "mtev_rand.h"
 
 #include <unistd.h>
 #include <errno.h>
@@ -221,13 +222,13 @@ mtev_net_heartbeat_serialize_and_send(mtev_net_heartbeat_ctx *ctx) {
 
   /* 4 bytes of IV */
   ivec = (unsigned char *)payload + HDR_LENSIZE;
-  hdr[i++] = lrand48();
-  hdr[i++] = lrand48();
-  hdr[i++] = lrand48();
-  hdr[i++] = lrand48();
+  hdr[i++] = mtev_rand();
+  hdr[i++] = mtev_rand();
+  hdr[i++] = mtev_rand();
+  hdr[i++] = mtev_rand();
   /* 2 words of gibberish */
-  hdr[i++] = lrand48();
-  hdr[i++] = lrand48();
+  hdr[i++] = mtev_rand();
+  hdr[i++] = mtev_rand();
   /* 2 words of magic */
   hdr[i++] = htonl(HBPKTMAGIC1);
   hdr[i++] = htonl(HBPKTMAGIC2);
@@ -582,5 +583,6 @@ mtev_net_heartbeat_from_conf(const char *basepath) {
 
 void
 mtev_net_heartbeat_init(void) {
+  mtev_rand_init();
   global = mtev_net_heartbeat_from_conf("/*/netheartbeat");
 }

--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -34,6 +34,7 @@
 #include "mtev_config.h"
 #include "mtev_hash.h"
 #include "mtev_log.h"
+#include "mtev_rand.h"
 #include "mtev_watchdog.h"
 #include <time.h>
 #include <stdio.h>
@@ -126,7 +127,6 @@ hs_compare(const void *previous, const void *compare)
   return false;
 }
 
-static int rand_init;
 void mtev_hash_init(mtev_hash_table *h) {
   return mtev_hash_init_size(h, MTEV_HASH_DEFAULT_SIZE);
 }
@@ -274,15 +274,12 @@ void mtev_hash_init_size(mtev_hash_table *h, int size) {
 }
 
 void mtev_hash_init_locks(mtev_hash_table *h, int size, mtev_hash_lock_mode_t lock_mode) {
-  if(!rand_init) {
-    srand48((long int)time(NULL));
-    rand_init = 1;
-  }
+  mtev_rand_init();
 
   if(size < 8) size = 8;
 
   mtevAssert(ck_hs_init(&h->u.hs, CK_HS_MODE_OBJECT | CK_HS_MODE_SPMC, hs_hash, hs_compare, &my_allocator,
-                         size, lrand48()));
+                        size, mtev_rand()));
   mtevAssert(h->u.hs.hf != NULL);
 
   h->u.locks.locks = calloc(1, sizeof(struct locks_container));

--- a/src/utils/mtev_lru.c
+++ b/src/utils/mtev_lru.c
@@ -1,6 +1,7 @@
 #include "mtev_lru.h"
 #include "mtev_hash.h"
 #include "mtev_log.h"
+#include "mtev_rand.h"
 
 #include <ck_hs.h>
 #include <sys/queue.h>
@@ -43,8 +44,6 @@ static struct ck_malloc malloc_ck_hs = {
   .free = lru_free
 };
 
-static int rand_init = 0;
-
 static unsigned long
 lru_entry_hash(const void *k, unsigned long seed)
 {
@@ -57,13 +56,10 @@ lru_entry_hash(const void *k, unsigned long seed)
 static void
 hs_init(ck_hs_t *hs, unsigned int mode, ck_hs_hash_cb_t *hf, ck_hs_compare_cb_t *cf, unsigned long size)
 {
-  if(!rand_init) {
-    srand48((long int)time(NULL));
-    rand_init = 1;
-  }
+  mtev_rand_init();
   struct ck_malloc *allocator = &malloc_ck_hs;
 
-  if (ck_hs_init(hs, mode | CK_HS_MODE_SPMC, hf, cf, allocator, size, lrand48()) == false) {
+  if (ck_hs_init(hs, mode | CK_HS_MODE_SPMC, hf, cf, allocator, size, mtev_rand()) == false) {
     mtevFatal(mtev_error, "Cannot initialize ck_hs\n");
   }
 }

--- a/src/utils/mtev_lru.c
+++ b/src/utils/mtev_lru.c
@@ -188,6 +188,7 @@ mtev_lru_put(mtev_lru_t *lru, const char *key, size_t key_len, void *val)
   }
   if (previous) {
     struct lru_entry *p = container_of(previous, struct lru_entry, key);
+    TAILQ_REMOVE(&lru->lru_cache, p, list_entry);
     lru->free_fn(p->entry);
     free(p);
   }

--- a/src/utils/mtev_lru.c
+++ b/src/utils/mtev_lru.c
@@ -231,7 +231,7 @@ mtev_lru_remove(mtev_lru_t *c, const char *key, size_t key_len)
     free(r);
 
     /* when removing, perform GC every 100K rows */
-    if (c->lru_cache_size % GC_CADENCE == 0) {
+    if (ck_hs_count(&c->hash) > 0 && c->lru_cache_size % GC_CADENCE == 0) {
       ck_hs_gc(&c->hash, GC_CADENCE, (rand() % ck_hs_count(&c->hash)));
     }
   }

--- a/src/utils/mtev_lru.c
+++ b/src/utils/mtev_lru.c
@@ -1,0 +1,252 @@
+#include "mtev_lru.h"
+#include "mtev_hash.h"
+#include "mtev_log.h"
+
+#include <ck_hs.h>
+#include <sys/queue.h>
+
+struct lru_entry {
+  void *entry;
+  size_t key_len;
+  TAILQ_ENTRY(lru_entry) list_entry;
+  char key[];
+};
+
+struct mtev_lru {
+  ck_hs_t hash;
+  int32_t max_entries;
+  TAILQ_HEAD(lru_list, lru_entry) lru_cache;
+  int32_t lru_cache_size;
+  uint32_t expire_count;
+  void (*free_fn)(void *);
+  pthread_mutex_t mutex;
+};
+
+static void *
+lru_malloc(size_t r)
+{
+  return malloc(r);
+}
+
+static void
+lru_free(void *p, size_t b, bool r)
+{
+  (void)b;
+  (void)r;
+  free(p);
+  return;
+}
+
+static struct ck_malloc malloc_ck_hs = {
+  .malloc = lru_malloc,
+  .free = lru_free
+};
+
+static int rand_init = 0;
+
+#define HS_HF_STRING(F)                         \
+  static unsigned long                          \
+  F(const void *k, unsigned long seed)          \
+  {                                             \
+    return mtev_hash__hash(k, strlen(k), seed);   \
+  }
+
+HS_HF_STRING(lru_entry_hash);
+
+#define offset_of(type, member)                 \
+  ((size_t)(&((type *)0)->member))
+
+#define container_of(derived_ptr, type, field)                \
+  ((type *)((char *)(derived_ptr) - offset_of(type, field)))
+
+static void
+hs_init(ck_hs_t *hs, unsigned int mode, ck_hs_hash_cb_t *hf, ck_hs_compare_cb_t *cf, unsigned long size)
+{
+  if(!rand_init) {
+    srand48((long int)time(NULL));
+    rand_init = 1;
+  }
+  struct ck_malloc *allocator = &malloc_ck_hs;
+
+  if (ck_hs_init(hs, mode | CK_HS_MODE_SPMC, hf, cf, allocator, size, lrand48()) == false) {
+    mtevFatal(mtev_error, "Cannot initialize ck_hs\n");
+  }
+}
+
+static inline bool
+hs_string_compare(const void *a, const void *b)
+{
+  return strcmp((const char * const)a, (const char * const)b) == 0;
+}
+
+mtev_lru_t *
+mtev_lru_create(int32_t max_entries, void (*free_fn)(void *)) 
+{
+  struct mtev_lru *r = malloc(sizeof(struct mtev_lru));
+  if (max_entries <= 0) {
+    hs_init(&r->hash, CK_HS_MODE_OBJECT | CK_HS_MODE_DELETE, lru_entry_hash, hs_string_compare, 1024);
+  } else {
+    hs_init(&r->hash, CK_HS_MODE_OBJECT | CK_HS_MODE_DELETE, lru_entry_hash, hs_string_compare, max_entries * 2);
+  }
+  TAILQ_INIT(&r->lru_cache);
+  r->lru_cache_size = 0;
+  r->expire_count = 0;
+  r->max_entries = max_entries;
+  if (free_fn != NULL) {
+    r->free_fn = free_fn;
+  } else {
+    r->free_fn = free;
+  }
+  pthread_mutex_init(&r->mutex, NULL);
+  return r;
+}
+
+void
+mtev_lru_destroy(mtev_lru_t *lru) 
+{
+  mtev_lru_invalidate(lru);
+  ck_hs_destroy(&lru->hash);
+  free(lru);
+}
+
+void
+mtev_lru_invalidate(mtev_lru_t *lru)
+{
+  pthread_mutex_lock(&lru->mutex);
+  void *entry;
+  ck_hs_iterator_t it = CK_HS_ITERATOR_INITIALIZER;
+  while(ck_hs_next(&lru->hash, &it, &entry) == true) {
+    struct lru_entry *e = container_of(entry, struct lru_entry, key);
+    lru->free_fn(e->entry);
+    free(e);
+  }
+  lru->lru_cache_size = 0;
+  pthread_mutex_unlock(&lru->mutex);
+}
+
+#define GC_CADENCE 10000
+
+/* this requires a lock to be held elsewhere */
+static void
+expire_oldest_lru_cache_no_lock(mtev_lru_t *c)
+{
+  /* remove from TAILQ */
+  struct lru_entry *e = TAILQ_LAST(&c->lru_cache, lru_list);
+  TAILQ_REMOVE(&c->lru_cache, e, list_entry);
+  c->lru_cache_size--;
+
+  /* remove from hs */
+  unsigned long hash = CK_HS_HASH(&c->hash, lru_entry_hash, e->key);
+  ck_hs_remove(&c->hash, hash, e->key);
+
+  int ec = ck_pr_load_32(&c->expire_count);
+  if (ec == GC_CADENCE) {
+    c->expire_count = 0;
+    ck_hs_gc(&c->hash, GC_CADENCE, (rand() % ck_hs_count(&c->hash)));
+  }
+  c->expire_count++;
+
+  if (e->entry != NULL) {
+    c->free_fn(e->entry);
+  }
+  free(e);
+}
+
+static void 
+add_lru_cache_no_lock(mtev_lru_t *c, struct lru_entry *e)
+{
+  if (c->max_entries > 0) {
+    if ((c->lru_cache_size + 1) > c->max_entries) {
+      expire_oldest_lru_cache_no_lock(c);
+    }
+    TAILQ_INSERT_HEAD(&c->lru_cache, e, list_entry);
+  }
+  c->lru_cache_size++;
+}
+
+static void 
+touch_lru_cache_no_lock(mtev_lru_t *c, struct lru_entry *e)
+{
+  if (c->max_entries > 0) {
+    if (e->list_entry.tqe_next != NULL || e->list_entry.tqe_prev != NULL) {
+      TAILQ_REMOVE(&c->lru_cache, e, list_entry);
+    }
+    TAILQ_INSERT_HEAD(&c->lru_cache, e, list_entry);
+  }
+}
+
+
+mtev_boolean
+mtev_lru_put(mtev_lru_t *lru, const char *key, size_t key_len, void *val)
+{
+  unsigned long hash = CK_HS_HASH(&lru->hash, lru_entry_hash, key);
+  struct lru_entry *e = malloc(sizeof(struct lru_entry) + sizeof(key_len));
+  e->entry = val;
+  e->key_len = key_len;
+  memcpy(e->key, key, key_len);
+  e->key[key_len] = '\0';
+
+  pthread_mutex_lock(&lru->mutex);
+  void *previous = NULL;
+  if (ck_hs_set(&lru->hash, hash, e->key, &previous) == false) {
+    free(e);
+    pthread_mutex_unlock(&lru->mutex);
+    return mtev_false;
+  }
+  if (previous) {
+    struct lru_entry *p = container_of(previous, struct lru_entry, key);
+    lru->free_fn(p->entry);
+    free(p);
+  }
+  add_lru_cache_no_lock(lru, e);
+  pthread_mutex_unlock(&lru->mutex);
+  return mtev_true;
+}
+
+void *
+mtev_lru_get(mtev_lru_t *c, const char *key, size_t key_len)
+{
+  unsigned long hash = CK_HS_HASH(&c->hash, lru_entry_hash, key);
+  void *entry = ck_hs_get(&c->hash, hash, key);
+
+  if (entry != NULL) {
+    struct lru_entry *r = container_of(entry, struct lru_entry, key);
+    pthread_mutex_lock(&c->mutex);
+    touch_lru_cache_no_lock(c, r);
+    pthread_mutex_unlock(&c->mutex);
+    return r->entry;
+  }
+  return NULL;
+}
+
+
+void *
+mtev_lru_remove(mtev_lru_t *c, const char *key, size_t key_len)
+{
+  unsigned long hash = CK_HS_HASH(&c->hash, lru_entry_hash, key);
+  void *rval = NULL;
+  pthread_mutex_lock(&c->mutex);
+  void *entry = ck_hs_remove(&c->hash, hash, key);
+  if (entry != NULL) {
+    struct lru_entry *r = container_of(entry, struct lru_entry, key);
+    if (c->max_entries > 0) {
+      TAILQ_REMOVE(&c->lru_cache, r, list_entry);
+    }
+    c->lru_cache_size--;
+    rval = r->entry;
+    free(r);
+
+    /* when removing, perform GC every 100K rows */
+    if (c->lru_cache_size % GC_CADENCE == 0) {
+      ck_hs_gc(&c->hash, GC_CADENCE, (rand() % ck_hs_count(&c->hash)));
+    }
+  }
+  pthread_mutex_unlock(&c->mutex);
+  return rval;
+}
+
+int32_t
+mtev_lru_size(mtev_lru_t *c)
+{
+  return c->lru_cache_size;
+}

--- a/src/utils/mtev_lru.h
+++ b/src/utils/mtev_lru.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name Circonus, Inc. nor the names
+ *       of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written
+ *       permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _MTEV_LRU_H
+#define _MTEV_LRU_H
+
+#include "mtev_defines.h"
+
+typedef struct mtev_lru mtev_lru_t;
+
+/**
+ * make an LRU cache of max_entries.  call free_fn when an item is evicted.
+ * if free_fn is null, call free.  If max_entries == -1 then this devolves to a normal hashtable
+ */
+API_EXPORT(mtev_lru_t *)
+  mtev_lru_create(int32_t max_entries, void (*free_fn)(void *));
+
+API_EXPORT(void)
+  mtev_lru_destroy(mtev_lru_t *lru);
+
+API_EXPORT(void)
+  mtev_lru_invalidate(mtev_lru_t *lru);
+
+/* if some other thread has added a val at this key this will overwrite it */
+API_EXPORT(mtev_boolean)
+  mtev_lru_put(mtev_lru_t *lru, const char *key, size_t key_len, void *value);
+
+API_EXPORT(void *)
+  mtev_lru_get(mtev_lru_t *lru, const char *key, size_t key_len);
+
+/**
+ * remove key from cache.  This does not call the free_fn, instead it returns the value
+ */
+API_EXPORT(void *)
+  mtev_lru_remove(mtev_lru_t *lru, const char *key, size_t key_len);
+
+API_EXPORT(int32_t)
+  mtev_lru_size(mtev_lru_t *lru);
+
+#endif

--- a/src/utils/mtev_rand.c
+++ b/src/utils/mtev_rand.c
@@ -1,0 +1,17 @@
+#include "mtev_rand.h"
+
+static int rand_init = 0;
+
+void
+mtev_rand_init(void){
+  if(rand_init == 0) {
+    srand48((long int)time(NULL));
+    rand_init = 1;
+  }
+}
+
+inline uint64_t
+mtev_rand(void)
+{
+  return lrand48();
+}

--- a/src/utils/mtev_rand.h
+++ b/src/utils/mtev_rand.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name Circonus, Inc. nor the names
+ *       of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written
+ *       permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MTEV_RAND_H
+#define MTEV_RAND_H
+
+#include "mtev_defines.h"
+
+API_EXPORT(void)
+  mtev_rand_init(void);
+
+API_EXPORT(uint64_t)
+  mtev_rand(void);
+
+#endif /* MTEV_RAND_H */

--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -20,6 +20,7 @@
 #include "mtev_defines.h"
 #include "mtev_skiplist.h"
 #include "mtev_log.h"
+#include "mtev_rand.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,9 +50,9 @@ int mtev_compare_voidptr(const void *a, const void *b) {
 static int get_b_rand(void) {
   static int ph=32; /* More bits than we will ever use */
   static unsigned long randseq;
-  if(ph > 31) { /* Num bits in return of lrand48() */
+  if(ph > 31) { /* Num bits in return of mtev_rand() */
     ph=0;
-    randseq = lrand48();
+    randseq = mtev_rand();
   }
   ph++;
   return ((randseq & (1 << (ph-1))) >> (ph-1));
@@ -74,6 +75,7 @@ static int indexing_compk(const void *a, const void *bv) {
 }
 
 void mtev_skiplist_init(mtev_skiplist *sl) {
+  mtev_rand_init();
   mtev_skiplisti_init(sl);
   sl->index = (mtev_skiplist *)malloc(sizeof(mtev_skiplist));
   mtev_skiplisti_init(sl->index);

--- a/test/Makefile.in
+++ b/test/Makefile.in
@@ -41,7 +41,7 @@ LUA_FILES=mtevbusted/init.lua mtevbusted/cli.lua mtevbusted/api.lua mtevbusted/c
 
 all:	check
 
-TESTS=hash_test uuid_test time_test hll_test maybe_alloc_test dyn_buffer_test speculatelog_test pool-shift-async/test
+TESTS=hash_test uuid_test time_test hll_test maybe_alloc_test dyn_buffer_test speculatelog_test lru_test pool-shift-async/test
 
 pool-shift-async/test:	pool-shift-async/test.c
 	$(Q)$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS) -L../src $(LDFLAGS) -o $@ $< -lmtev $(LIBMTEV_LIBS)
@@ -69,6 +69,9 @@ dyn_buffer_test: dyn_buffer_test.c
 
 speculatelog_test: speculatelog_test.c
 	$(Q)$(CC) -I../src/utils -I../src -I../src/json-lib $(CPPFLAGS) $(CFLAGS) -L../src $(LDFLAGS) -o $@ $? -lmtev $(LIBMTEV_LIBS)
+
+lru_test: lru_test.c
+	$(Q)$(CC) -I../src/utils $(CPPFLAGS) $(CFLAGS) -L../src $(LDFLAGS) -o lru_test lru_test.c -lmtev $(LIBMTEV_LIBS)
 
 .c.o:
 	@echo "- compiling $<"

--- a/test/lru_test.c
+++ b/test/lru_test.c
@@ -1,0 +1,75 @@
+#include <mtev_lru.h>
+#include <mtev_time.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <uuid/uuid.h>
+
+#define FAIL(...)                           \
+  printf("** ");                            \
+  printf( __VA_ARGS__);                     \
+  printf("\n** FAILURE\n"); \
+  exit(1);
+
+struct data{
+  int i;
+  char key[10];
+};
+
+void
+noop_free(void *x)
+{
+  (void)x;
+  return;
+}
+
+int main(int argc, char **argv) 
+{
+  uuid_t uuid;
+  char s[PATH_MAX];
+  srand(time(NULL));
+
+  struct data datas[10] = 
+    {
+      {0, "zero"},
+      {1, "one"},
+      {2, "two"},
+      {3, "three"},
+      {4, "four"},
+      {5, "five"},
+      {6, "six"},
+      {7, "seven"},
+      {8, "eight"},
+      {9, "nine"}
+    };
+
+  /* test max entries */
+  mtev_lru_t *lru = mtev_lru_create(5, noop_free);
+  
+  for (int j = 0; j < 10; j++) {
+    mtev_lru_put(lru, datas[j].key, strlen(datas[j].key), &datas[j]);
+  }
+
+  if (mtev_lru_size(lru) != 5) {
+    FAIL("LRU size is not 5");
+  }
+
+  /* test that the last 5 entries are what remains in the LRU */
+  for (int j = 5; j < 10; j++) {
+    void *d = mtev_lru_get(lru, datas[j].key, strlen(datas[j].key));
+    struct data* dd = (struct data *)d;
+    if (dd->i != datas[j].i) {
+      FAIL("LRU expected %d, got %d", datas[j].i, dd->i);
+    }
+  }
+
+  mtev_lru_invalidate(lru);
+  if (mtev_lru_size(lru) != 0) {
+    FAIL("LRU size is not 0");
+  }
+
+  mtev_lru_destroy(lru);
+  printf("SUCCESS\n");
+
+}


### PR DESCRIPTION
Simple LRU with configurable free function for evicted items.

Went with `ck_hs` directly instead of `mtev_hash_table` because I needed access to `ck_hs_set` to catch conflicting puts.