### PR TITLE
Fix Memory Leak And Bad Switch Statement

### DIFF
--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -1044,9 +1044,9 @@ mtev_lua_open(const char *module_name, void *lmc,
 
   lua_gc(L, LUA_GCRESTART, 0);
 
-  Lptr = malloc(sizeof(*Lptr));
-  *Lptr = L;
   if(lmc) {
+    Lptr = malloc(sizeof(*Lptr));
+    *Lptr = L;
     pthread_mutex_lock(&mtev_lua_states_lock);
     mtev_hash_store(&mtev_lua_states,
                     (const char *)Lptr, sizeof(*Lptr), lmc);

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -130,6 +130,8 @@ lua_web_resume(mtev_lua_resume_info_t *ri, int nargs) {
 
   switch(status) {
     case 0:
+      mtev_lua_gc(ri->lmc);
+      break;
     case LUA_YIELD:
       mtev_lua_gc(ri->lmc);
       return 0;


### PR DESCRIPTION
1) Fix a memory leak where we were allocating something and not storing
it.

2) Fix a bad switch statement in lua_web_resume - if we have case 0, we
want to break, not just return 0.