### PR TITLE
Use tlsv1.2, tlsv1.1, sslv23 in that order if not specified.

### DIFF
--- a/src/eventer/eventer_SSL_fd_opset.h
+++ b/src/eventer/eventer_SSL_fd_opset.h
@@ -123,6 +123,8 @@ API_EXPORT(time_t)
 API_EXPORT(time_t)
   eventer_ssl_get_peer_end_time(eventer_ssl_ctx_t *ctx);
 API_EXPORT(const char *)
+  eventer_ssl_get_sni_name(eventer_ssl_ctx_t *ctx);
+API_EXPORT(const char *)
   eventer_ssl_get_cipher_list(eventer_ssl_ctx_t *ctx, int prio);
 API_EXPORT(const char *)
   eventer_ssl_get_current_cipher(eventer_ssl_ctx_t *ctx);

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -1697,6 +1697,7 @@ mtev_ssl_ctx_index_func(lua_State *L) {
       }
       break;
     case 's':
+      LUA_RETSTRING(sni_name, eventer_ssl_get_sni_name(ssl_ctx));
       LUA_RETSTRING(san_list, eventer_ssl_get_peer_san_list(ssl_ctx));
       LUA_RETSTRING(subject, eventer_ssl_get_peer_subject(ssl_ctx));
       LUA_RETINTEGER(start_time, eventer_ssl_get_peer_start_time(ssl_ctx));


### PR DESCRIPTION
Support retrieving the SNI name the client issued.