### PR TITLE
Always use ASYNCH_BARRIER method of epoch gc.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,8 @@
  * Remove local callback latency tracking
  * Add per-pool callback latency tracking
  * Skip epoch reclamation in threads that have never freed anything.
+ * Always do asynchronous barrier epoch collection from the eventloop.
+ * Batch asynchronous epoch reclamation to reduce epoch synching.
  * Fix lua/ssl_upgrade eventer actuation.
  * Add granular lua garbage collection configuration
    default: step 1000 time before a full collect.

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -525,27 +525,20 @@ int eventer_get_epoch(struct timeval *epoch) {
 int NE_SOCK_CLOEXEC = 0;
 int NE_O_CLOEXEC = 0;
 
+#define ITERS_PER_COLLECT 1000
+
 static int
 eventer_mtev_memory_maintenance(eventer_t e, int mask, void *c,
                                 struct timeval *now) {
   unsigned int *counter = (unsigned int *)c;
 
-  /* Each time through we'll try to reclaim memory, if it
-   * fails 1000 times in a row, we'll schedule an asynchronous
-   * force (barrier) cleanup.
-   */
-  if(*counter < 1000) {
-    if(mtev_memory_maintenance_ex(MTEV_MM_TRY) < 0) {
-      (*counter)++;
-      return 0; /* no work was done */
-    } else
-      *counter = 0;
-  }
-  else {
+  if((*counter)++ > ITERS_PER_COLLECT) {
     mtev_memory_maintenance_ex(MTEV_MM_BARRIER_ASYNCH);
     *counter = 0;
+    return EVENTER_RECURRENT;
   }
-  return EVENTER_RECURRENT;
+  mtev_memory_maintenance_ex(MTEV_MM_NONE);
+  return 0;
 }
 static void eventer_per_thread_init(struct eventer_impl_data *t) {
   char qname[80];

--- a/src/utils/mtev_memory.h
+++ b/src/utils/mtev_memory.h
@@ -37,7 +37,8 @@
 typedef enum {
   MTEV_MM_BARRIER,
   MTEV_MM_TRY,
-  MTEV_MM_BARRIER_ASYNCH
+  MTEV_MM_BARRIER_ASYNCH,
+  MTEV_MM_NONE
 } mtev_memory_maintenance_method_t;
 
 API_EXPORT(void) mtev_memory_init(void); /* call once at process start */


### PR DESCRIPTION
Have the asynch method dequeue up to 100 lists,
synchronise, then hand back. 100x less syncronization.
Add a NONE method which will just reclaim the completed
sync, but no request any work.