### PR TITLE
mtev_flow_regulator will not return DISABLE instruction on ACK.

### DIFF
--- a/src/utils/mtev_flow_regulator.c
+++ b/src/utils/mtev_flow_regulator.c
@@ -43,8 +43,9 @@ mtev_flow_regulator_adjust_up(mtev_flow_regulator_t *fr, unsigned int adjustment
   do {
     old_val = ck_pr_load_uint(&fr->cur);
     if (old_val == fr->high) {
-      if (ck_pr_cas_uint(&fr->state, MTEV_FLOW_REGULATOR_STATE_ENABLED,
-                        MTEV_FLOW_REGULATOR_STATE_DISABLING))
+      if (adjustment > 0 &&
+          ck_pr_cas_uint(&fr->state, MTEV_FLOW_REGULATOR_STATE_ENABLED,
+                         MTEV_FLOW_REGULATOR_STATE_DISABLING))
         return MTEV_FLOW_REGULATOR_TOGGLE_DISABLE;
       else
         return MTEV_FLOW_REGULATOR_TOGGLE_DISABLED;

--- a/src/utils/mtev_flow_regulator.h
+++ b/src/utils/mtev_flow_regulator.h
@@ -128,11 +128,14 @@ mtev_flow_regulator_toggle_t mtev_flow_regulator_lower(mtev_flow_regulator_t *fr
 
     * `MTEV_FLOW_REGULATOR_TOGGLE_DISABLED`: Flow control is currently
       disabled. No client action necessary.
-    * `MTEV_FLOW_REGULATOR_TOGGLE_DISABLE`: Flow control _was_ enabled,
-      and we've started transitioning to DISABLED. (The transition to
-      DISABLED is not complete until the client calls
-      `mtev_flow_regulator_ack`, again.) Client MAY try to prevent
-      generating new work before calling `mtev_flow_regulator_ack`, again.
+    * `MTEV_FLOW_REGULATOR_TOGGLE_DISABLE`: Flow control _was_
+      enabled, and we've started transitioning to DISABLED. (The
+      transition to DISABLED is not complete until the client calls
+      `mtev_flow_regulator_ack`.) Client MAY try to prevent generating
+      new work before calling `mtev_flow_regulator_ack`. Note:
+      `mtev_flow_regulator_ack` WILL NOT return `DISABLE`, this
+      toggle-instruction will only ever be returned by
+      `mtev_flow_regulator_raise_one`.
     * `MTEV_FLOW_REGULATOR_TOGGLE_KEEP`: No client action required.
     * `MTEV_FLOW_REGULATOR_TOGGLE_ENABLE`: Flow control _was_ disabled,
       and has just started transitioning to ENABLED. (The transition to


### PR DESCRIPTION
This means that the only time we'll return DISABLE is when trying
to add work, via `mtev_flow_regulator_raise_one`.