### PR TITLE
Protect against null dereference.

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1324,13 +1324,13 @@ mtev_http_session_req_consume_read(mtev_http_session_ctx *ctx,
 
  successful_chunk_size:
   {
+    /* ensure we are looking at the first input */
+    head = ctx->req.first_input;
+    if (head == NULL) {
+      /* nothing to read */
+      return -1;
+    }
     if (next_chunk > 0) {
-      /* ensure we are looking at the first input */
-      head = ctx->req.first_input;
-      if (head == NULL) {
-        /* nothing to read */
-        return -1;
-      }
       mtevL(http_debug, " ... have chunk (%d)\n", next_chunk);
       struct bchain *data = ALLOC_BCHAIN(next_chunk);
       data->compression = compression_type;


### PR DESCRIPTION
It is possible to release the head chain (nulling it), then break to here
from the EAGAIN read state to if there is data available and wind up with
no next chunk and head unassigned.  We need to always assign head upon
entering this section of code.