### PR TITLE
Add event contexts and a zipkin layer for them.

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -112,6 +112,40 @@ typedef struct _event
 #endif
 *eventer_t;
 
+typedef struct eventer_context_opset_t {
+  eventer_t (*eventer_t_init)(eventer_t);
+  void (*eventer_t_deinit)(eventer_t);
+  void (*eventer_t_copy)(eventer_t, const eventer_t);
+  void (*eventer_t_callback_prep)(eventer_t, int, void *, struct timeval *);
+  void (*eventer_t_callback_cleanup)(eventer_t, int);
+} eventer_context_opset_t;
+
+/*! \fn int eventer_register_context(const char *name, eventer_context_opset_t *opset)
+    \brief Register an eventer carry context.
+    \param name a string naming the context class.
+    \param opset an opset for context maintenance
+    \return A `ctx_idx`, -1 on failure.
+*/
+int eventer_register_context(const char *name,
+                             eventer_context_opset_t *opset);
+
+/*! \fn int eventer_get_context(eventer_t e, int ctx_idx)
+    \brief Get a context for an event.
+    \param e an event object
+    \param ctx_idx is an idx returned from `eventer_register_context`
+    \return The attached context.
+*/
+void *eventer_get_context(eventer_t e, int ctx_idx);
+
+/*! \fn void *eventer_set_context(eventer_t e, int ctx_idx, void *data)
+    \brief Set a context for an event.
+    \param e an event object
+    \param ctx_idx is an idx returned from `eventer_register_context`
+    \param data is new context data.
+    \return The previously attached context.
+*/
+void *eventer_set_context(eventer_t e, int ctx_idx, void *);
+
 typedef struct eventer_pool_t eventer_pool_t;
 
 /*! \fn eventer_fd_accept_t eventer_fd_opset_get_accept(eventer_fd_opset_t opset)
@@ -955,6 +989,12 @@ API_EXPORT(int) eventer_thread_check(eventer_t);
     This function will remove the event from the eventer and set the socket into blocking mode.
 */
 API_EXPORT(void) eventer_run_in_thread(eventer_t, int mask);
+
+/*! \fn eventer_t eventer_get_this_event(void)
+    \brief Get the eventer_t (if any) of which we are currently in the callback.
+    \return An eventer_t or NULL.
+*/
+API_EXPORT(eventer_t) eventer_get_this_event(void);
 
 /* Private */
 API_EXPORT(int) eventer_impl_init(void);

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -349,7 +349,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
   mtev_memory_begin();
   LIBMTEV_EVENTER_CALLBACK_ENTRY((void *)e, (void *)e->callback, (char *)cbname, fd, e->mask, mask);
   start = mtev_gethrtime();
-  newmask = e->callback(e, mask, e->closure, &__now);
+  newmask = eventer_run_callback(e, mask, e->closure, &__now);
   duration = mtev_gethrtime() - start;
   LIBMTEV_EVENTER_CALLBACK_RETURN((void *)e, (void *)e->callback, (char *)cbname, newmask);
   mtev_memory_end();

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -379,8 +379,10 @@ eventer_jobq_execute_timeout(eventer_t e, int mask, void *closure,
                                  my_precious->fd, my_precious->mask,
                                  EVENTER_ASYNCH_CLEANUP);
           start = mtev_gethrtime();
-          my_precious->callback(my_precious, EVENTER_ASYNCH_CLEANUP,
-                                my_precious->closure, &job->finish_time);
+          eventer_set_this_event(my_precious);
+          eventer_run_callback(my_precious, EVENTER_ASYNCH_CLEANUP,
+                       my_precious->closure, &job->finish_time);
+          eventer_set_this_event(NULL);
           duration = mtev_gethrtime() - start;
           LIBMTEV_EVENTER_CALLBACK_RETURN((void *)my_precious, (void *)my_precious->callback, NULL, -1);
           stats_set_hist_intscale(eventer_callback_latency, duration, -9, 1);
@@ -424,8 +426,8 @@ eventer_jobq_consume_available(eventer_t e, int mask, void *closure,
                              job->fd_event->mask);
       start = mtev_gethrtime();
       mtevL(eventer_deb, "jobq %p running job [%p]\n", jobq, job);
-      newmask = job->fd_event->callback(job->fd_event, job->fd_event->mask,
-                                        job->fd_event->closure, now);
+      newmask = eventer_run_callback(job->fd_event, job->fd_event->mask,
+                             job->fd_event->closure, now);
       duration = mtev_gethrtime() - start;
       LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                               (void *)job->fd_event->callback, NULL, newmask);
@@ -548,8 +550,8 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
                              job->fd_event->fd, job->fd_event->mask,
                              EVENTER_ASYNCH_CLEANUP);
       start = mtev_gethrtime();
-      job->fd_event->callback(job->fd_event, EVENTER_ASYNCH_CLEANUP,
-                              job->fd_event->closure, &job->finish_time);
+      eventer_run_callback(job->fd_event, EVENTER_ASYNCH_CLEANUP,
+                   job->fd_event->closure, &job->finish_time);
       duration = mtev_gethrtime() - start;
       LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                               (void *)job->fd_event->callback, NULL, -1);
@@ -603,8 +605,8 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
                                  job->fd_event->fd, job->fd_event->mask,
                                  EVENTER_ASYNCH_WORK);
           start = mtev_gethrtime();
