### PR TITLE
Add mtev_uuid_copy Inline Function

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -113,6 +113,7 @@ MAPPEDHEADERS=utils/mtev_atomic.h utils/mtev_b32.h utils/mtev_b64.h \
     utils/mtev_perftimer.h utils/mtev_zipkin.h \
     utils/mtev_hyperloglog.h json-lib/mtev_arraylist.h \
     utils/mtev_stacktrace.h utils/mtev_maybe_alloc.h \
+    utils/mtev_uuid_copy.h utils/mtev_uuid.h \
     json-lib/mtev_bits.h json-lib/mtev_debug.h \
     json-lib/mtev_json_object.h json-lib/mtev_json_tokener.h \
     json-lib/mtev_json_util.h json-lib/mtev_json.h \

--- a/src/utils/mtev_uuid.h
+++ b/src/utils/mtev_uuid.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names
+ *      of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef UTILS_MTEV_UUID_H
+#define UTILS_MTEV_UUID_H
+
+#include "mtev_uuid_parse.h"
+#include "mtev_uuid_copy.h"
+
+#endif

--- a/src/utils/mtev_uuid_copy.h
+++ b/src/utils/mtev_uuid_copy.h
@@ -36,7 +36,7 @@
 static inline
 void mtev_uuid_copy(uuid_t dst, const uuid_t src)
 {
-  memcpy(dst, src, sizeof(uuid_t));
+  memcpy((void *)dst, (const void *)src, sizeof(uuid_t));
 }
 
 #endif

--- a/src/utils/mtev_uuid_copy.h
+++ b/src/utils/mtev_uuid_copy.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, Circonus, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *    * Neither the name Circonus, Inc. nor the names
+ *      of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written
+ *      permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#ifndef UTILS_MTEV_UUID_COPY_H
+#define UTILS_MTEV_UUID_COPY_H
+
+static inline
+void mtev_uuid_copy(uuid_t dst, const uuid_t src)
+{
+  memcpy(dst, src, sizeof(uuid_t));
+}
+
+#endif


### PR DESCRIPTION
libuuid's uuid_copy function copies character-by-character. This is
pretty inefficient. Add a mtev_uuid_copy function that just does a
memcpy.

Also - add a mtev_uuid.h header to allow just including that to get all
of the mtev uuid utilities.