### PR TITLE
Default luamtev to an eventer concurrency of 1.

### DIFF
--- a/docs-md/config/eventer.md
+++ b/docs-md/config/eventer.md
@@ -39,9 +39,10 @@ The keys and values supported are:
  * ##### concurrency
 
    The number of event loop threads to start.  This effects the concurrency
-   of the default event loop and sets the default of any non-default event loops.
-   If not specified, the library will attempt to make a reasonable guess as to
-   a good concurrency level based on the number of CPU cores in the system.
+   of the default event loop and sets the default of any non-default event
+   loops.  If not specified or specified as 0, the library will attempt to
+   make a reasonable guess as to a good concurrency level based on the number
+   of CPU cores in the system.
 
  * ##### loop_&lt;name&gt;
 

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -392,7 +392,7 @@ int eventer_impl_propset(const char *key, const char *value) {
       return -1;
     }
     int requested = atoi(value);
-    if(requested < 1) requested = 1;
+    if(requested < 0) requested = 0;
     __default_loop_concurrency = requested;
     return 0;
   }

--- a/src/luamtev.conf.tmpl
+++ b/src/luamtev.conf.tmpl
@@ -2,6 +2,7 @@
 "<cli>\n" \
 "  <eventer>\n" \
 "    <config>\n" \
+"      <concurrency>%d</concurrency>\n" \
 "      <ssl_dhparam1024_file/>\n" \
 "      <ssl_dhparam2048_file/>\n" \
 "    </config>\n" \


### PR DESCRIPTION
Change the "concurrency" eventer config to support 0 for default
behavior.  Add a -n flag to luamtev to control concurrency and
default it to 1 if the flag is unused.