-          job->fd_event->callback(job->fd_event, EVENTER_ASYNCH_WORK,
-                                  job->fd_event->closure, &start_time);
+          eventer_run_callback(job->fd_event, EVENTER_ASYNCH_WORK,
+                       job->fd_event->closure, &start_time);
           duration = mtev_gethrtime() - start;
           LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                                   (void *)job->fd_event->callback, NULL, -1);
@@ -646,8 +648,8 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
                                job->fd_event->fd, job->fd_event->mask,
                                EVENTER_ASYNCH_CLEANUP);
         start = mtev_gethrtime();
-        job->fd_event->callback(job->fd_event, EVENTER_ASYNCH_CLEANUP,
-                                job->fd_event->closure, &job->finish_time);
+        eventer_run_callback(job->fd_event, EVENTER_ASYNCH_CLEANUP,
+                     job->fd_event->closure, &job->finish_time);
         duration = mtev_gethrtime() - start;
         LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                                 (void *)job->fd_event->callback, NULL, -1);

--- a/src/eventer/eventer_kqueue_impl.c
+++ b/src/eventer/eventer_kqueue_impl.c
@@ -357,7 +357,7 @@ static void eventer_kqueue_impl_trigger(eventer_t e, int mask) {
   mtev_memory_begin();
   LIBMTEV_EVENTER_CALLBACK_ENTRY((void *)e, (void *)e->callback, (char *)cbname, fd, e->mask, mask);
   start = mtev_gethrtime();
-  newmask = e->callback(e, mask, e->closure, &__now);
+  newmask = eventer_run_callback(e, mask, e->closure, &__now);
   duration = mtev_gethrtime() - start;
   LIBMTEV_EVENTER_CALLBACK_RETURN((void *)e, (void *)e->callback, (char *)cbname, newmask);
   mtev_memory_end();

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -280,7 +280,7 @@ eventer_ports_impl_trigger(eventer_t e, int mask) {
   mtev_memory_begin();
   LIBMTEV_EVENTER_CALLBACK_ENTRY((void *)e, (void *)e->callback, (char *)cbname, fd, e->mask, mask);
   start = mtev_gethrtime();
-  newmask = e->callback(e, mask, e->closure, &__now);
+  newmask = eventer_run_callback(e, mask, e->closure, &__now);
   duration = mtev_gethrtime() - start;
   LIBMTEV_EVENTER_CALLBACK_RETURN((void *)e, (void *)e->callback, (char *)cbname, newmask);
   mtev_memory_end();

--- a/src/utils/mtev_zipkin_curl.h
+++ b/src/utils/mtev_zipkin_curl.h
@@ -36,12 +36,50 @@
 #include <curl/curl.h>
 
 static inline struct curl_slist *
-mtev_zipkin_inst_curl_headers(struct curl_slist *inheaders) {
+mtev_zipkin_inst_curl_headers_name(struct curl_slist *inheaders,
+                                   const char *uri) {
+  char name[1024];
+  char hdr[128];
+  snprintf(name, sizeof(name), "curl: %s", uri);
+  mtev_zipkin_client_new(NULL, name, true);
+  if(mtev_zipkin_client_trace_hdr(NULL, hdr, sizeof(hdr))) {
+    inheaders = curl_slist_append(inheaders, hdr);
+    inheaders = curl_slist_append(inheaders, HEADER_ZIPKIN_SAMPLED ": 1");
+  }
+  if(mtev_zipkin_client_parent_hdr(NULL, hdr, sizeof(hdr)))
+    inheaders = curl_slist_append(inheaders, hdr);
+  if(mtev_zipkin_client_span_hdr(NULL, hdr, sizeof(hdr)))
+    inheaders = curl_slist_append(inheaders, hdr);
   return inheaders;
+}
+static inline struct curl_slist *
+mtev_zipkin_inst_curl_headers(struct curl_slist *inheaders) {
+  static const char *curl_name = "request";
+  return mtev_zipkin_inst_curl_headers_name(inheaders, curl_name);
 }
 
 static inline CURLcode mtev_zipkin_curl_easy_perform(CURL *curl) {
-  return curl_easy_perform(curl);
+  static const char *zipkin_http_uri = "http.uri";
+  static const char *zipkin_http_status = "http.status_code";
+  Zipkin_Span *span = mtev_zipkin_client_span(NULL);
+  CURLcode rv;
+
+  if(!span) return curl_easy_perform(curl);
+ 
+  long httpcode = 0;
+  char *url = NULL;
+
+  mtev_zipkin_span_annotate(span, NULL, ZIPKIN_CLIENT_SEND, false);
+  rv = curl_easy_perform(curl);
+  if(CURLE_OK == curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpcode)) {
+    mtev_zipkin_span_bannotate_i32(span, zipkin_http_status, false, httpcode);
+  }
+  if(CURLE_OK == curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url) && url) {
+    mtev_zipkin_span_bannotate_str(span, zipkin_http_uri, false, url, true);
+  }
+  mtev_zipkin_span_annotate(span, NULL, ZIPKIN_CLIENT_RECV, false);
+  mtev_zipkin_client_publish(NULL);
+  return rv;
 }
 
 #endif


### PR DESCRIPTION
 * Allow external components to register eventer contexts that
   provide contextural data and ghosting of eventer creation,
   copying, deallocation, and callback invocation.

 * Provide a TLS that represents the event currently in callback.

 * Add a zipkin event context layer and connect it to the HTTP
   server such that inbould requests attach spans to the connection
   if a span exists and have that span persisted forward through
   causally created events.

 * Provide a zipkin event context client span managment API and
   provide mtev_zipkin_curl.h as a sample client wrapper.