### PR TITLE
Make SMR and ACO friendly.

### DIFF
--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -1480,7 +1480,7 @@ void eventer_aco_start_stack(void (*func)(void), void *closure, size_t stksz) {
 mtev_boolean eventer_is_aco(eventer_t e) {
   if(e != NULL) return eventer_is_aco_opset(e);
   struct eventer_impl_data *t = get_my_impl_data();
-  if(t == NULL) return mtev_false;
+  mtevAssert(t);
   aco_t *co = aco_get_co();
   return co != NULL && co != t->aco_main_co;
 }
@@ -1492,6 +1492,8 @@ void eventer_aco_start(void (*func)(void), void *closure) {
 int eventer_aco_shutdown(aco_t *co) {
   struct eventer_impl_data *t = get_my_impl_data();
   mtevAssert(t);
+  struct aco_cb_ctx *ctx = co->arg;
+  mtevAssert(ctx->section.begin_end == 0); /* we can't off an exit in a critical section */
   free(co->arg);
   unsigned long hash = CK_HS_HASH(t->aco_registry, __ck_hash_from_ptr, co);
   mtevEvalAssert(ck_hs_remove(t->aco_registry, hash, co));

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -35,6 +35,7 @@
 #define EVENTER_EVENTER_IMPL_PRIVATE_H
 
 #include "mtev_stats.h"
+#include "mtev_memory.h"
 #include "aco/aco.h"
 
 #include <ck_hs.h>
@@ -77,6 +78,7 @@ struct aco_cb_ctx {
   int rv;
   int mask;
   int private_errno;
+  mtev_memory_section_t section;
 
   struct timeval *timeout;
   eventer_t timeout_e;

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -330,7 +330,7 @@ eventer_jobq_create_internal(const char *queue_name, eventer_jobq_memory_safety_
 
 eventer_jobq_t *
 eventer_jobq_create_backq(const char *queue_name) {
-  return eventer_jobq_create_internal(queue_name, EVENTER_JOBQ_MS_CS, mtev_true);
+  return eventer_jobq_create_internal(queue_name, EVENTER_JOBQ_MS_GC, mtev_true);
 }
 eventer_jobq_t *
 eventer_jobq_create_ms(const char *queue_name,
@@ -339,7 +339,7 @@ eventer_jobq_create_ms(const char *queue_name,
 }
 eventer_jobq_t *
 eventer_jobq_create(const char *queue_name) {
-  return eventer_jobq_create_internal(queue_name, EVENTER_JOBQ_MS_CS, mtev_false);
+  return eventer_jobq_create_internal(queue_name, EVENTER_JOBQ_MS_GC, mtev_false);
 }
 
 eventer_jobq_t *

--- a/src/utils/mtev_memory.h
+++ b/src/utils/mtev_memory.h
@@ -33,6 +33,7 @@
 
 #include "mtev_defines.h"
 #include <stdbool.h>
+#include <ck_epoch.h>
 
 typedef enum {
   MTEV_MM_BARRIER,
@@ -41,6 +42,13 @@ typedef enum {
   MTEV_MM_NONE
 } mtev_memory_maintenance_method_t;
 
+typedef struct {
+  uint32_t begin_end;
+  ck_epoch_section_t section;
+} mtev_memory_section_t;
+
+#define MTEV_MEMORY_SECTION_INIT { .begin_end = 0, .section = { .bucket = 0 } }
+
 API_EXPORT(void) mtev_memory_init(void); /* call once at process start */
 API_EXPORT(void) mtev_memory_gc_asynch(void); /* Make asynch gc work */
 API_EXPORT(void) mtev_memory_init_thread(void); /* at subsequent thread start */
@@ -48,6 +56,7 @@ API_EXPORT(void) mtev_memory_fini_thread(void); /* at thread exit */
 API_EXPORT(mtev_boolean) mtev_memory_thread_initialized(void);
 API_EXPORT(void) mtev_memory_maintenance(void); /* Call to force reclamation */
 API_EXPORT(int) mtev_memory_maintenance_ex(mtev_memory_maintenance_method_t method);
+API_EXPORT(mtev_memory_section_t *) mtev_memory_set_section(mtev_memory_section_t *);
 API_EXPORT(void) mtev_memory_begin(void); /* being a block */
 API_EXPORT(void) mtev_memory_end(void); /* end a block */
 API_EXPORT(mtev_boolean) mtev_memory_barriers(mtev_boolean *); /* do or try */

--- a/test/smr_test.c
+++ b/test/smr_test.c
@@ -11,20 +11,23 @@
 #include "mtev_perftimer.h"
 #include "mtev_rand.h"
 #include "mtev_log.h"
+#include "mtev_thread.h"
 
 /* test repeatedly allocates and frees
  * NSLOTS worth of BSIZE byte buffers.
  */
-#define NSLOTS 128
+#define NSLOTS 32
 #define BSIZE 64
 int NITERS = 50000;
 int NTHREAD = 4;
+sem_t done;
 char *memslots[NSLOTS] = { 0 };
 
 static uint64_t gbl = 0;
 
-void *thr_alloc_free(void *unused) {
-  (void)unused;
+void *thr_alloc_free(void *thrid) {
+  mtev_thread_setnamef("alloc-free/%zu",(uintptr_t)thrid);
+  mtevL(mtev_notice, "memory manip thread start\n");
   mtev_memory_init_thread();
   for(int iters=0; iters<NITERS/2; iters++) {
     mtev_memory_begin();
@@ -33,14 +36,17 @@ void *thr_alloc_free(void *unused) {
       memslots[i] = mtev_memory_safe_malloc(BSIZE);
     }
     mtev_memory_end();
+    mtev_memory_maintenance_ex(MTEV_MM_BARRIER_ASYNCH);
     usleep(2);
   }
   mtev_memory_fini_thread();
+  mtevL(mtev_notice, "memory manip thread end\n");
   return NULL;
 }
 
-void *thr_access(void *unused) {
-  (void)unused;
+void *thr_access(void *thrid) {
+  mtev_thread_setnamef("access/%zu", (uintptr_t)thrid);
+  mtevL(mtev_notice, "memory access thread start\n");
   mtev_memory_init_thread();
   for(int iters=0; iters<NITERS/5; iters++) {
     char *my_memslots[NSLOTS];
@@ -57,7 +63,39 @@ void *thr_access(void *unused) {
     mtev_memory_end();
   }
   mtev_memory_fini_thread();
+  mtevL(mtev_notice, "memory access thread end\n");
   pthread_exit(NULL);
+}
+
+void aco_access(void) {
+  mtevL(mtev_notice, "memory access aco thread start\n");
+  struct timeval duration = { 0, 2 };
+  for(int iters=0; iters<NITERS/5; iters++) {
+    char *my_memslots[NSLOTS];
+    mtev_memory_begin();
+    for(int i=0; i<NSLOTS; i++) {
+      my_memslots[i] = memslots[i];
+    }
+    eventer_aco_sleep(&duration);
+    for(int i=0; i<NSLOTS; i++) {
+      if(my_memslots[i]) {
+        gbl += my_memslots[i][BSIZE-1];
+      }
+    }
+    mtev_memory_end();
+  }
+  mtevL(mtev_notice, "memory access aco thread end\n");
+  sem_post(&done);
+  aco_exit();
+}
+static int
+aco_access_trigger(eventer_t e, int mask, void *c, struct timeval *now) {
+  (void)e;
+  (void)mask;
+  (void)c;
+  (void)now;
+  eventer_aco_start(aco_access, NULL);
+  return 0;
 }
 
 int child_main() {
@@ -69,25 +107,34 @@ int child_main() {
   eventer_init();
   mtev_console_init("smr_test");
   mtev_listener_init("smr_test");
+  for(i=0; i<NTHREAD; i++) {
+    eventer_add_in_s_us(aco_access_trigger, NULL, 0, 0);
+  }
   eventer_loop_return();
 
   pthread_t tid, thrtid[NTHREAD];
   pthread_create(&tid, NULL, thr_alloc_free, NULL);
 
   for(i=0; i<NTHREAD; i++) {
-    pthread_create(&thrtid[i], NULL, thr_access, NULL);
+    pthread_create(&thrtid[i], NULL, thr_access, (void *)(uintptr_t)i);
   }
+
   for(i=0; i<NTHREAD; i++) {
     void *ignored;
     pthread_join(tid, &ignored);
   }
   pthread_join(tid, &ignored);
-  sleep(2);
+
+  for(i=0; i<NTHREAD; i++) {
+    sem_wait(&done);
+  }
+  mtev_memory_maintenance_ex(MTEV_MM_BARRIER);
   exit(0);
   return 0;
 }
 
 int main(int argc, char **argv) {
+  mtevAssert(sem_init(&done, 0, 0) == 0);
   if(argc > 1) {
     NITERS = atoi(argv[1]);
   }

--- a/test/smr_test.conf
+++ b/test/smr_test.conf
@@ -6,4 +6,8 @@
       <ssl_dhparam2048_file/>
     </config>
   </eventer>
+  <logs>
+    <outlet name="stderr"/>
+    <log name="error" debug="on"/>
+  </logs>
 </smr_test>


### PR DESCRIPTION
Given that ACO feels procedural but can span across many eventer loop
cycles, it is possible that an ACO consumer could quite unintentionally
create an SMR critical section (mtev_memory_{begin,end}) that spans
across the eventer loop boundary.  If this were to happen frequently,
SMR garbage collection could cease to make progress.  ck_epoch supports
this use case via ck_epoch_section_ts.  This change switches to use
ck_epoch_section_t for critical sections and attaches and transparently
activates a new section for each ACO coroutine.  We may want to lift the
mtev_memory_section_t and the swapping of these section into aco.c so
that aco could still be directly used outside the eventer.