### PR TITLE
Make lua GC on next eventer tick.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,13 @@
 
 ## 1.5
 
+### 1.5.x
+
+ * Apply lua GC on next tick and not inline.
+ * Make "cs" the default jobq memory safety level.
+
 ### 1.5.15
+
  * Make mtev_memory_{begin,end} recursively safe.
  * Use asynch barrier SMR in jobqs.
  * Avoid clipping last letter off long log lines.

--- a/src/modules/lua_mtev.c
+++ b/src/modules/lua_mtev.c
@@ -2112,7 +2112,7 @@ nl_waitfor_notify(lua_State *L) {
     ci = mtev_lua_find_resume_info(q->L, mtev_false);
     if(!ci) q->L = NULL;
   }
-  if(q->L) {
+  if(lua_isyieldable(L) && q->L) {
     lua_xmove(L, q->L, nargs);
     q->L = NULL;
 

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -71,6 +71,7 @@ typedef struct lua_module_closure {
 
 API_EXPORT(void) mtev_lua_set_gc_params(lua_module_closure_t *, lua_module_gc_params_t *);
 API_EXPORT(void) mtev_lua_gc(lua_module_closure_t *);
+API_EXPORT(void) mtev_lua_gc_full(lua_module_closure_t *);
 
 /*! \fn lua_module_closure_t *mtev_lua_lmc_alloc(mtev_dso_generic_t *self, mtev_lua_resume_info_t *resume)
     \brief Allocated and initialize a `lua_module_closure_t` for a new runtime.

--- a/src/modules/lua_web.c
+++ b/src/modules/lua_web.c
@@ -185,9 +185,8 @@ lua_web_handler(mtev_http_rest_closure_t *restc,
     ctx = ri->context_data = calloc(1, sizeof(mtev_lua_resume_rest_info_t));
     ctx->restc = restc;
     ri->lmc = lmc;
-    lua_getglobal(lmc->lua_state, "mtev_coros");
     ri->coro_state = lua_newthread(lmc->lua_state);
-    ri->coro_state_ref = luaL_ref(lmc->lua_state, -2);
+    ri->coro_state_ref = luaL_ref(lmc->lua_state, LUA_REGISTRYINDEX);
 
     mtev_lua_set_resume_info(lmc->lua_state, ri);
 

--- a/test/lua-tests/coro_spec.lua
+++ b/test/lua-tests/coro_spec.lua
@@ -1,0 +1,44 @@
+describe("coro tear harness", function()
+
+  it("20 coros", function()
+    local cnt = 0
+    for j = 1,10 do
+      mtev.coroutine_spawn(function()
+        for i = 1,1000 do
+          mtev.sleep(0)
+          cnt = cnt + 1
+        end
+        if cnt == 20000 then mtev.notify("done") end
+        mtev.coroutine_spawn(function()
+          for i = 1,1000 do
+            mtev.sleep(0)
+            cnt = cnt + 1
+          end
+          if cnt == 20000 then mtev.notify("done") end
+        end)
+      end)
+    end
+    mtev.waitfor("done", 10)
+    assert.is_equal(20000, cnt)
+  end)
+
+  it("2000 coros", function()
+    local cnt = 0
+    for j = 1,1000 do
+      mtev.coroutine_spawn(function()
+        local key, v = mtev.waitfor("test-" .. j)
+        cnt = cnt + v
+        if cnt == 1000 then mtev.notify("done", "success") end
+      end)
+    end
+    for j = 1,1000 do
+      mtev.coroutine_spawn(function()
+        mtev.notify("test-" .. j, 1)
+      end)
+    end
+    local key, success = mtev.waitfor("done", 10)
+    assert.is_equal("done", key)
+    assert.is_equal("success", success)
+  end)
+
+end)


### PR DESCRIPTION
We can be in a lua call triggering into C completing and decide "we're done"
with the coroutine that is servicing the request.  From lua's perspective
we are done, but it is littered through the calling frames and is very likely
going to be used before we unwind.  So, instead of GC in place, we make
mtev_lua_gc schedule a GC on next tick which makes for a clean (empty) call
stack and greatly simplifies the next of lua/C call stacks.