### PR TITLE
mtev_cluster: Make sure uuids are not null before printing

### DIFF
--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -824,6 +824,7 @@ mtev_cluster_set_self(uuid_t id) {
   }
   return 0;
 }
+
 void
 mtev_cluster_get_self(uuid_t id) {
   uuid_copy(id, my_cluster_id);
@@ -1007,7 +1008,7 @@ mtev_cluster_to_json(mtev_cluster_t *c) {
   MJ_KV(obj, "maturity", MJ_INT(c->maturity));
 
   char uuid_str[UUID_STR_LEN+1];
-  if(c->oldest_node) {
+  if(c->oldest_node && !uuid_is_null(c->oldest_node->id)) {
     uuid_unparse_lower(c->oldest_node->id, uuid_str);
     MJ_KV(obj, "oldest_node", MJ_STR(uuid_str));
   }
@@ -1050,9 +1051,11 @@ rest_show_cluster_json(mtev_http_rest_closure_t *restc, int n, char **p) {
 
   doc = MJ_OBJ();
 
-  char uuid_str[UUID_STR_LEN+1];
-  uuid_unparse_lower(my_cluster_id, uuid_str);
-  MJ_KV(doc, "my_id", MJ_STR((const char *)uuid_str));
+  if(!uuid_is_null(my_cluster_id)) {
+    char uuid_str[UUID_STR_LEN+1];
+    uuid_unparse_lower(my_cluster_id, uuid_str);
+    MJ_KV(doc, "my_id", MJ_STR((const char *)uuid_str));
+  }
 
   if(n >= 2 && strlen(p[1])) {
     mtev_cluster_t *c = mtev_cluster_by_name(p[1]);
@@ -1103,7 +1106,7 @@ mtev_cluster_to_xmlnode(mtev_cluster_t *c) {
   snprintf(maturity, sizeof(maturity), "%d", c->maturity);
   xmlSetProp(cluster, (xmlChar *)"maturity", (xmlChar *)maturity);
 
-  if(c->oldest_node) {
+  if(c->oldest_node && !uuid_is_null(c->oldest_node->id)) {
     xmlNodePtr node;
     char uuid_str[UUID_STR_LEN+1];
     uuid_unparse_lower(c->oldest_node->id, uuid_str);

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -112,11 +112,12 @@ API_EXPORT(int) mtev_cluster_size(mtev_cluster_t *);
 
     Sets the local node's cluster identity, potentially updating the on-disk configuration.
 */
-API_EXPORT(void) mtev_cluster_set_self(uuid_t);
+API_EXPORT(int) mtev_cluster_set_self(uuid_t);
 
 /*! \fn void mtev_cluster_get_self(uuid_t id)
     \brief Reports the UUID of the local node.
     \param id The UUID to be updated.
+    \return Returns -1 on error
 
     Pouplates the passed uuid_t with the local node's UUID.
 */


### PR DESCRIPTION
# mtev_cluster: Make sure uuids are not null before printing.

It's not garuantted that my_cluster_id will be set at startup, so it can be nil.
Similarlly oldest_node is only determined after some heartbeats arrived.

# Complain about missing //clusters in mtev_cluster_set_self()

mtev_cluster_set_self fails silently if there are no matches for `//clusters`.
Now, it emit's a corresponding log line, and returns -1. 
The RC is not actually used on the call sites, but I found it clearer to indicate the error exit.
Happy to revert that to maintain the original signature (void return).

Also the logic was re-arranged a little:
1. Check for //clusters
2. Check for //clusters/@my_id
Not the other way around.