### PR TITLE
If logging was on, we attempted to annotate a span too late.

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -1937,9 +1937,9 @@ mtev_http_session_drive(eventer_t e, int origmask, void *closure,
     goto release;
   }
   if(ctx->res.complete == mtev_true) {
-    end_span(ctx);
     LIBMTEV_HTTP_RESPONSE_FINISH(CTXFD(ctx), ctx);
     mtev_http_log_request(ctx);
+    end_span(ctx);
     mtev_http_request_release(ctx);
     mtev_http_response_release(ctx);
   }

--- a/src/utils/mtev_zipkin.c
+++ b/src/utils/mtev_zipkin.c
@@ -663,6 +663,7 @@ mtev_zipkin_span_publish(Zipkin_Span *span) {
 
     zipkin_publish_hook_invoke(traceid, spanid, buffer, len);
     if(allocd) free(allocd);
+    return;
   }
   mtev_zipkin_span_drop(span);
 }


### PR DESCRIPTION
Do to a double drop in publish, we erroneously free before use.