### PR TITLE
Support GNU libc v2.24+ and GCC 7

### DIFF
--- a/src/mtev_defines.h
+++ b/src/mtev_defines.h
@@ -215,7 +215,20 @@ static inline void uuid_unparse_lower(uuid_t in, char *out) {
 #if defined(__sun) && !defined(HAVE_POSIX_READDIR_R)
 #define portable_readdir_r(a,b,c) (((*(c)) = readdir_r(a,b)) == NULL)
 #else
+/* https://lwn.net/Articles/696474/ */
+#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 24)
+#if HAVE_DIRENT_H
+#include <dirent.h>
+#endif
+static inline int portable_readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return readdir_r(dirp, entry, result);
+#pragma GCC diagnostic pop
+}
+#else
 #define portable_readdir_r readdir_r
+#endif
 #endif
 #include "noitedit/strlcpy.h"
 

--- a/src/noitedit/compat.h
+++ b/src/noitedit/compat.h
@@ -37,7 +37,7 @@
 #include "mtev_defines.h"
 
 #ifndef __RCSID
-#define  __RCSID(x) static const char rcsid[] = x
+#define  __RCSID(x) __attribute__ ((unused)) static const char rcsid[] = x;
 #endif
 #ifndef __COPYRIGHT
 #define  __COPYRIGHT(x)

--- a/src/noitedit/term.c
+++ b/src/noitedit/term.c
@@ -428,7 +428,8 @@ term_alloc(EditLine *el, const struct termcapstr *t, char *cap)
          */
 	tlen = 0;
 	for (tmp = tlist; tmp < &tlist[T_str]; tmp++)
-		if (*tmp != NULL && *tmp != '\0' && *tmp != *str) {
+		/* http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libedit/terminal.c.diff?r1=1.22&r2=1.24 */
+		if (*tmp != NULL && **tmp != '\0' && *tmp != *str) {
 			char *ptr;
 
 			for (ptr = *tmp; *ptr != '\0'; termbuf[tlen++] = *ptr++)


### PR DESCRIPTION
### These fixes are required to build `libmtev` on the latest Ubuntu:

- As of GNU `libc` version 2.24, `readdir_r()` has been deprecated. Fix by allowing deprecated calls only within the inline function `portable_readdir_r()`, so as not to remove the warning globally. These hints are also understood by Clang. (See discussion on LWN: https://lwn.net/Articles/696474/)

- GCC 7 on Linux no longer recognizes CVS `rcsid` version strings as special
- GCC 7 is now more strict on empty string checks with `char**` (Fix from NetBSD)