### PR TITLE
mtevbusted don't *force* application/json

### DIFF
--- a/test/mtevbusted/api.lua
+++ b/test/mtevbusted/api.lua
@@ -118,7 +118,7 @@ function HTTP(method, host, port, uri, headers, payload, _pp, config)
   if rv ~= 0 then return -1, { error =  "client:connect failed" } end
 
   headers.Host = host
-  if headers.Accept ~= nil then headers.Accept = 'application/json' end
+  if headers.Accept == nil then headers.Accept = 'application/json' end
   mtev.log("debug/http", "%s\n", mtev.tojson({method, uri, headers, payload}):tostring())
   local rv = client:do_request(method, uri, headers, payload, "1.1")
   client:get_response(100000000)


### PR DESCRIPTION
Trivial fix for commit [`fix headers and don't *force* application/json`](https://github.com/circonus-labs/libmtev/commit/238fe32b3d54aafe6ce3f026c5e70239cf5a3d44#diff-9daeae86c13fd321c25041329f9741a7)