### PR TITLE
Stop abusing "sampled" to force downstream traces.

### DIFF
--- a/src/utils/mtev_zipkin.h
+++ b/src/utils/mtev_zipkin.h
@@ -379,6 +379,15 @@ API_EXPORT(void) mtev_zipkin_client_new(eventer_t e, const char *, bool);
 */
 API_EXPORT(Zipkin_Span *) mtev_zipkin_client_span(eventer_t e);
 
+/*! \fn bool mtev_zipkin_client_sampled_hdr(eventer_t e, char *buf, size_t len)
+    \brief Format a sampled HTTP header for an HTTP request.
+    \param e An event object (or NULL for the current event)
+    \param buf An output buffer for "Header: Value"
+    \param len The available space in `buf`
+    \return True if successful, false if no trace is available of len is too short.
+*/
+API_EXPORT(bool) mtev_zipkin_client_sampled_hdr(eventer_t e, char *, size_t);
+
 /*! \fn bool mtev_zipkin_client_trace_hdr(eventer_t e, char *buf, size_t len)
     \brief Format a trace HTTP header for an HTTP request.
     \param e An event object (or NULL for the current event)

--- a/src/utils/mtev_zipkin_curl.h
+++ b/src/utils/mtev_zipkin_curl.h
@@ -42,13 +42,13 @@ mtev_zipkin_inst_curl_headers_name(struct curl_slist *inheaders,
   char hdr[128];
   snprintf(name, sizeof(name), "curl: %s", uri);
   mtev_zipkin_client_new(NULL, name, true);
-  if(mtev_zipkin_client_trace_hdr(NULL, hdr, sizeof(hdr))) {
+  if(mtev_zipkin_client_trace_hdr(NULL, hdr, sizeof(hdr)))
     inheaders = curl_slist_append(inheaders, hdr);
-    inheaders = curl_slist_append(inheaders, HEADER_ZIPKIN_SAMPLED ": 1");
-  }
   if(mtev_zipkin_client_parent_hdr(NULL, hdr, sizeof(hdr)))
     inheaders = curl_slist_append(inheaders, hdr);
   if(mtev_zipkin_client_span_hdr(NULL, hdr, sizeof(hdr)))
+    inheaders = curl_slist_append(inheaders, hdr);
+  if(mtev_zipkin_client_sampled_hdr(NULL, hdr, sizeof(hdr)))
     inheaders = curl_slist_append(inheaders, hdr);
   return inheaders;
 }


### PR DESCRIPTION
Sampled in, sampled out.  Otherwise, respect the probabilities configured.