### PR TITLE
Coverity fixes

### DIFF
--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -1447,7 +1447,6 @@ mtev_ssl_ctx_index_func(lua_State *L) {
         const char *ciphername;
         lua_newtable(L);
         while(NULL != (ciphername = eventer_ssl_get_cipher_list(ssl_ctx,i))) {
-          if(!ciphername) break;
           lua_pushnumber(L, ++i);
           lua_pushstring(L, ciphername);
           lua_settable(L,-3);
@@ -2822,10 +2821,6 @@ nl_conf_replace_value(lua_State *L) {
     mtev_conf_section_t section;
     char *element, *base;
     SPLIT_PATH(path, base, element);
-    if (!element) {
-      lua_pushboolean(L, 0);
-      return 1;
-    }
     while (NULL != (section = mtev_conf_get_section(NULL, path))) {
       mtev_conf_remove_section(section);
     }
@@ -2847,10 +2842,6 @@ nl_conf_replace_boolean(lua_State *L) {
     mtev_conf_section_t section;
     char *element, *base;
     SPLIT_PATH(path, base, element);
-    if (!element) {
-      lua_pushboolean(L, 0);
-      return 1;
-    }
     while (NULL != (section = mtev_conf_get_section(NULL, path))) {
       mtev_conf_remove_section(section);
     }
@@ -4041,7 +4032,7 @@ mtev_lua_serialize(lua_State *L, int index){
     case(LUA_TTABLE):
       data->value.table = mtev_lua_serialize_table(L, index);
       break;
-    case(LUA_TNIL): // we already returned NULL
+    //case(LUA_TNIL):  we already returned NULL
     default: 
       free(data);
       mtevL(nlerr, "Cannot serialize unsupported lua type %d\n", type);

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -4032,7 +4032,6 @@ mtev_lua_serialize(lua_State *L, int index){
     case(LUA_TTABLE):
       data->value.table = mtev_lua_serialize_table(L, index);
       break;
-    //case(LUA_TNIL):  we already returned NULL
     default: 
       free(data);
       mtevL(nlerr, "Cannot serialize unsupported lua type %d\n", type);

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -1800,7 +1800,7 @@ mtev_conf_set_string(mtev_conf_section_t section,
     mtev_conf_section_t *sections;
     sections = mtev_conf_get_sections(section, path, &cnt);
     if(cnt > 1) {
-      char *spath = section ? (char *)xmlGetNodePath(section) : strdup("(root)");
+      char *spath = (char *)xmlGetNodePath(section);
       mtevL(mtev_error, "Ambiguous set_string \"%s\" \"%s\"\n", spath, path);
       free(spath);
       return 0;

--- a/src/mtev_console_state.c
+++ b/src/mtev_console_state.c
@@ -725,7 +725,7 @@ expand_range(const char *range, char ***set, int max_count, const char **err) {
     pcre_copy_substring(range, ovector, rv, 3, buff, sizeof(buff));
     mask = atoi(buff);
     if(mask == 32) full = 1; /* host implies.. the host */
-    if(mask < 0 || mask > 32) {
+    if(mask <= 0 || mask > 32) {
       *err = "invalid netmask";
       return 0;
     }

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -1174,7 +1174,7 @@ mtev_connection_ssl_upgrade(eventer_t e, int mask, void *closure,
     const char *cert_error = eventer_ssl_get_peer_error(sslctx);
     mtevL(nlerr, "[%s] [%s] mtev_connection_ssl_upgrade: %s [%s]\n",
       nctx->remote_str ? nctx->remote_str : "(null)",
-      cn_expected ? cn_expected : "(null)", error, cert_error);
+      cn_expected, error, cert_error);
   }
   nctx->close(nctx, e);
   mtev_connection_schedule_reattempt(nctx, now);

--- a/src/noitedit/read.c
+++ b/src/noitedit/read.c
@@ -271,8 +271,6 @@ read_char(EditLine *el, char *cp)
 		else
 			num_read = read(el->el_infd, cp, 1);
 
-		if (num_read)
-			break;
 		if (num_read == -1) {
 			if (errno == EAGAIN) return 0;
 		 	if (!tried && read__fixio(el->el_infd, errno) == 0) {

--- a/src/noitedit/read.c
+++ b/src/noitedit/read.c
@@ -270,7 +270,8 @@ read_char(EditLine *el, char *cp)
 			num_read = eventer_read(el->el_in_e, cp, 1, &mask);
 		else
 			num_read = read(el->el_infd, cp, 1);
-
+                if(num_read > 0)
+                        breakl=;
 		if (num_read == -1) {
 			if (errno == EAGAIN) return 0;
 		 	if (!tried && read__fixio(el->el_infd, errno) == 0) {

--- a/src/noitedit/read.c
+++ b/src/noitedit/read.c
@@ -271,7 +271,7 @@ read_char(EditLine *el, char *cp)
 		else
 			num_read = read(el->el_infd, cp, 1);
                 if(num_read > 0)
-                        breakl=;
+                        break;
 		if (num_read == -1) {
 			if (errno == EAGAIN) return 0;
 		 	if (!tried && read__fixio(el->el_infd, errno) == 0) {

--- a/src/utils/mtev_confstr.c
+++ b/src/utils/mtev_confstr.c
@@ -293,7 +293,7 @@ mtev_confstr_parse_time_gm(const char *input, uint64_t *output)
       if(! is_valid_time(construct_tzoffs.tm_hour, construct_tzoffs.tm_min, 0))
         return MTEV_CONFSTR_PARSE_ERR_FORMAT;
       input = iter;
-      tz_offset = (construct_tzoffs.tm_hour * 60 + construct_tzoffs.tm_min) * 60;
+      tz_offset = ((int64_t) construct_tzoffs.tm_hour * 60 + construct_tzoffs.tm_min) * 60;
       if(tzchr == '-')
         tz_offset *= -1;
       break;

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -814,7 +814,6 @@ posix_logio_cull(mtev_log_stream_t ls, int age, ssize_t bytes) {
   size = MIN(size, PATH_MAX + 128);
   de = alloca(size);
 
-  if(!d) return -1;
   pathlen = strlen(filename);
   now = time(NULL);
   while(portable_readdir_r(d, de, &entry) == 0 && entry != NULL) {

--- a/src/utils/mtev_security.c
+++ b/src/utils/mtev_security.c
@@ -135,7 +135,10 @@ mtev_security_usergroup(const char *user, const char *group, mtev_boolean effect
           pwnam_buflen = safe_size * 2;
           safe_size = MAX(grnam_buflen, pwnam_buflen);
           free(mallocd);
-          buf = mallocd = malloc(safe_size);
+          if(safe_size >= 0) 
+            buf = mallocd = malloc(safe_size);
+          else
+            printf("error, safe_size cannot be less than zero\n");
           goto retry_user;
         }
         free(mallocd);

--- a/src/utils/mtev_security.c
+++ b/src/utils/mtev_security.c
@@ -135,10 +135,8 @@ mtev_security_usergroup(const char *user, const char *group, mtev_boolean effect
           pwnam_buflen = safe_size * 2;
           safe_size = MAX(grnam_buflen, pwnam_buflen);
           free(mallocd);
-          if(safe_size >= 0) 
-            buf = mallocd = malloc(safe_size);
-          else
-            printf("error, safe_size cannot be less than zero\n");
+          mtevAssert(safe_size > 0); 
+          buf = mallocd = malloc(safe_size);
           goto retry_user;
         }
         free(mallocd);


### PR DESCRIPTION
Misc fixes that were required in coverity. Most are removals of dead code. Functionality appears to have not been interrupted as gmake built correctly and all tests were successful. 