### PR TITLE
Fix Crash In mtev_skiplist_find_neighbors

### DIFF
--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -170,6 +170,7 @@ void *mtev_skiplist_find_neighbors(mtev_skiplist *sl,
                                    mtev_skiplist_node **next) {
   void *ret;
   mtev_skiplist_node *aiter;
+  if(!sl) return 0;
   if(!sl->compare) return 0;
   if(iter)
     ret = mtev_skiplist_find_neighbors_compare(sl, data, iter,


### PR DESCRIPTION
We were trying to access sl->compare when sl was null. Need to check for
existance of sl before trying to access sl->compare.