### PR TITLE
Add thread-safety to mtev_conf.

### DIFF
--- a/src/luamtev.c
+++ b/src/luamtev.c
@@ -231,11 +231,14 @@ child_main(void) {
   }
 
   /* update the lua module */
-  section = mtev_conf_get_section(NULL, "/cli/modules/generic[@name=\"lua_general\"]/config");
-  if(!section || !mtev_conf_set_string(section, "lua_module", lua_file)) {
+  section = mtev_conf_get_section(MTEV_CONF_ROOT, "/cli/modules/generic[@name=\"lua_general\"]/config");
+  if(mtev_conf_section_is_empty(section) ||
+     !mtev_conf_set_string(section, "lua_module", lua_file)) {
     mtevL(mtev_stderr, "Cannot set target lua module, invalid config.\n");
+    mtev_conf_release_section(section);
     exit(2);
   }
+  mtev_conf_release_section(section);
 
   eventer_init();
   mtev_dso_init();

--- a/src/modules/mtev_amqp.c
+++ b/src/modules/mtev_amqp.c
@@ -106,13 +106,13 @@ struct amqp_module_config {
     ck_fifo_spsc_t outbound, inbound;
     struct connection_configs *config;
     char *host;
-    int   port;
+    int32_t port;
     char *user;
     char *pass;
     char *vhost;
     char *exchange;
     char *bindingkey;
-    int   framesize;
+    int32_t framesize;
   } *amqp_conns;
   int number_of_conns;
 };
