### PR TITLE
Lua socket close yield (2)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 1.6
 
+* Fix deadlock caused by eventer_t:close() in lua
+
 ### 1.6.13
 
  * Fix crash (double free) in sending AMQP messages in duplicate.


### PR DESCRIPTION
Avoid deadlock caused by eventer_t:close() in lua

Variant of https://github.com/circonus-labs/libmtev/pull/525
