### PR TITLE
Fix race in lua subsystem w.r.t. coroutine GC.

### DIFF
--- a/src/modules/lua_general.c
+++ b/src/modules/lua_general.c
@@ -137,7 +137,9 @@ lua_general_resume(mtev_lua_resume_info_t *ri, int nargs) {
 
 static mtev_lua_resume_info_t *
 lua_general_new_resume_info(lua_module_closure_t *lmc) {
-  return mtev_lua_new_resume_info(lmc, LUA_GENERAL_INFO_MAGIC);
+  mtev_lua_resume_info_t *ri = mtev_lua_new_resume_info(lmc, LUA_GENERAL_INFO_MAGIC);
+  ri->new_ri_f = lua_general_new_resume_info;
+  return ri;
 }
 
 static int

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -119,6 +119,7 @@ struct mtev_lua_resume_info {
   mtev_hash_table *events; /* Any eventers we need to cleanup */
   int context_magic;
   void *context_data;
+  struct mtev_lua_resume_info *(*new_ri_f)(lua_module_closure_t *);
 };
 #define LUA_GENERAL_INFO_MAGIC 0x918243fa
 
@@ -155,7 +156,7 @@ struct nl_slcl {
   size_t read_sofar;
   size_t read_goal;
   const char *read_terminator;
-	size_t read_terminator_len;
+  size_t read_terminator_len;
   const char *outbuff;
   size_t write_sofar;
   size_t write_goal;
@@ -208,6 +209,7 @@ int luaopen_mtev_stats(lua_State *);
 int luaopen_pack(lua_State *L); /* from lua_lpack.c */
 int luaopen_bit(lua_State *L); /* from lua_bit.c */
 mtev_lua_resume_info_t *mtev_lua_get_resume_info(lua_State *L);
+mtev_lua_resume_info_t *mtev_lua_find_resume_info(lua_State *L, mtev_boolean lua_error);
 void mtev_lua_set_resume_info(lua_State *L, mtev_lua_resume_info_t *ri);
 int mtev_lua_yield(mtev_lua_resume_info_t *ci, int nargs);
 void mtev_lua_register_event(mtev_lua_resume_info_t *ci, eventer_t e);

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -284,7 +284,9 @@ mtev_lua_web_driver_onload(mtev_image_t *self) {
 
 static mtev_lua_resume_info_t *
 lua_web_new_resume_info(lua_module_closure_t *lmc) {
-  return mtev_lua_new_resume_info(lmc, LUA_REST_INFO_MAGIC);
+  mtev_lua_resume_info_t *ri = mtev_lua_new_resume_info(lmc, LUA_REST_INFO_MAGIC);
+  ri->new_ri_f = lua_web_new_resume_info;
+  return ri;
 }
 
 static int


### PR DESCRIPTION
It is possible that a coroutine is "removed" from the mtev
registry and and yet garbarge collection is delayed enough
that it still executed in the lua VM.  This would cause the
revivification of the resume_info in the mtev coro state
tracker and desperately confuse things.  Events that are
solely owned (and are active) within a coro that is canceled
can fire their callbacks as well.  In these changes we
see a few things:

 * resume info states know how to create same time infos.
 * a find function for resume info was added that does not
   autovivify resume info when missing.
 * all callbacks from the event system that land in a lua
   state that has no resume info are cleaned up; lua error.
 * better safety is added for events removed on-demand that
   then later get removed via resume info cleanup.