### PR TITLE
Provide mtev_http_request_payload_complete

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -218,6 +218,7 @@ HTTP_DIS(size_t, request_content_length, request *, r, (mtev_http_request *r), (
 HTTP_DIS(size_t, request_content_length_read, request *, r, (mtev_http_request *r), (t_r))
 HTTP_DIS(mtev_boolean, request_payload_chunked, request *, r, (mtev_http_request *r), (t_r))
 HTTP_DIS(mtev_boolean, request_has_payload, request *, r, (mtev_http_request *r), (t_r))
+HTTP_DIS(mtev_boolean, request_payload_complete, request *, r, (mtev_http_request *r), (t_r))
 HTTP_DIS(const char *, request_querystring, request *, r, (mtev_http_request *r, const char *k), (t_r, k))
 HTTP_DIS(const char *, request_orig_querystring, request *, r, (mtev_http_request *r), (t_r))
 HTTP_DIS(mtev_hash_table *, request_querystring_table, request *, r, (mtev_http_request *r), (t_r))

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -129,6 +129,8 @@ API_EXPORT(mtev_boolean)
   mtev_http_request_payload_chunked(mtev_http_request *);
 API_EXPORT(mtev_boolean)
   mtev_http_request_has_payload(mtev_http_request *);
+API_EXPORT(mtev_boolean)
+  mtev_http_request_payload_complete(mtev_http_request *);
 API_EXPORT(const char *)
   mtev_http_request_querystring(mtev_http_request *, const char *);
 API_EXPORT(const char *)

--- a/src/mtev_http1.h
+++ b/src/mtev_http1.h
@@ -125,6 +125,8 @@ API_EXPORT(size_t)
 API_EXPORT(mtev_boolean)
   mtev_http1_request_payload_chunked(mtev_http1_request *);
 API_EXPORT(mtev_boolean)
+  mtev_http1_request_payload_complete(mtev_http1_request *);
+API_EXPORT(mtev_boolean)
   mtev_http1_request_has_payload(mtev_http1_request *);
 API_EXPORT(const char *)
   mtev_http1_request_querystring(mtev_http1_request *, const char *);

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -253,6 +253,9 @@ mtev_boolean mtev_http2_request_payload_chunked(mtev_http2_request *req) {
   (void)req;
   return mtev_false;
 }
+mtev_boolean mtev_http2_request_payload_complete(mtev_http2_request *req) {
+  return req->payload_complete;
+}
 mtev_boolean mtev_http2_request_has_payload(mtev_http2_request *req) {
   return req->has_payload;
 }

--- a/src/mtev_http2.h
+++ b/src/mtev_http2.h
@@ -137,6 +137,8 @@ API_EXPORT(size_t)
 API_EXPORT(mtev_boolean)
   mtev_http2_request_payload_chunked(mtev_http2_request *req);
 API_EXPORT(mtev_boolean)
+  mtev_http2_request_payload_complete(mtev_http2_request *req);
+API_EXPORT(mtev_boolean)
   mtev_http2_request_has_payload(mtev_http2_request *req);
 API_EXPORT(const char *)
   mtev_http2_request_querystring(mtev_http2_request *req, const char *k);


### PR DESCRIPTION
This is clearly too hard to get right from the client side as
I've coded it three different wrong ways. Provide a superbly
simply solution to determine if you should need to call
mtev_http_request_consume_read again if it has returned you
a 0.