### PR TITLE
Fix race in asynch event_close.

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -340,17 +340,6 @@ API_EXPORT(int) eventer_write(eventer_t e, const void *buff, size_t len, int *ma
 */
 API_EXPORT(int) eventer_close(eventer_t e, int *mask);
 
-/*! \fn int eventer_close(eventer_t e, int *mask)
-    \brief Execute an opset-appropriate `close` call synchronously
-    \param e an event object
-    \param mask a point the a mask. If the call does not complete, `*mask` it set.
-    \return 0 on sucess or -1 with errno set.
-
-    If the function returns -1 and `errno` is `EAGAIN`, the `*mask` reflects the
-    necessary activity to make progress.
-*/
-API_EXPORT(int) eventer_close_synch(eventer_t e, int *mask);
-
 #include "eventer/eventer_POSIX_fd_opset.h"
 #include "eventer/eventer_SSL_fd_opset.h"
 #include "eventer/eventer_aco_opset.h"

--- a/src/eventer/eventer_POSIX_fd_opset.c
+++ b/src/eventer/eventer_POSIX_fd_opset.c
@@ -85,8 +85,8 @@ POSIX_close(int fd, int *mask, void *closure) {
   if(fd < 0) {
     errno = EBADFD;
   } else {
-    shutdown(fd, SHUT_RDWR);
-    rv = close(fd);
+    posix_asynch_shutdown_close(fd);
+    rv = 0;
   }
   LIBMTEV_EVENTER_CLOSE_RETURN(fd, *mask, closure, rv);
   mtevL(eventer_deb, "POSIX_close(%d) -> %d\n", fd, rv);

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -1197,8 +1197,8 @@ eventer_SSL_close(int fd, int *mask, void *closure) {
   if(fd < 0) {
     errno = EBADFD;
   } else {
-    shutdown(fd, SHUT_RDWR);
-    rv = close(fd);
+    posix_asynch_shutdown_close(fd);
+    rv = 0;
   }
   *mask = 0;
   e->opset->set_opset_ctx(e, NULL);

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -226,5 +226,6 @@ void eventer_aco_init(void);
 void *eventer_aco_get_opset_ctx(void *closure);
 struct _fd_opset *eventer_aco_get_opset(void *closure);
 int eventer_aco_shutdown(aco_t *co);
+void posix_asynch_shutdown_close(int fd);
 
 #endif


### PR DESCRIPTION
Make the actual POSIX shutdown and close operations asynchronous
and not the whole event_close path b/c the event_close (and opset
dispatch) can happen while an event is being taken into or out of
ACO mode and it will abort.  This should be safe.