### PR TITLE
Forcefully remove migrating thread from epoll.

### DIFF
--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -324,6 +324,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
       eventer_deref(e);
       return;
     }
+    /* We've acquired the lock, recheck out predicate */
     if(master_fds[fd].e == NULL) { 
     /*
      * If we are readding the event to the master list here, also do the needful

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -324,7 +324,7 @@ static void eventer_epoll_impl_trigger(eventer_t e, int mask) {
       eventer_deref(e);
       return;
     }
-    /* We've acquired the lock, recheck out predicate */
+    /* We've acquired the lock, recheck our predicate */
     if(master_fds[fd].e == NULL) { 
     /*
      * If we are readding the event to the master list here, also do the needful

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -215,6 +215,7 @@ extern stats_handle_t *eventer_unnamed_callback_latency;
 stats_handle_t *eventer_latency_handle_for_callback(eventer_func_t f);
 
 int eventer_jobq_init_internal(eventer_jobq_t *jobq, const char *queue_name);
+const char *eventer_thread_name(pthread_t tid);
 eventer_job_t *eventer_current_job(void);
 void eventer_heartbeat(void);
 void eventer_jobq_ping(eventer_jobq_t *jobq);


### PR DESCRIPTION
When a thread returns from an FD-triggered callback and the owner
has changed, we should always remove the thread from epoll because
if we do not, it will fail to add to the other loop spec and then
subsequently fire on the wrong thread and chaos will ensue.