### PR TITLE
Realloc Request And Response At Next Req

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1751,6 +1751,8 @@ mtev_http_session_drive(eventer_t e, int origmask, void *closure,
   }
 
  next_req:
+  check_realloc_request(&ctx->req);
+  check_realloc_response(&ctx->res);
   if(ctx->req.complete != mtev_true) {
     int maybe_write_mask;
     mtevL(http_debug, "   -> mtev_http_complete_request(%d)\n", eventer_get_fd(e));


### PR DESCRIPTION
When we hit the "next_req" flag, we need to realloc the request and
response. Otherwise, we could end up allocating data into a structure
flagged "freed", leading to memory leaks.