### PR TITLE
Fix Memory Leak In rest_xml_payload_free Function

### DIFF
--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -655,6 +655,7 @@ rest_xml_payload_free(void *f) {
   if (xmlin) {
     if(xmlin->buffer) free(xmlin->buffer);
     if(xmlin->indoc) xmlFreeDoc(xmlin->indoc);
+    free(xmlin);
   }
 }
 


### PR DESCRIPTION
We need to free the actual object being passed into
rest_xml_payload_free, not just its components.