### PR TITLE
Mtev hash iterate spmc

### DIFF
--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -374,7 +374,7 @@ int mtev_hash_set(mtev_hash_table *h, const char *k, int klen, void *data,
   ck_hash_attr_t *attr = NULL;
 
   if(h->u.hs.hf == NULL) {
-    mtevL(mtev_error, "warning: null hashtable in mtev_hash_replace... initializing\n");
+    mtevL(mtev_error, "warning: null hashtable in mtev_hash_set... initializing\n");
     mtev_stacktrace(mtev_error);
     mtev_hash_init(h);
   }
@@ -415,7 +415,7 @@ int mtev_hash_set(mtev_hash_table *h, const char *k, int klen, void *data,
       free(attr);
     }
   }
-  return 1;
+  return ret;
 }
 
 int mtev_hash_retrieve(mtev_hash_table *h, const char *k, int klen, void **data) {

--- a/src/utils/mtev_hash.h
+++ b/src/utils/mtev_hash.h
@@ -135,8 +135,17 @@ void mtev_hash_init_mtev_memory(mtev_hash_table *h, int size, mtev_hash_lock_mod
  * mtev_hash_delete(), mtev_hash_delete_all() or mtev_hash_destroy().
  * */
 int mtev_hash_store(mtev_hash_table *h, const char *k, int klen, void *data);
+/* replace and delete (call keyfree and datafree functions) anything that was 
+ * already in this hash location
+ */
 int mtev_hash_replace(mtev_hash_table *h, const char *k, int klen, void *data,
                       NoitHashFreeFunc keyfree, NoitHashFreeFunc datafree);
+
+/* replace and return the old value and old key that was in this hash location
+ */
+int mtev_hash_set(mtev_hash_table *h, const char *k, int klen, void *data,
+                  char **oldkey, void **olddata);
+
 int mtev_hash_retrieve(mtev_hash_table *h, const char *k, int klen, void **data);
 int mtev_hash_retr_str(mtev_hash_table *h, const char *k, int klen, const char **dstr);
 int mtev_hash_delete(mtev_hash_table *h, const char *k, int klen,

--- a/src/utils/mtev_hash.h
+++ b/src/utils/mtev_hash.h
@@ -117,6 +117,18 @@ void mtev_hash_init_size(mtev_hash_table *h, int size);
  */
 void mtev_hash_init_locks(mtev_hash_table *h, int size, mtev_hash_lock_mode_t lock_mode);
 
+/**
+ * Choose the lock mode when initing the hash.
+ * 
+ * It's worth noting that the lock only affects the write side of the hash,
+ * the read side remains completely lock free.
+ * 
+ * This variant will use mtev_memory ck allocator functions to allow this
+ * hash to participate in SMR via mtev_memory block.  You need to wrap 
+ * memory blocks in mtev_memory_begin()/mtev_memory_end()
+ */
+void mtev_hash_init_mtev_memory(mtev_hash_table *h, int size, mtev_hash_lock_mode_t lock_mode);
+
 /* NOTE! "k" and "data" MUST NOT be transient buffers, as the hash table
  * implementation does not duplicate them.  You provide a pair of
  * NoitHashFreeFunc functions to free up their storage when you call
@@ -152,6 +164,20 @@ void mtev_hash_merge_as_dict(mtev_hash_table *dst, mtev_hash_table *src);
      }
 */
 int mtev_hash_adv(mtev_hash_table *h, mtev_hash_iter *iter);
+
+/* This is an iterator and requires that if the hash it written to
+   during the iteration process, you must employ SMR on the hash itself
+   to prevent destruction of memory for hash resizes by using the 
+   special init function mtev_hash_init_mtev_memory.
+
+   To use:
+   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
+
+   while(mtev_hash_adv_spmc(h, &iter)) {
+   .... use iter.key.{str,ptr}, iter.klen and iter.value.{str,ptr} ....
+   }
+*/
+int mtev_hash_adv_spmc(mtev_hash_table *h, mtev_hash_iter *iter);
 
 /* These are older, more painful APIs... use mtev_hash_adv */
 /* Note that neither of these sets the key, value, or klen in iter */

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -194,7 +194,7 @@ mtev_memory_gc(void *unused) {
     ck_fifo_spsc_dequeue_lock(&gc_queue);
     while(ck_fifo_spsc_dequeue(&gc_queue, &ar)) {
 #ifdef HAVE_CK_EPOCH_SYNCHRONIZE_WAIT
-      ck_epoch_synchronize_wait(epoch_rec, mtev_memory_sync_wait, NULL);
+      ck_epoch_synchronize_wait(&epoch_ht, mtev_memory_sync_wait, NULL);
 #else
       ck_epoch_synchronize(epoch_rec);
 #endif

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -55,7 +55,7 @@ static pthread_mutex_t mem_debug_lock = PTHREAD_MUTEX_INITIALIZER;
 void mtev_memory_init_thread(void) {
   if(epoch_rec == NULL) {
     epoch_rec = malloc(sizeof(*epoch_rec));
-    ck_epoch_register(&epoch_ht, epoch_rec);
+    ck_epoch_register(&epoch_ht, epoch_rec, NULL);
   }
 }
 
@@ -110,8 +110,8 @@ void mtev_memory_maintenance(void) {
        epoch_temporary.n_peak != epoch_rec->n_peak ||
        epoch_temporary.n_dispatch != epoch_rec->n_dispatch) {
       mtevL(mem_debug,
-            "summary: [%u/%u/%u] %u pending, %u peak, %lu reclamations -> "
-              "[%u/%u/%u] %u pending, %u peak, %lu reclamations\n",
+            "summary: [%u/%u/%u] %u pending, %u peak, %u reclamations -> "
+              "[%u/%u/%u] %u pending, %u peak, %u reclamations\n",
               epoch_temporary.state, epoch_temporary.epoch,epoch_temporary.active,
               epoch_temporary.n_pending, epoch_temporary.n_peak, epoch_temporary.n_dispatch,
               epoch_rec->state, epoch_rec->epoch,epoch_rec->active,
@@ -165,8 +165,8 @@ mtev_gc_sync_complete(struct asynch_reclaim *ar) {
      epoch_temporary.n_peak != epoch_rec->n_peak ||
      epoch_temporary.n_dispatch != epoch_rec->n_dispatch) {
     mtevL(mem_debug,
-          "[%p:asynch] summary: [%u/%u/%u] %u pending, %u peak, %lu reclamations -> "
-            "[%u/%u/%u] %u pending, %u peak, %lu reclamations\n",
+          "[%p:asynch] summary: [%u/%u/%u] %u pending, %u peak, %u reclamations -> "
+            "[%u/%u/%u] %u pending, %u peak, %u reclamations\n",
             epoch_rec,
             epoch_temporary.state, epoch_temporary.epoch,epoch_temporary.active,
             epoch_temporary.n_pending, epoch_temporary.n_peak, epoch_temporary.n_dispatch,
@@ -273,8 +273,8 @@ mtev_memory_maintenance_ex(mtev_memory_maintenance_method_t method) {
        epoch_temporary.n_peak != epoch_rec->n_peak ||
        epoch_temporary.n_dispatch != epoch_rec->n_dispatch) {
       mtevL(mem_debug,
-            "[%p:%s] summary: [%u/%u/%u] %u pending, %u peak, %lu reclamations -> "
-              "[%u/%u/%u] %u pending, %u peak, %lu reclamations\n",
+            "[%p:%s] summary: [%u/%u/%u] %u pending, %u peak, %u reclamations -> "
+              "[%u/%u/%u] %u pending, %u peak, %u reclamations\n",
               epoch_rec, (method == MTEV_MM_TRY) ? "try" : "barrier",
               epoch_temporary.state, epoch_temporary.epoch,epoch_temporary.active,
               epoch_temporary.n_pending, epoch_temporary.n_peak, epoch_temporary.n_dispatch,


### PR DESCRIPTION
This relies on HEAD of concurrency kit to get `ck_hs_next_spmc`

I will leave this open until we have a libck package based on HEAD.

There is a bunch of safe memory stuff below.  

The short story is: You can use mtev_hash as SPMC going forward and iterate/get from it on the read side without locks.  Even in the face of deletes from the writer thread.  Before this merge this wasn't really safe because ck_hs did not memoize the internal map and iterations and gets could hit the old map after a resize in the write thread which could have already been freed.