### PR TITLE
Fix NPE on rest raw handler.

### DIFF
--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -921,7 +921,11 @@ mtev_http_rest_raw_handler(eventer_t e, int mask, void *closure,
 
   if(mask & EVENTER_EXCEPTION || (restc && restc->wants_shutdown)) {
     /* Exceptions cause us to simply snip the connection */
-    (void)mtev_http_session_drive(e, mask, restc->http_ctx, now, &done);
+    if(restc) {
+      (void)mtev_http_session_drive(e, mask, restc->http_ctx, now, &done);
+    } else {
+      eventer_close(e, &mask);
+    }
     mtev_acceptor_closure_free(ac);
     return 0;
   }


### PR DESCRIPTION
If we received an exception on the socket before our first read, then
we would dereference a NULL restc context. Just close the event and
bail in that case.

CIRC-4052