### PR TITLE
Suppress GCC 7 warnings for "-Wimplicit-fallthrough" and "-Wclobbered"

### DIFF
--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -695,6 +695,8 @@ jobq_thread_should_terminate(eventer_jobq_t *jobq, mtev_boolean want_reduce) {
   }
   return mtev_false;
 }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wclobbered"
 void *
 eventer_jobq_consumer(eventer_jobq_t *jobq) {
   eventer_job_t *job;
@@ -917,6 +919,7 @@ static void jobq_fire_blanks(eventer_jobq_t *jobq, int n) {
     eventer_jobq_enqueue(jobq, job, NULL);
   }
 }
+#pragma GCC diagnostic pop
 
 void eventer_jobq_ping(eventer_jobq_t *jobq) {
   jobq_fire_blanks(jobq, 1);

--- a/src/json-lib/mtev_json_object.c
+++ b/src/json-lib/mtev_json_object.c
@@ -383,6 +383,8 @@ void mtev_json_object_set_int64(struct mtev_json_object *jso, int64_t v)
   jso->overflow.c_int64 = v;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 int mtev_json_object_get_int(struct mtev_json_object *jso)
 {
   int cint;
@@ -441,6 +443,7 @@ double mtev_json_object_get_double(struct mtev_json_object *jso)
     return 0.0;
   }
 }
+#pragma GCC diagnostic pop
 
 
 /* mtev_json_object_string */

--- a/src/json-lib/mtev_json_object.c
+++ b/src/json-lib/mtev_json_object.c
@@ -383,8 +383,6 @@ void mtev_json_object_set_int64(struct mtev_json_object *jso, int64_t v)
   jso->overflow.c_int64 = v;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 int mtev_json_object_get_int(struct mtev_json_object *jso)
 {
   int cint;
@@ -399,6 +397,7 @@ int mtev_json_object_get_int(struct mtev_json_object *jso)
     return jso->o.c_boolean;
   case mtev_json_type_string:
     if(sscanf(jso->o.c_string, "%d", &cint) == 1) return cint;
+    /* fall through */
   default:
     return 0;
   }
@@ -439,11 +438,11 @@ double mtev_json_object_get_double(struct mtev_json_object *jso)
     return jso->o.c_boolean;
   case mtev_json_type_string:
     if(sscanf(jso->o.c_string, "%lf", &cdouble) == 1) return cdouble;
+    /* fall through */
   default:
     return 0.0;
   }
 }
