### PR TITLE
The universal callback times are useless.

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -46,7 +46,7 @@ eventer_impl_t __eventer;
 mtev_log_stream_t eventer_err;
 mtev_log_stream_t eventer_deb;
 stats_ns_t *eventer_stats_ns;
-stats_handle_t *eventer_callback_latency;
+stats_handle_t *eventer_callback_latency_orphaned;
 stats_handle_t *eventer_unnamed_callback_latency;
 static uint64_t ealloccnt;
 static uint64_t ealloctotal;
@@ -356,9 +356,9 @@ void eventer_init_globals(void) {
   eventer_stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "eventer");
   mtev_hash_init_locks(&__name_to_func, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
   mtev_hash_init_locks(&__func_to_name, MTEV_HASH_DEFAULT_SIZE, MTEV_HASH_LOCK_MODE_MUTEX);
-  eventer_callback_latency =
+  eventer_callback_latency_orphaned =
     stats_register(mtev_stats_ns(eventer_stats_ns, "callbacks"),
-                   "_aggregate", STATS_TYPE_HISTOGRAM_FAST);
+                   "_orphaned", STATS_TYPE_HISTOGRAM_FAST);
   eventer_unnamed_callback_latency =
     stats_register(mtev_stats_ns(eventer_stats_ns, "callbacks"),
                    "_unnamed", STATS_TYPE_HISTOGRAM_FAST);

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -206,8 +206,10 @@ static inline int eventer_run_callback(eventer_t e, int m, void *c, struct timev
 }
 
 extern stats_ns_t *eventer_stats_ns;
-extern stats_handle_t *eventer_callback_latency;
+extern stats_handle_t *eventer_callback_latency_orphaned;
+extern __thread stats_handle_t *eventer_callback_pool_latency;
 extern stats_handle_t *eventer_unnamed_callback_latency;
+#define eventer_callback_latency (eventer_callback_pool_latency ? eventer_callback_pool_latency : eventer_callback_latency_orphaned)
 stats_handle_t *eventer_latency_handle_for_callback(eventer_func_t f);
 
 int eventer_jobq_init_internal(eventer_jobq_t *jobq, const char *queue_name);

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -573,7 +573,6 @@ eventer_jobq_execute_timeout(eventer_t e, int mask, void *closure,
           eventer_set_this_event(NULL);
           duration = mtev_gethrtime() - start;
           LIBMTEV_EVENTER_CALLBACK_RETURN((void *)my_precious, (void *)my_precious->callback, NULL, -1);
-          stats_set_hist_intscale(eventer_callback_latency, duration, -9, 1);
           stats_set_hist_intscale(eventer_latency_handle_for_callback(my_precious->callback), duration, -9, 1);
         }
       }
@@ -744,7 +743,6 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
         duration = mtev_gethrtime() - start;
         LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                               (void *)job->fd_event->callback, NULL, -1);
-        stats_set_hist_intscale(eventer_callback_latency, duration, -9, 1);
         stats_set_hist_intscale(eventer_latency_handle_for_callback(job->fd_event->callback), duration, -9, 1);
         eventer_jobq_finished_job(jobq, job);
         pthread_mutex_unlock(&job->lock);
@@ -798,7 +796,6 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
           duration = mtev_gethrtime() - start;
           LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                                   (void *)job->fd_event->callback, NULL, -1);
-          stats_set_hist_intscale(eventer_callback_latency, duration, -9, 1);
           stats_set_hist_intscale(eventer_latency_handle_for_callback(job->fd_event->callback), duration, -9, 1);
           mtevL(eventer_deb, "jobq[%s] -> dispatch END\n", jobq->queue_name);
           if(job->fd_event && job->fd_event->mask & EVENTER_CANCEL)
@@ -841,7 +838,6 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
         duration = mtev_gethrtime() - start;
         LIBMTEV_EVENTER_CALLBACK_RETURN((void *)job->fd_event,
                                 (void *)job->fd_event->callback, NULL, -1);
-        stats_set_hist_intscale(eventer_callback_latency, duration, -9, 1);
         stats_set_hist_intscale(eventer_latency_handle_for_callback(job->fd_event->callback), duration, -9, 1);
       }
 

--- a/src/examples/example1.c
+++ b/src/examples/example1.c
@@ -127,17 +127,17 @@ static void init_cluster(void) {
 
 static int handler_subwork(eventer_t e, int mask, void *closure,
                         struct timeval *now) {
-  uintptr_t len = (uintptr_t)closure;
-  int i;
-  int us = (len % 1000000);
-  int lvl = (len / 10) % 10;
+  uintptr_t param = (uintptr_t)closure;
+  int lvl = param % 10;
   if(mask == EVENTER_ASYNCH_WORK) {
-    for(i=0;i<(10-lvl)/2;i++) {
-      long foo = mtev_rand() * 100;
-      foo += (lvl-1) * 10;
-      foo += i;
-      usleep(us/10);
-      eventer_add_asynch_dep(NULL, eventer_alloc_asynch(handler_subwork, (void *)foo));
+    for(int i=0;i<(6-lvl)/2;i++) {
+      uintptr_t nparam = mtev_rand() % 100000;
+      nparam /= 10;
+      nparam *= 10;
+      nparam += lvl + 1;
+      mtevL(mtev_error, "doing something useless: %d\n", lvl);
+      usleep(nparam);
+      eventer_add_asynch_dep(NULL, eventer_alloc_asynch(handler_subwork, (void *)nparam));
     }
   }
   return 0;


### PR DESCRIPTION
Instead of tracking a universal latency chart for callbacks, track
it per pool as that is more useful for developers.