### PR TITLE
Fix Crashing Bug In lua_mtev.c

### DIFF
--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -137,6 +137,7 @@ static void
 nl_extended_free(void *vcl) {
   struct nl_slcl *cl = vcl;
   if(cl->inbuff) free(cl->inbuff);
+  if(cl->eptr) *cl->eptr = NULL;
   free(cl);
 }
 static void


### PR DESCRIPTION
When we free, we need to set the eptr to NULL to prevent reuse.