### PR TITLE
fix undefined XXH64 which collides with rdkafka

### DIFF
--- a/src/utils/mtev_hash.c
+++ b/src/utils/mtev_hash.c
@@ -33,7 +33,9 @@
 
 #include "mtev_config.h"
 #include "mtev_hash.h"
+#define XXH_PRIVATE_API
 #include "xxhash.h"
+#undef XXH_PRIVATE_API
 #include "mtev_log.h"
 #include "mtev_memory.h"
 #include "mtev_rand.h"

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -58,7 +58,9 @@
 #include "mtev_str.h"
 #include "mtev_thread.h"
 #include "mtev_zipkin.h"
+#define XXH_PRIVATE_API
 #include "xxhash.h"
+#undef XXH_PRIVATE_API
 #include <jlog.h>
 #include <jlog_private.h>
 #include "libmtev_dtrace.h"

--- a/src/utils/xxhash.c
+++ b/src/utils/xxhash.c
@@ -111,7 +111,6 @@ static void  XXH_free  (void* p)  { free(p); }
 #include <string.h>
 static void* XXH_memcpy(void* dest, const void* src, size_t size) { return memcpy(dest,src,size); }
 
-#define XXH_STATIC_LINKING_ONLY
 #include "xxhash.h"
 
 


### PR DESCRIPTION
Make all xxhash accesses private to the modules utilizing them.