### PR TITLE
Fix Leaks And Add Safety To Lua Functions

### DIFF
--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -75,7 +75,7 @@ mtev_lua_lmc_free(lua_module_closure_t *lmc) {
   if(lmc) {
     if(lmc->lua_state) lua_close(lmc->lua_state);
     if(lmc->pending) {
-      mtev_hash_destroy(lmc->pending, free, NULL);
+      mtev_hash_destroy(lmc->pending, free, free);
       free(lmc->pending);
     }
     mtev_hash_destroy(&lmc->state_coros, NULL, NULL);


### PR DESCRIPTION
* Fix a memory leak where we weren't freeing the data in a hash
* Check for failure on mtev_hash_store and if we DO fail, clean up the
  allocated memory and throw an error.