### PR TITLE
Add mtev_thread_setnamef and mtev_thread_getname.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 ## 1.7
 
  * Set app:<appname> tag on all top-level stats namespaces.
+ * Add mtev_thread_setnamef and mtev_thread_getname.
+ * Support logging thread names that are set via mtev_thread_ APIs.
 
 ### 1.7.0
 

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -33,6 +33,8 @@
 #include <mtev_time.h>
 #include <mtev_log.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <stdarg.h>
 #include <errno.h>
 
 #ifdef HAVE_VALGRIND_VALGRIND_H
@@ -193,21 +195,45 @@ mtev_thread_create(pthread_t *thread, const pthread_attr_t *attr,
   return pthread_create(thread, attr, mtev_thread_start_routine, c);
 }
 
+static __thread char thread_local_name[16];
 void
 mtev_thread_setname(const char *name) {
 #ifdef HAVE_PTHREAD_SETNAME_NP
   char thrname[16] = "\0";
-  if(!name)
-    pthread_setname_np(pthread_self(), "terminating_thread");
-  else {
-    if(!strcmp(name, "default/0")) return;
-    strlcat(thrname, name, sizeof(thrname));
-    pthread_setname_np(pthread_self(), thrname);
-  }
+  memset(thread_local_name, 0, sizeof(thread_local_name));
+  if(!name) name = "terminated";
+
+  strlcat(thrname, name, sizeof(thrname));
+  pthread_setname_np(pthread_self(), thrname);
+  strlcpy(thread_local_name, thrname, sizeof(thread_local_name));
 #else
   (void)name;
 #endif
 }
+
+void
+mtev_thread_setnamef(const char *fmt, ...) {
+#ifdef HAVE_PTHREAD_SETNAME_NP
+  char thrname[16] = "\0";
+  if(!fmt) return mtev_thread_setname(NULL);
+
+  va_list arg;
+  va_start(arg, fmt);
+  memset(thread_local_name, 0, sizeof(thread_local_name));
+  vsnprintf(thrname, sizeof(thrname), fmt, arg);
+  pthread_setname_np(pthread_self(), thrname);
+  strlcpy(thread_local_name, thrname, sizeof(thread_local_name));
+  va_end(arg);
+#else
+  (void)name;
+#endif
+}
+
+const char *
+mtev_thread_getname(void) {
+  return thread_local_name;
+}
+
 void
 mtev_thread_init(void)
 {  

--- a/src/mtev_thread.c
+++ b/src/mtev_thread.c
@@ -198,22 +198,19 @@ mtev_thread_create(pthread_t *thread, const pthread_attr_t *attr,
 static __thread char thread_local_name[16];
 void
 mtev_thread_setname(const char *name) {
-#ifdef HAVE_PTHREAD_SETNAME_NP
   char thrname[16] = "\0";
   memset(thread_local_name, 0, sizeof(thread_local_name));
   if(!name) name = "terminated";
 
   strlcat(thrname, name, sizeof(thrname));
+#ifdef HAVE_PTHREAD_SETNAME_NP
   pthread_setname_np(pthread_self(), thrname);
-  strlcpy(thread_local_name, thrname, sizeof(thread_local_name));
-#else
-  (void)name;
 #endif
+  strlcpy(thread_local_name, thrname, sizeof(thread_local_name));
 }
 
 void
 mtev_thread_setnamef(const char *fmt, ...) {
-#ifdef HAVE_PTHREAD_SETNAME_NP
   char thrname[16] = "\0";
   if(!fmt) return mtev_thread_setname(NULL);
 
@@ -221,12 +218,11 @@ mtev_thread_setnamef(const char *fmt, ...) {
   va_start(arg, fmt);
   memset(thread_local_name, 0, sizeof(thread_local_name));
   vsnprintf(thrname, sizeof(thrname), fmt, arg);
+#ifdef HAVE_PTHREAD_SETNAME_NP
   pthread_setname_np(pthread_self(), thrname);
+#endif
   strlcpy(thread_local_name, thrname, sizeof(thread_local_name));
   va_end(arg);
-#else
-  (void)name;
-#endif
 }
 
 const char *

--- a/src/mtev_thread.h
+++ b/src/mtev_thread.h
@@ -74,6 +74,12 @@ API_EXPORT(void)
 API_EXPORT(void)
   mtev_thread_setname(const char *);
 
+API_EXPORT(void)
+  mtev_thread_setnamef(const char *, ...);
+
+API_EXPORT(const char *)
+  mtev_thread_getname(void);
+
 /**
  * attempt to schedule as a real-time process within the system.
  * nqt is the request scheduling quantum in nanoseconds. If the OS

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1972,10 +1972,12 @@ mtev_vlog(mtev_log_stream_t ls, const struct timeval *now,
     else tbuf[0] = '\0';
     if(IS_DEBUG_BELOW(ls) || logspan) {
       const char *tname = eventer_get_thread_name();
-      if(tname)
+      if(!tname || strlen(tname) == 0) tname = mtev_thread_getname();
+      if(tname && strlen(tname))
         snprintf(dbuf, sizeof(dbuf), "[t@%u/%s,%s:%d] ", mtev_thread_id(), tname, file, line);
-      else
+      else {
         snprintf(dbuf, sizeof(dbuf), "[t@%u,%s:%d] ", mtev_thread_id(), file, line);
+      }
       dbuflen = strlen(dbuf);
     }
     else dbuf[0] = '\0';


### PR DESCRIPTION
Fix logging to report thread names set via mtev_thread_* APIs.