### PR TITLE
Fix typedef that collides with curl namespace

### DIFF
--- a/src/examples/echo_client.c
+++ b/src/examples/echo_client.c
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
   CURL *curl = curl_easy_init();
   struct curl_slist *list = NULL;
 
-  mtev_decompress_curl_helper_t *data_helper = mtev_decompress_create_curl_helper((curl_write_callback)process_response, &data, MTEV_COMPRESS_LZ4F);
+  mtev_decompress_curl_helper_t *data_helper = mtev_decompress_create_curl_helper((mtev_curl_write_func_t)process_response, &data, MTEV_COMPRESS_LZ4F);
 
 
   curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 0);

--- a/src/utils/mtev_compress.c
+++ b/src/utils/mtev_compress.c
@@ -28,7 +28,7 @@ struct mtev_stream_decompress_ctx
 
 struct mtev_decompress_curl_helper
 {
-  curl_write_callback write_function;
+  mtev_curl_write_func_t write_function;
   void *write_closure;
   mtev_stream_decompress_ctx_t decompress_ctx;
 };
@@ -573,7 +573,7 @@ mtev_stream_decompress_finish(mtev_stream_decompress_ctx_t *ctx)
 }
 
 mtev_decompress_curl_helper_t *
-mtev_decompress_create_curl_helper(curl_write_callback write_function, void *closure, mtev_compress_type type)
+mtev_decompress_create_curl_helper(mtev_curl_write_func_t write_function, void *closure, mtev_compress_type type)
 {
   mtev_decompress_curl_helper_t *ch = malloc(sizeof(mtev_decompress_curl_helper_t));
   ch->write_function = write_function;

--- a/src/utils/mtev_compress.h
+++ b/src/utils/mtev_compress.h
@@ -41,7 +41,7 @@ typedef enum {
   MTEV_COMPRESS_DEFLATE
 } mtev_compress_type;
 
-typedef size_t (*curl_write_callback)(char *ptr, size_t size, size_t nmemb, void *userdata);
+typedef size_t (*mtev_curl_write_func_t)(char *ptr, size_t size, size_t nmemb, void *userdata);
 typedef struct mtev_stream_compress_ctx mtev_stream_compress_ctx_t;
 typedef struct mtev_stream_decompress_ctx mtev_stream_decompress_ctx_t;
 typedef struct mtev_decompress_curl_helper mtev_decompress_curl_helper_t;
@@ -207,7 +207,7 @@ API_EXPORT(int)
   mtev_stream_decompress_finish(mtev_stream_decompress_ctx_t *ctx);
 
 API_EXPORT(mtev_decompress_curl_helper_t *)
-mtev_decompress_create_curl_helper(curl_write_callback write_function, void *closure, mtev_compress_type type);
+mtev_decompress_create_curl_helper(mtev_curl_write_func_t write_function, void *closure, mtev_compress_type type);
 
 API_EXPORT(void)
   mtev_decompress_destroy_curl_helper(mtev_decompress_curl_helper_t *ch);


### PR DESCRIPTION
Recent libcurl now defines `curl_write_callback` so we should avoid using that name.