### PR TITLE
Implement eventer_aco_set_*_timeout.

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -333,6 +333,27 @@ API_EXPORT(int) eventer_close(eventer_t e, int *mask);
 #include "eventer/eventer_SSL_fd_opset.h"
 #include "eventer/eventer_aco_opset.h"
 
+/*! \fn void eventer_aco_set_accept_timeout(eventer_aco_t e, struct timeval *duration)
+    \brief Change the default timeout for ACO events.
+    \param e the ACO event to update.
+    \param duration a timeout duration, NULL will under the default.
+*/
+API_EXPORT(void) eventer_aco_set_accept_timeout(eventer_aco_t e, struct timeval *duration);
+
+/*! \fn void eventer_aco_set_read_timeout(eventer_aco_t e, struct timeval *duration)
+    \brief Change the default timeout for ACO events.
+    \param e the ACO event to update.
+    \param duration a timeout duration, NULL will under the default.
+*/
+API_EXPORT(void) eventer_aco_set_read_timeout(eventer_aco_t e, struct timeval *duration);
+
+/*! \fn void eventer_aco_set_write_timeout(eventer_aco_t e, struct timeval *duration)
+    \brief Change the default timeout for ACO events.
+    \param e the ACO event to update.
+    \param duration a timeout duration, NULL will under the default.
+*/
+API_EXPORT(void) eventer_aco_set_write_timeout(eventer_aco_t e, struct timeval *duration);
+
 /*! \fn void eventer_aco_sleep(struct timeval *duration)
     \brief Execute a sleep within an aco context.
     \param duration the time to suspend.


### PR DESCRIPTION
 * This sets a default timeout for aco events if NULL is passed.
 * This allows traditional eventer read/write to respect timeouts.