### PR TITLE
Lua mtev.shared_seq

### DIFF
--- a/src/examples/lua-hello-world/hello-world.lua
+++ b/src/examples/lua-hello-world/hello-world.lua
@@ -41,7 +41,10 @@ function main()
     mtev.coroutine_spawn(coro_main, i, WAIT)
   end
 
-  -- Q: Is there a way to list all co-routines within this lua state?
+  -- List all co-routines within this lua state
+  for i, coro in pairs(mtev_coros) do
+    mtev.log("out", "coroutine %d : %s\n", i, coroutine.status(coro))
+  end
 
   -- Join co-routines
   local results = {}

--- a/src/examples/lua-hello-world/hello-world.lua
+++ b/src/examples/lua-hello-world/hello-world.lua
@@ -98,8 +98,12 @@ function coro_main(coro_id, w)
   mtev.notify("SLEEP", coro_id, slept:seconds())
 
   -- retrieve a global sequence number
-  local n = mtev.shared_seq("key")
-  mtev.log("out", "Global sequence %d.\n", coro_id, n)
+  local cnt = 10
+  repeat
+    mtev.log("out", "Global sequence key1 from coro %d: %d.\n", coro_id, mtev.shared_seq("key1"))
+    mtev.log("out", "Global sequence key2 from coro %d: %d.\n", coro_id, mtev.shared_seq("key2"))
+    cnt = cnt - 1
+  until cnt < 0
 
   -- do some async I/O from the co-routine
   local proc = mtev.spawn("/bin/echo", { "echo", "Hello from echo" })

--- a/src/examples/lua-hello-world/hello-world.lua
+++ b/src/examples/lua-hello-world/hello-world.lua
@@ -94,6 +94,10 @@ function coro_main(coro_id, w)
   local slept = mtev.sleep(wait)
   mtev.notify("SLEEP", coro_id, slept:seconds())
 
+  -- retrieve a global sequence number
+  local n = mtev.shared_seq("key")
+  mtev.log("out", "Global sequence %d.\n", coro_id, n)
+
   -- do some async I/O from the co-routine
   local proc = mtev.spawn("/bin/echo", { "echo", "Hello from echo" })
   local status, errno = proc:wait(1)

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -80,6 +80,7 @@
 
 static mtev_hash_table shared_table = MTEV_HASH_EMPTY;
 static pthread_mutex_t shared_table_mutex;
+static uint64_t shared_seq;
 
 
 typedef struct {
@@ -4762,6 +4763,17 @@ nl_shared_get(lua_State *L) {
   return 1;
 }
 
+/*! \lua seq = mtev.shared_seq()
+\brief returns a sequence number that is increasing across all mtev-lua states and coroutines
+\return seq the sequence number
+*/
+static int
+nl_shared_seq(lua_State *L) {
+  lua_pushnumber(L, ck_pr_faa_64(&shared_seq, 1));
+  return 1;
+}
+
+
 /*! \lua mtev.cancel_coro()
 */
 static int
@@ -4898,6 +4910,7 @@ Use sha256_hex instead.
   { "eventer_loop_concurrency", nl_eventer_loop_concurrency },
   { "shared_set", nl_shared_set},
   { "shared_get", nl_shared_get},
+  { "shared_seq", nl_shared_seq},
   { "watchdog_child_heartbeat", nl_watchdog_child_heartbeat },
   { "watchdog_timeout", nl_watchdog_timeout },
   { NULL, NULL }


### PR DESCRIPTION
There are situations where we want to have access to an sequence number in lua that is increasing across all lua states and co-routines. E.g. to generate monotonic requests ids.

The given implementation is fast and straight forward.

It has the downside, that there is only one single SEQ in a single process / applications. So if you have two libs that make use of sequences they would see each other's incs. 
This is fine for situations where only monotony is required not single stepping.
Also, I don't see a way around this that does not sacrifice simplicity and performance by introducing locks.