### PR TITLE
Fix munmap in large http chains.

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -269,6 +269,7 @@ struct bchain *bchain_alloc(size_t size, int line) {
       free(n);
       return NULL;
     }
+    n->mmap_size = size;
   }
   else {
     n = malloc(size + offsetof(struct bchain, _buff));
@@ -295,6 +296,7 @@ struct bchain *bchain_mmap(int fd, size_t len, int flags, off_t offset) {
   n->type = BCHAIN_MMAP;
   n->buff = buff;
   n->size = len;
+  n->mmap_size = len;
   n->allocd = len;
 #if defined(HAVE_POSIX_MADVISE)
   posix_madvise(buff, len, POSIX_MADV_SEQUENTIAL);
@@ -307,7 +309,7 @@ void bchain_free(struct bchain *b, int line) {
   (void)line;
   /*mtevL(mtev_error, "bchain_free(%p) : %d\n", b, line);*/
   if(b->type == BCHAIN_MMAP) {
-    munmap(b->buff, b->allocd);
+    munmap(b->buff, b->mmap_size);
   }
   free(b);
 }

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -72,11 +72,12 @@ typedef struct mtev_http_response mtev_http_response;
 
 struct bchain {
   bchain_type_t type;
+  mtev_compress_type compression;
   struct bchain *next, *prev;
   size_t start; /* where data starts (buff + start) */
   size_t size;  /* data length (past start) */
   size_t allocd;/* total allocation */
-  mtev_compress_type compression;
+  size_t mmap_size; /* size of original mmap */
   char *buff;
   char _buff[1]; /* over allocate as needed */
 };


### PR DESCRIPTION
The http chain processor can sometimes under-use large blocks in a
bchain.  If they are large enough to qualify for mmap, they must
later be munmap'd instead of freed.  We used the `allocd` field
to track how large they were, but if we under-use the block, the
allocd will be forced down to match size (to ensure no one uses
the remainder) and then subsequent munmap will provide an
insufficient length to the call leaving some mmap'd memory stranded.
This fix uses a separate struct field (that is never modified) to
track the mmap size so that the corresponding munmap is guaranteed
to match.