-#pragma GCC diagnostic pop
 
 
 /* mtev_json_object_string */

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -254,6 +254,8 @@ static char *encode_txt(char *dst, const unsigned char *src, int len) {
   return dst;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static void dns_resume(dns_lookup_ctx_t *dlc) {
   int r = dlc->results_len;
   void *result = dlc->results;
@@ -386,6 +388,7 @@ static int dns_resume_event(eventer_t e, int mask, void *closure,
   dns_resume(closure);
   return 0;
 }
+#pragma GCC diagnostic push
 
 static void dns_cb(struct dns_ctx *ctx, void *result, void *data) {
   eventer_t e;

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -254,8 +254,6 @@ static char *encode_txt(char *dst, const unsigned char *src, int len) {
   return dst;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static void dns_resume(dns_lookup_ctx_t *dlc) {
   int r = dlc->results_len;
   void *result = dlc->results;
@@ -342,12 +340,19 @@ static void dns_resume(dns_lookup_ctx_t *dlc) {
           break;
 
         case DNS_T_CNAME: if(!fieldname) fieldname = "cname";
+        /* fall through */
         case DNS_T_PTR: if(!fieldname) fieldname = "ptr";
+        /* fall through */
         case DNS_T_NS: if(!fieldname) fieldname = "ns";
+        /* fall through */
         case DNS_T_MB: if(!fieldname) fieldname = "mb";
+        /* fall through */
         case DNS_T_MD: if(!fieldname) fieldname = "md";
+        /* fall through */
         case DNS_T_MF: if(!fieldname) fieldname = "mf";
+        /* fall through */
         case DNS_T_MG: if(!fieldname) fieldname = "mg";
+        /* fall through */
         case DNS_T_MR: if(!fieldname) fieldname = "mr";
          if(dns_getdn(pkt, &dptr, end, dn, DNS_MAXDN) <= 0) break;
          dns_dntop(dn, buff, sizeof(buff));
@@ -388,7 +393,6 @@ static int dns_resume_event(eventer_t e, int mask, void *closure,
   dns_resume(closure);
   return 0;
 }
-#pragma GCC diagnostic push
 
 static void dns_cb(struct dns_ctx *ctx, void *result, void *data) {
   eventer_t e;

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -901,8 +901,6 @@ on_frame_not_send_callback(nghttp2_session *session, const nghttp2_frame *frame,
         p_session, nghttp2_strerror(lib_error_code));
   return 0;
 }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static int
 on_frame_recv_callback(nghttp2_session *session,
                        const nghttp2_frame *frame, void *user_data) {
@@ -920,7 +918,7 @@ on_frame_recv_callback(nghttp2_session *session,
   case NGHTTP2_DATA:
     stream->req.payload_complete = mtev_true;
     stream->req.content_length = stream->req.user_data_bytes;
-    /* FALLTRHU */
+    /* fall through */
   case NGHTTP2_HEADERS:
     mtev_http_begin_span((mtev_http_session_ctx *)stream);
     http_request_complete_hook_invoke((mtev_http_session_ctx *)stream);
@@ -934,7 +932,6 @@ on_frame_recv_callback(nghttp2_session *session,
   }
   return 0;
 }
-#pragma GCC diagnostic pop
 static int
 on_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags,
                             int32_t stream_id, const uint8_t *data, size_t len,

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -901,6 +901,8 @@ on_frame_not_send_callback(nghttp2_session *session, const nghttp2_frame *frame,
         p_session, nghttp2_strerror(lib_error_code));
   return 0;
 }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static int
 on_frame_recv_callback(nghttp2_session *session,
                        const nghttp2_frame *frame, void *user_data) {
@@ -932,6 +934,7 @@ on_frame_recv_callback(nghttp2_session *session,
   }
   return 0;
 }
+#pragma GCC diagnostic pop
 static int
 on_data_chunk_recv_callback(nghttp2_session *session, uint8_t flags,
                             int32_t stream_id, const uint8_t *data, size_t len,

--- a/src/slz-lib/tables.h
+++ b/src/slz-lib/tables.h
@@ -4556,6 +4556,8 @@ static inline void __slz_make_crc_table(void)
  *		bits--;
  *
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static inline uint32_t dist_to_code(uint32_t l)
 {
 	uint32_t code;
@@ -4595,6 +4597,7 @@ static inline uint32_t dist_to_code(uint32_t l)
 
 	return code;
 }
+#pragma GCC diagnostic pop
 
 /* not thread-safe, must be called exactly once */
 static inline void __slz_prepare_dist_table(void)

--- a/src/slz-lib/tables.h
+++ b/src/slz-lib/tables.h
@@ -4561,7 +4561,6 @@ static inline void __slz_make_crc_table(void)
 static inline uint32_t dist_to_code(uint32_t l)
 {
 	uint32_t code;
-
 	code = 0;
 	switch (l) {
 	case 24577 ... 32768: code++;

--- a/src/utils/android-demangle/cp-demangle.c
+++ b/src/utils/android-demangle/cp-demangle.c
@@ -5502,6 +5502,8 @@ d_print_mod_list (struct d_print_info *dpi, int options,
 
 /* Print a modifier.  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static void
 d_print_mod (struct d_print_info *dpi, int options,
              const struct demangle_component *mod)
@@ -5568,6 +5570,7 @@ d_print_mod (struct d_print_info *dpi, int options,
       return;
     }
 }
+#pragma GCC diagnostic pop
 
 /* Print a function type, except for the return type.  */
 

--- a/src/utils/android-demangle/cp-demangle.c
+++ b/src/utils/android-demangle/cp-demangle.c
@@ -5502,8 +5502,6 @@ d_print_mod_list (struct d_print_info *dpi, int options,
 
 /* Print a modifier.  */
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 static void
 d_print_mod (struct d_print_info *dpi, int options,
              const struct demangle_component *mod)
@@ -5534,11 +5532,13 @@ d_print_mod (struct d_print_info *dpi, int options,
     case DEMANGLE_COMPONENT_REFERENCE_THIS:
       /* For the ref-qualifier, put a space before the &.  */
       d_append_char (dpi, ' ');
+      /* fall through */
     case DEMANGLE_COMPONENT_REFERENCE:
       d_append_char (dpi, '&');
       return;
     case DEMANGLE_COMPONENT_RVALUE_REFERENCE_THIS:
       d_append_char (dpi, ' ');
+      /* fall through */
     case DEMANGLE_COMPONENT_RVALUE_REFERENCE:
       d_append_string (dpi, "&&");
       return;
@@ -5570,7 +5570,6 @@ d_print_mod (struct d_print_info *dpi, int options,
       return;
     }
 }
-#pragma GCC diagnostic pop
 
 /* Print a function type, except for the return type.  */
 

--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -261,6 +261,7 @@ static void extract_symbols(struct dmap_node *node, Dwarf_Die sib) {
            dwarf_formflag(attr, &flag, &err) != DW_DLV_OK ||
            flag == 0) break;
         n.low = (uintptr_t)dlsym(NULL, die_name);
+        /* fall through */
       case DW_TAG_subprogram:
         if(dwarf_attrlist(sib, &attrs, &attrcount, &err) == DW_DLV_OK) {
           for(i=0; i<attrcount; i++) {

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -597,6 +597,8 @@ update_retries(int* offset, time_t times[]) {
   return 1;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 int mtev_watchdog_start_child(const char *app, int (*func)(void),
                               int child_watchdog_timeout_int) {
   int child_pid, crashing_pid = -1;
@@ -792,6 +794,7 @@ int mtev_watchdog_start_child(const char *app, int (*func)(void),
     }
   }
 }
+#pragma GCC diagnostic pop
 
 mtev_watchdog_t *mtev_watchdog_create(void) {
   int i;

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -597,8 +597,6 @@ update_retries(int* offset, time_t times[]) {
   return 1;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 int mtev_watchdog_start_child(const char *app, int (*func)(void),
                               int child_watchdog_timeout_int) {
   int child_pid, crashing_pid = -1;
@@ -794,7 +792,6 @@ int mtev_watchdog_start_child(const char *app, int (*func)(void),
     }
   }
 }
-#pragma GCC diagnostic pop
 
 mtev_watchdog_t *mtev_watchdog_create(void) {
   int i;


### PR DESCRIPTION
Fixes `libmtev` build with GCC 7 on newer Ubuntu. (Follow up to PR #370)