### PR TITLE
mtev_memory_safe_free before thread "fini"

### DIFF
--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -121,7 +121,11 @@ eventer_set_thread_name_internal(const char *name, mtev_boolean unsafe) {
   struct thread_name *to_free = pthread_getspecific(thread_name_key);
   if(to_free != NULL) {
     char *oldname = to_free->name;
-    to_free->name = unsafe ? strdup(name) : mtev_memory_safe_strdup(name);
+    if(name) {
+      to_free->name = unsafe ? strdup(name) : mtev_memory_safe_strdup(name);
+    } else {
+      to_free->name = NULL;
+    }
     if(to_free->unsafe) free(oldname);
     else mtev_memory_safe_free(oldname);
     to_free->unsafe = unsafe;
@@ -129,7 +133,11 @@ eventer_set_thread_name_internal(const char *name, mtev_boolean unsafe) {
   else {
     to_free = calloc(1, sizeof(*to_free));
     to_free->unsafe = unsafe;
-    to_free->name = unsafe ? strdup(name) : mtev_memory_safe_strdup(name);
+    if(name) {
+      to_free->name = unsafe ? strdup(name) : mtev_memory_safe_strdup(name);
+    } else {
+      to_free->name = NULL;
+    }
     pthread_setspecific(thread_name_key, to_free);
   }
 }

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -516,7 +516,10 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
     mtevL(eventer_deb, "jobq[%s] over provisioned, backing out.",
           jobq->queue_name);
     ck_pr_dec_32(&jobq->concurrency);
-    if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_fini_thread();
+    if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) {
+      eventer_set_thread_name(NULL);
+      mtev_memory_fini_thread();
+    }
     pthread_exit(NULL);
     return NULL;
   }
@@ -687,7 +690,10 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
   if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_maintenance_ex(MTEV_MM_BARRIER);
   pthread_cleanup_pop(0);
   mtevL(eventer_deb, "jobq[%s/%p] -> terminating\n", jobq->queue_name, pthread_self_ptr());
-  if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) mtev_memory_fini_thread();
+  if(jobq->mem_safety != EVENTER_JOBQ_MS_NONE) {
+    eventer_set_thread_name(NULL);
+    mtev_memory_fini_thread();
+  }
   pthread_exit(NULL);
   return NULL;
 }


### PR DESCRIPTION
We were uninitializing the epoch system and then attmepting
to epoch free in the thread tear-down.  We need to make sure
the thread tear down doesn't do any memory safe things.  We
NULL out the thread name to account for this ordering issue.