### PR TITLE
Fix Some Memory Leaks And Races

### DIFF
--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -62,7 +62,7 @@ mtev_lua_lmc_alloc(mtev_dso_generic_t *self, mtev_lua_resume_t resume) {
   lua_module_closure_t *lmc;
   lmc = calloc(1, sizeof(*lmc));
   lmc->pending = calloc(1, sizeof(*lmc->pending));
-  mtev_hash_init(lmc->pending);
+  mtev_hash_init_locks(lmc->pending, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
   mtev_hash_init(&lmc->state_coros);
   lmc->owner = pthread_self();
   lmc->self = self;
@@ -75,7 +75,7 @@ mtev_lua_lmc_free(lua_module_closure_t *lmc) {
   if(lmc) {
     if(lmc->lua_state) lua_close(lmc->lua_state);
     if(lmc->pending) {
-      mtev_hash_destroy(lmc->pending, free, NULL);
+      mtev_hash_destroy(lmc->pending, free, free);
       free(lmc->pending);
     }
     mtev_hash_destroy(&lmc->state_coros, NULL, NULL);

--- a/src/modules/lua_general.c
+++ b/src/modules/lua_general.c
@@ -703,7 +703,7 @@ mtev_lua_general_init(mtev_dso_generic_t *self) {
   }
 
   lmc->pending = calloc(1, sizeof(*lmc->pending));
-  mtev_hash_init(lmc->pending);
+  mtev_hash_init_locks(lmc->pending, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
 
   if(conf->booted) return true;
   conf->booted = mtev_true;

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -407,7 +407,7 @@ mtev_lua_web_setup_lmc(mtev_dso_generic_t *self) {
     lmc->resume = lua_web_resume;
     lmc->owner = pthread_self();
     lmc->pending = calloc(1, sizeof(*lmc->pending));
-    mtev_hash_init(lmc->pending);
+    mtev_hash_init_locks(lmc->pending, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
     pthread_setspecific(conf->key, lmc);
   }
   if(lmc->lua_state == NULL) {


### PR DESCRIPTION
We could potentially leak memory if mtev_hash_store calls fail, and a
cleanup function was not freeing everything it should have been. Fixed
these conditions.