### PR TITLE
Even More Coverity Fixes

### DIFF
--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -1947,7 +1947,7 @@ mtev_conf_set_string(mtev_conf_section_t section,
     sections = mtev_conf_get_sections(section, dup, &cnt);
     mtev_conf_section_t copy;
     if(cnt > 1 || cnt == 0) {
-      char *spath = section ? (char *)xmlGetNodePath(section) : strdup("(root)");
+      char *spath = (char *)xmlGetNodePath(section);
       mtevL(mtev_error, "%s set_string \"%s\" \"%s\"\n",
             cnt ? "Ambiguous" : "Path missing", spath, dup);
       free(spath);

--- a/src/mtev_console_telnet.c
+++ b/src/mtev_console_telnet.c
@@ -124,7 +124,7 @@ int	not42 = 1;
 static void
 netflush(mtev_console_closure_t ncct) {
   int unused;
-  mtev_console_continue_sending(ncct, &unused);
+  (void) mtev_console_continue_sending(ncct, &unused);
 }
 static void set_termbuf(mtev_console_closure_t ncct);
 static void init_termbuf(mtev_console_closure_t ncct);

--- a/src/mtev_net_heartbeat.c
+++ b/src/mtev_net_heartbeat.c
@@ -111,7 +111,7 @@ mtev_net_heartbeat_handler(eventer_t e, int mask, void *closure, struct timeval 
     }
     if(len < (HDR_LENSIZE + HDR_IVSIZE)) {
       /* discard */
-      recvmsg(fd, &msg, 0);
+      (void) recvmsg(fd, &msg, 0);
       continue;
     }
     len = ntohl(netlen);
@@ -125,7 +125,7 @@ mtev_net_heartbeat_handler(eventer_t e, int mask, void *closure, struct timeval 
         free(newpayload);
         free(newtext);
         mtevL(mtev_error, "recvmsg error: payload too large %d\n", len);
-        recvmsg(fd, &msg, 0);
+        (void) recvmsg(fd, &msg, 0);
         continue;
       }
       if(payload != payload_buff) free(payload);

--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -119,7 +119,9 @@ void mtev_stacktrace(mtev_log_stream_t ls) {
     /* This is Async-Signal-Safe (at least on Illumos) */
     char tmpfilename[MAXPATHLEN];
     snprintf(tmpfilename, sizeof(tmpfilename), "/var/tmp/mtev_%d_XXXXXX", (int)getpid());
+    oldmask = umask(0600);
     _global_stack_trace_fd = mkstemp(tmpfilename);
+    umask(oldmask);
     if(_global_stack_trace_fd >= 0) unlink(tmpfilename);
   }
   if(_global_stack_trace_fd >= 0) {


### PR DESCRIPTION
Fixes for an insecure temp file, deadcode, and unchecked return values.
Couldn't fix other temp file yet due to testing errors.
**Warning** umask might break stuff due to the nature of the command.  
Merge with caution and if a problem is noticed, notify me and I will fix it.