### PR TITLE
Implement safe memory thread shutdown.

### DIFF
--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -516,6 +516,7 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
     mtevL(eventer_deb, "jobq[%s] over provisioned, backing out.",
           jobq->queue_name);
     ck_pr_dec_32(&jobq->concurrency);
+    if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_fini_thread();
     pthread_exit(NULL);
     return NULL;
   }
@@ -686,6 +687,7 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
   if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_maintenance_ex(MTEV_MM_BARRIER);
   pthread_cleanup_pop(0);
   mtevL(eventer_deb, "jobq[%s/%p] -> terminating\n", jobq->queue_name, pthread_self_ptr());
+  if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_fini_thread();
   pthread_exit(NULL);
   return NULL;
 }

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -52,10 +52,21 @@ static void *mtev_memory_gc(void *unused);
 static mtev_log_stream_t mem_debug = NULL;
 static pthread_mutex_t mem_debug_lock = PTHREAD_MUTEX_INITIALIZER;
 
+mtev_boolean mtev_memory_thread_initialized(void) {
+  return epoch_rec != NULL;
+}
+
 void mtev_memory_init_thread(void) {
   if(epoch_rec == NULL) {
     epoch_rec = malloc(sizeof(*epoch_rec));
     ck_epoch_register(&epoch_ht, epoch_rec);
+  }
+}
+
+void mtev_memory_fini_thread(void) {
+  if(epoch_rec != NULL) {
+    ck_epoch_unregister(epoch_rec);
+    epoch_rec = NULL;
   }
 }
 

--- a/src/utils/mtev_memory.h
+++ b/src/utils/mtev_memory.h
@@ -42,6 +42,8 @@ typedef enum {
 
 API_EXPORT(void) mtev_memory_init(void); /* call once at process start */
 API_EXPORT(void) mtev_memory_init_thread(void); /* at subsequent thread start */
+API_EXPORT(void) mtev_memory_fini_thread(void); /* at thread exit */
+API_EXPORT(mtev_boolean) mtev_memory_thread_initialized(void);
 API_EXPORT(void) mtev_memory_maintenance(void); /* Call to force reclamation */
 API_EXPORT(int) mtev_memory_maintenance_ex(mtev_memory_maintenance_method_t method);
 API_EXPORT(void) mtev_memory_begin(void); /* being a block */


### PR DESCRIPTION
As threads exited in jobq pool maintenance, we would leak
epoch records.  This provides an API for shutdown and uses
it in thread shutdown of jobq pools.  Additionally, an API
is provided to determine if this thread has be memory_safe
initialized.