@@ -358,11 +358,11 @@ rabbitmq_manage_connection(void *vconn) {
 
 static int
 init_conns(void) {
-  mtev_conf_section_t *mqs = mtev_conf_get_sections(NULL, CONFIG_AMQP_IN_MQ,
+  mtev_conf_section_t *mqs = mtev_conf_get_sections(MTEV_CONF_ROOT, CONFIG_AMQP_IN_MQ,
       &the_conf->number_of_conns);
 
   if(the_conf->number_of_conns == 0) {
-    free(mqs);
+    mtev_conf_release_sections(mqs, the_conf->number_of_conns);
     return 0;
   }
 
@@ -380,9 +380,9 @@ init_conns(void) {
       cc->host = strdup("localhost");
     if(!mtev_conf_get_string(mqs[section_id], CONFIG_AMQP_VHOST, &cc->vhost))
       cc->vhost = strdup("/");
-    if(!mtev_conf_get_int(mqs[section_id], CONFIG_AMQP_PORT, &cc->port))
+    if(!mtev_conf_get_int32(mqs[section_id], CONFIG_AMQP_PORT, &cc->port))
       cc->port = 5672;
-    if(!mtev_conf_get_int(mqs[section_id], CONFIG_AMQP_FRAMESIZE, &cc->framesize))
+    if(!mtev_conf_get_int32(mqs[section_id], CONFIG_AMQP_FRAMESIZE, &cc->framesize))
       cc->framesize = AMQP_DEFAULT_FRAME_SIZE;
     if(!mtev_conf_get_string(mqs[section_id], CONFIG_AMQP_USER, &cc->user))
       cc->user = strdup("guest");
@@ -398,11 +398,11 @@ init_conns(void) {
       goto bail;
     }
   }
-  free(mqs);
+  mtev_conf_release_sections(mqs, the_conf->number_of_conns);
   return 0;
 
  bail:
-  free(mqs);
+  mtev_conf_release_sections(mqs, the_conf->number_of_conns);
   return -1;
 }
 

--- a/src/modules/mtev_fq.c
+++ b/src/modules/mtev_fq.c
@@ -53,7 +53,7 @@ MTEV_HOOK_IMPL(mtev_fq_handle_message_dyn,
 
 typedef struct connection_configs {
   char* host;
-  int port;
+  int32_t port;
   char* user;
   char* pass;
 } connection_configs;
@@ -192,8 +192,8 @@ static connection_configs *check_connection_conf(mtev_conf_section_t section) {
       mtev_conf_default_string("localhost"));
   mtev_conf_get_value(&desc, &configs_table->host);
 
-  desc = mtev_conf_description_int(section, CONFIG_FQ_PORT,
-      "Port number of the fq broker", mtev_conf_default_int(8765));
+  desc = mtev_conf_description_int32(section, CONFIG_FQ_PORT,
+      "Port number of the fq broker", mtev_conf_default_int32(8765));
   mtev_conf_get_value(&desc, &configs_table->port);
 
   desc = mtev_conf_description_string(section, CONFIG_FQ_USER,
@@ -212,11 +212,11 @@ static connection_configs *check_connection_conf(mtev_conf_section_t section) {
 
 static void
 init_conns(void) {
-  mtev_conf_section_t *mqs = mtev_conf_get_sections(NULL, CONFIG_FQ_IN_MQ,
+  mtev_conf_section_t *mqs = mtev_conf_get_sections(MTEV_CONF_ROOT, CONFIG_FQ_IN_MQ,
       &the_conf->number_of_conns);
 
   if(the_conf->number_of_conns == 0) {
-    free(mqs);
+    mtev_conf_release_sections(mqs, the_conf->number_of_conns);
     return;
   }
 
@@ -234,7 +234,7 @@ init_conns(void) {
     free(exchange);
     free(program);
   }
-  free(mqs);
+  mtev_conf_release_sections(mqs, the_conf->number_of_conns);
 }
 
 /* Do not mtevL in these functions, as they may implement mtevL */

--- a/src/mtev_conf.h
+++ b/src/mtev_conf.h
@@ -42,7 +42,11 @@
 #include <uuid/uuid.h>
 #include <pcre.h>
 
-typedef void * mtev_conf_section_t;
+typedef struct mtev_conf_section {
+  void *opaque1;
+  void *opaque2;
+} mtev_conf_section_t;
+
 API_EXPORT(mtev_conf_section_t) MTEV_CONF_ROOT;
 API_EXPORT(mtev_conf_section_t) MTEV_CONF_EMPTY;
 
@@ -78,7 +82,7 @@ typedef struct {
 
 enum mtev_conf_type {
   MTEV_CONF_TYPE_BOOLEAN,
-  MTEV_CONF_TYPE_INT,
+  MTEV_CONF_TYPE_INT32,
   MTEV_CONF_TYPE_INT64,
   MTEV_CONF_TYPE_FLOAT,
   MTEV_CONF_TYPE_DOUBLE,
@@ -88,7 +92,7 @@ enum mtev_conf_type {
 
 typedef union mtev_conf_value_t {
   mtev_boolean val_bool;
-  int val_int;
+  int32_t val_int32;
   int64_t val_int64;
   float val_float;
   double val_double;
@@ -136,7 +140,7 @@ API_EXPORT(mtev_conf_default_or_optional_t) \
   mtev_conf_default_##name (type default_value);
 
 mtev_conf_default_hdr(boolean, int)
-mtev_conf_default_hdr(int, int)
+mtev_conf_default_hdr(int32, int32_t)
 mtev_conf_default_hdr(int64, int64_t)
 mtev_conf_default_hdr(float, float)
 mtev_conf_default_hdr(double, double)
@@ -153,7 +157,7 @@ extern mtev_conf_description_t \
     char* description, mtev_conf_default_or_optional_t default_or_optional);
 
 mtev_conf_description_hdr(boolean, int)
-mtev_conf_description_hdr(int, int)
+mtev_conf_description_hdr(int32, int32_t)
 mtev_conf_description_hdr(int64, int64_t)
 mtev_conf_description_hdr(float, float)
 mtev_conf_description_hdr(double, double)
@@ -170,9 +174,22 @@ API_EXPORT(void) mtev_console_conf_init(void);
 
 API_EXPORT(mtev_conf_section_t)
   mtev_conf_get_section(mtev_conf_section_t section, const char *path);
+API_EXPORT(void)
+  mtev_conf_release_section(mtev_conf_section_t section);
 API_EXPORT(mtev_conf_section_t *)
   mtev_conf_get_sections(mtev_conf_section_t section, const char *path,
                          int *cnt);
+API_EXPORT(void)
+  mtev_conf_release_sections(mtev_conf_section_t *sections, int cnt);
+
+struct _xmlNode;
+API_EXPORT(mtev_conf_section_t)
+  mtev_conf_section_from_xmlnodeptr(struct _xmlNode *node);
+API_EXPORT(struct _xmlNode *)
+  mtev_conf_section_to_xmlnodeptr(mtev_conf_section_t section);
+API_EXPORT(mtev_boolean)
+  mtev_conf_section_is_empty(mtev_conf_section_t section);
+
 API_EXPORT(int)
   mtev_conf_remove_section(mtev_conf_section_t section);
 
@@ -183,18 +200,18 @@ API_EXPORT(mtev_hash_table *)
                                 const char *path, const char *ns);
 
 API_EXPORT(char*)
-mtev_conf_section_to_xpath(mtev_conf_section_t* section);
+  mtev_conf_section_to_xpath(mtev_conf_section_t section);
 
 API_EXPORT(int) mtev_conf_get_string(mtev_conf_section_t section,
                                      const char *path, char **value);
 
 API_EXPORT(int) mtev_conf_get_stringbuf(mtev_conf_section_t section,
                                         const char *path, char *value, int len);
-API_EXPORT(int) mtev_conf_get_int(mtev_conf_section_t section,
-                                  const char *path, int *value);
+API_EXPORT(int) mtev_conf_get_int32(mtev_conf_section_t section,
+                                  const char *path, int32_t *value);
 API_EXPORT(int) mtev_conf_get_int64(mtev_conf_section_t section,
                                     const char *path, int64_t *value);
-API_EXPORT(int) mtev_conf_string_to_int(const char *str);
+API_EXPORT(int32_t) mtev_conf_string_to_int32(const char *str);
 API_EXPORT(int) mtev_conf_get_float(mtev_conf_section_t section,
                                     const char *path, float *value);
 API_EXPORT(float) mtev_conf_string_to_float(const char *str);
@@ -218,8 +235,8 @@ API_EXPORT(int)
 
 API_EXPORT(int) mtev_conf_set_string(mtev_conf_section_t section,
                                      const char *path, const char *value);
-API_EXPORT(int) mtev_conf_set_int(mtev_conf_section_t section,
-                                  const char *path, int value);
+API_EXPORT(int) mtev_conf_set_int32(mtev_conf_section_t section,
+                                    const char *path, int32_t value);
 API_EXPORT(int) mtev_conf_set_float(mtev_conf_section_t section,
                                     const char *path, float value);
 API_EXPORT(int) mtev_conf_set_double(mtev_conf_section_t section,
@@ -326,17 +343,5 @@ MTEV_HOOK_PROTO(mtev_conf_delete_section,
                 void *, closure,
                 (void *closure, const char *root, const char *path,
                  const char *name, const char **err));
-
-
-/* COMPAT for future */
-#define mtev_conf_get_int32 mtev_conf_get_int
-#define mtev_conf_string_to_int32 mtev_conf_string_to_int
-#define mtev_conf_section_is_empty(a) (!(a))
-static inline void mtev_conf_release_section(mtev_conf_section_t a) {}
-static inline void mtev_conf_release_sections(mtev_conf_section_t *a, int c) {
-  free(a);
-}
-#define mtev_conf_section_to_xmlnodeptr(a) ((xmlNodePtr)(a))
-#define mtev_conf_section_from_xmlnodeptr(a) ((mtev_conf_section_t)(a))
 
 #endif

--- a/src/mtev_dso.c
+++ b/src/mtev_dso.c
@@ -148,7 +148,7 @@ int mtev_load_image(const char *file, const char *name,
   }
   else {
     char *basepath, *base, *brk;
-    if(!mtev_conf_get_string(NULL, "//modules/@directory", &basepath))
+    if(!mtev_conf_get_string(MTEV_CONF_ROOT, "//modules/@directory", &basepath))
       basepath = strdup("");
     for (base = strtok_r(basepath, ";:", &brk);
          base;
@@ -266,7 +266,7 @@ void mtev_dso_init(void) {
   mtev_dso_add_type("generic", mtev_dso_list_generics);
 
   /* Load our generic modules */
-  sections = mtev_conf_get_sections(NULL, "//modules//generic", &cnt);
+  sections = mtev_conf_get_sections(MTEV_CONF_ROOT, "//modules//generic", &cnt);
   for(i=0; i<cnt; i++) {
     char g_name[256];
     mtev_dso_generic_t *gen;
@@ -302,6 +302,7 @@ void mtev_dso_init(void) {
       else {
         config = mtev_conf_get_hash(sections[i], "config");
       }
+      mtev_conf_release_sections(include_sections, section_cnt);
       rv = gen->config(gen, config);
       if(rv == 0) {
         mtev_hash_destroy(config, free, free);
@@ -319,9 +320,9 @@ void mtev_dso_init(void) {
     else
       mtevL(mtev_debug, "Generic module %s successfully loaded.\n", g_name);
   }
-  if(sections) free(sections);
+  mtev_conf_release_sections(sections, cnt);
   /* Load our module loaders */
-  sections = mtev_conf_get_sections(NULL, "//modules//loader", &cnt);
+  sections = mtev_conf_get_sections(MTEV_CONF_ROOT, "//modules//loader", &cnt);
   for(i=0; i<cnt; i++) {
     char loader_name[256];
     mtev_dso_loader_t *loader;
@@ -357,6 +358,7 @@ void mtev_dso_init(void) {
       else {
         config = mtev_conf_get_hash(sections[i], "config");
       }
+      mtev_conf_release_sections(include_sections, section_cnt);
       rv = loader->config(loader, config);
       if(rv == 0) {
         mtev_hash_destroy(config, free, free);
@@ -371,7 +373,7 @@ void mtev_dso_init(void) {
     if(loader->init && loader->init(loader))
       mtevL(mtev_stderr, "Failed to init loader %s\n", loader_name);
   }
-  if(sections) free(sections);
+  mtev_conf_release_sections(sections, cnt);
 }
 
 void mtev_dso_post_init(void) {

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -458,14 +458,14 @@ mtev_listener_reconfig(const char *toplevel) {
 
   snprintf(path, sizeof(path), "/%s/listeners//listener|/%s/include/listeners//listener",
            toplevel ? toplevel : "*", toplevel ? toplevel : "*");
-  listener_configs = mtev_conf_get_sections(NULL, path, &cnt);
+  listener_configs = mtev_conf_get_sections(MTEV_CONF_ROOT, path, &cnt);
   mtevL(mtev_debug, "Found %d %s stanzas\n", cnt, path);
   for(i=0; i<cnt; i++) {
     char address[256];
     char type[256];
     unsigned short port;
-    int portint;
-    int backlog;
+    int32_t portint;
+    int32_t backlog;
     eventer_func_t f;
     mtev_boolean ssl, fanout = mtev_false, in_own_thread = mtev_false;
     eventer_pool_t *pool = NULL;
@@ -490,8 +490,8 @@ mtev_listener_reconfig(const char *toplevel) {
       address[0] = '*';
       address[1] = '\0';
     }
-    if(!mtev_conf_get_int(listener_configs[i],
-                          "ancestor-or-self::node()/@port", &portint))
+    if(!mtev_conf_get_int32(listener_configs[i],
+                            "ancestor-or-self::node()/@port", &portint))
       portint = 0;
     port = (unsigned short) portint;
     if(address[0] != '/' && (portint == 0 || (port != portint))) {
@@ -514,8 +514,8 @@ mtev_listener_reconfig(const char *toplevel) {
         mtevL(mtev_error, "Operator forced skipping listener %s\n", address);
       continue;
     }
-    if(!mtev_conf_get_int(listener_configs[i],
-                          "ancestor-or-self::node()/@backlog", &backlog))
+    if(!mtev_conf_get_int32(listener_configs[i],
+                            "ancestor-or-self::node()/@backlog", &backlog))
       backlog = 5;
 
     if(!mtev_conf_get_boolean(listener_configs[i],
@@ -557,7 +557,7 @@ mtev_listener_reconfig(const char *toplevel) {
       free(sslconfig);
     }
   }
-  free(listener_configs);
+  mtev_conf_release_sections(listener_configs, cnt);
 }
 int
 mtev_control_dispatch(eventer_t e, int mask, void *closure,

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -944,7 +944,7 @@ void mtev_http_rest_load_rules(void) {
   struct mtev_rest_acl_rule *remove_rule;
 
   snprintf(path, sizeof(path), "//rest//acl");
-  acls = mtev_conf_get_sections(NULL, path, &cnt);
+  acls = mtev_conf_get_sections(MTEV_CONF_ROOT, path, &cnt);
   mtevL(mtev_debug, "Found %d acl stanzas\n", cnt);
   for(ai = cnt-1; ai>=0; ai--) {
     char tbuff[32];
@@ -986,9 +986,9 @@ void mtev_http_rest_load_rules(void) {
       compile_re(rules[ri], newacl_rule, url);
       compile_listener_res(rules[ri], &newacl_rule->listener_res);
     }
-    free(rules);
+    mtev_conf_release_sections(rules, rcnt);
   }
-  free(acls);
+  mtev_conf_release_sections(acls, cnt);
 
   oldacls = global_rest_acls;
   global_rest_acls = newhead;

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -1523,13 +1523,13 @@ mtev_connections_from_config(mtev_hash_table *tracker, pthread_mutex_t *tracker_
   char path[256];
 
   snprintf(path, sizeof(path), "/%s/%ss//%s", toplevel ? toplevel : "*", type, type);
-  mtev_configs = mtev_conf_get_sections(NULL, path, &cnt);
+  mtev_configs = mtev_conf_get_sections(MTEV_CONF_ROOT, path, &cnt);
   mtevL(nldeb, "Found %d %s stanzas\n", cnt, path);
   for(i=0; i<cnt; i++) {
     char address[256];
     const char *expected_cn = NULL;
     unsigned short port;
-    int portint;
+    int32_t portint;
     mtev_hash_table *sslconfig, *config;
 
     if(!mtev_conf_get_stringbuf(mtev_configs[i],
@@ -1548,8 +1548,8 @@ mtev_connections_from_config(mtev_hash_table *tracker, pthread_mutex_t *tracker_
       continue;
     }
 
-    if(!mtev_conf_get_int(mtev_configs[i],
-                          "ancestor-or-self::node()/@port", &portint))
+    if(!mtev_conf_get_int32(mtev_configs[i],
+                            "ancestor-or-self::node()/@port", &portint))
       portint = 0;
     port = (unsigned short) portint;
     if(address[0] != '/' && (portint == 0 || (port != portint))) {
@@ -1574,7 +1574,7 @@ mtev_connections_from_config(mtev_hash_table *tracker, pthread_mutex_t *tracker_
     mtev_hash_destroy(config,free,free);
     free(config);
   }
-  free(mtev_configs);
+  mtev_conf_release_sections(mtev_configs, cnt);
   return found;
 }
 


### PR DESCRIPTION
This is an API/ABI breaking change.  Efforts were made to
preserve allocation model and be as load as possible on old
use.  One specific note is the need to release section(s)
fetched via mtev_conf_get_section(s).