### PR TITLE
using umask on stacktrace is not safe.

### DIFF
--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -119,9 +119,7 @@ void mtev_stacktrace(mtev_log_stream_t ls) {
     /* This is Async-Signal-Safe (at least on Illumos) */
     char tmpfilename[MAXPATHLEN];
     snprintf(tmpfilename, sizeof(tmpfilename), "/var/tmp/mtev_%d_XXXXXX", (int)getpid());
-    int oldmask = umask(0600);
     _global_stack_trace_fd = mkstemp(tmpfilename);
-    umask(oldmask);
     if(_global_stack_trace_fd >= 0) unlink(tmpfilename);
   }
   if(_global_stack_trace_fd >= 0) {


### PR DESCRIPTION
other threads may rely on umask having an application-set value,
so that modifying it during a stack-dump can cause those other threads
to misbehave.