### PR TITLE
Avoid waiting in mtev_memory_fini_thread for reclamation.

### DIFF
--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -267,7 +267,7 @@ mtev_gc_sync_complete(struct asynch_reclaim *ar, mtev_boolean accounting) {
   int i;
   unsigned long n_dispatch = 0;
 
-  mtevL(mem_debug, "mtev_memory_sync_complete\n");
+  mtevL(mem_debug, "mtev_gc_sync_complete\n");
   for(i=0;i<CK_EPOCH_LENGTH;i++) {
     unsigned int epoch = i & (CK_EPOCH_LENGTH - 1);
     ck_stack_entry_t *head, *next, *cursor;

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -137,7 +137,7 @@ void mtev_memory_init_thread(void) {
     epoch_rec = malloc(sizeof(*epoch_rec));
     ck_epoch_register(&epoch_ht, epoch_rec, NULL);
   }
-  if(!gc_return) {
+  if(gc_return == NULL) {
     gc_return = calloc(1, sizeof(*gc_return));
     gc_return->queue = calloc(1, sizeof(*gc_return->queue));
     ck_fifo_spsc_init(gc_return->queue, malloc(sizeof(ck_fifo_spsc_entry_t)));

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -133,7 +133,7 @@ mtev_boolean mtev_memory_thread_initialized(void) {
 
 void mtev_memory_init_thread(void) {
   if(epoch_rec == NULL) {
-    mtevL(mem_debug, "mtev_memory_fini_thread()\n");
+    mtevL(mem_debug, "mtev_memory_init_thread()\n");
     epoch_rec = malloc(sizeof(*epoch_rec));
     ck_epoch_register(&epoch_ht, epoch_rec, NULL);
   }

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -58,9 +58,9 @@ typedef struct {
   uint32_t disowned;
   ck_spinlock_t disown_lock;
 } gc_asynch_queue_t;
-static __thread gc_asynch_queue_t *gc_return;
+static __thread gc_asynch_queue_t *gc_return = NULL;
 static ck_epoch_t epoch_ht;
-static __thread ck_epoch_record_t *epoch_rec;
+static __thread ck_epoch_record_t *epoch_rec = NULL;
 static __thread int begin_end_depth = 0;
 /* needs_maintenance is used to avoid doing unnecessary work
  * in the epoch free cycle.

--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -152,7 +152,7 @@ void mtev_memory_fini_thread(void) {
   mtev_memory_maintenance_ex(MTEV_MM_BARRIER_ASYNCH);
   mtevL(mem_debug, "mtev_memory_fini_thread()\n");
   if(gc_return && gc_return->queue != NULL) {
-    if(asynch_gc) {
+    if(ck_pr_load_int(&asynch_gc)) {
       ck_pr_store_32(&gc_return->disowned, 1);
       mtev_memory_maintenance_ex(MTEV_MM_BARRIER_ASYNCH);
       mtev_memory_queue_asynch(); // this forces an enqueue


### PR DESCRIPTION
This change "disowns" any outstanding SMR actions such that the
memory gc thread will take responsibility and act on them.

Fixes #465