### PR TITLE
Fix thread migration for ACO rest calls.

### DIFF
--- a/src/eventer/eventer.c
+++ b/src/eventer/eventer.c
@@ -205,7 +205,10 @@ void eventer_update_whence(eventer_t e, struct timeval t) {
 }
 
 pthread_t eventer_get_owner(eventer_t e) { return e->thr_owner; }
-void eventer_set_owner(eventer_t e, pthread_t t) { e->thr_owner = t; }
+void eventer_set_owner(eventer_t e, pthread_t t) {
+  if(e->opset == eventer_aco_fd_opset) return;
+  e->thr_owner = t;
+}
 
 eventer_func_t eventer_get_callback(eventer_t e) { return e->callback; }
 void eventer_set_callback(eventer_t e, eventer_func_t f) { e->callback = f; }

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -153,6 +153,7 @@ struct mtev_http_session_ctx {
   int64_t drainage;
   pthread_mutex_t write_lock;
   size_t max_write;
+  mtev_boolean aco_enabled;
   mtev_http_connection conn;
   mtev_http_request req;
   mtev_http_response res;
@@ -360,6 +361,14 @@ request_compression_type(mtev_http_request *req)
   return MTEV_COMPRESS_NONE;
 }
 
+void
+mtev_http_session_set_aco(mtev_http_session_ctx *ctx, mtev_boolean nv) {
+  ctx->aco_enabled = nv;
+}
+mtev_boolean
+mtev_http_session_aco(mtev_http_session_ctx *ctx) {
+  return ctx->aco_enabled;
+}
 mtev_http_request *
 mtev_http_session_request(mtev_http_session_ctx *ctx) {
   return &ctx->req;

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -104,6 +104,10 @@ API_EXPORT(void)
 API_EXPORT(void)
   mtev_http_session_trigger(mtev_http_session_ctx *, int state);
 
+API_EXPORT(void)
+  mtev_http_session_set_aco(mtev_http_session_ctx *, mtev_boolean nv);
+API_EXPORT(mtev_boolean)
+  mtev_http_session_aco(mtev_http_session_ctx *);
 API_EXPORT(mtev_http_request *)
   mtev_http_session_request(mtev_http_session_ctx *);
 API_EXPORT(mtev_http_response *)


### PR DESCRIPTION
By default, if pools were specified, thread-fanout happened.  This
now always happens as "no pool" is treated correctly as the default
pool.