### PR TITLE
Don't Change user_len In mtev_http_session_req_consume

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1407,8 +1407,8 @@ mtev_http_session_decompress(mtev_compress_type type, struct bchain *in,
  */
 int
 mtev_http_session_req_consume(mtev_http_session_ctx *ctx,
-                              void *buf, size_t user_len, size_t blen,
-                              int *mask) 
+                              void *buf, const size_t user_len,
+                              const size_t blen, int *mask)
 {
   struct bchain *in, *tofree;
   size_t bytes_read = 0;
@@ -1517,11 +1517,6 @@ mtev_http_session_req_consume(mtev_http_session_ctx *ctx,
           ctx->req.user_data = in = in->next;
           tofree->next = NULL;
           RELEASE_BCHAIN(tofree);
-        }
-
-        if (total_decompressed_size > 0) {
-          /* rewrite expected read size based on decompressed size */
-          user_len = MIN(user_len, total_decompressed_size);
         }
       }
 

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -178,7 +178,8 @@ API_EXPORT(mtev_boolean)
   mtev_http_session_prime_input(mtev_http_session_ctx *, const void *, size_t);
 API_EXPORT(int)
   mtev_http_session_req_consume(mtev_http_session_ctx *ctx,
-                                void *buf, size_t len, size_t blen, int *mask);
+                                void *buf, const size_t len,
+                                const size_t blen, int *mask);
 API_EXPORT(mtev_boolean)
   mtev_http_response_status_set(mtev_http_session_ctx *, int, const char *);
 API_EXPORT(mtev_boolean)


### PR DESCRIPTION
We're altering a variable that is supposed to represent the size of the
buffer passed in; we don't want to change this, as it can have nasty
size effects.