### PR TITLE
Better coverity support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/modules/mtev_lua/
 src/dhparam*.txt
 src/js/node_modules/
 test/t/node_modules/
+src/libmtev.xmldb
 src/luamtev
 src/lua/src/lua
 **/*.dSYM/

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -370,6 +370,9 @@ install-docs:
 
 install:	install-bins install-docs install-headers install-libs install-modules
 
+libmtev.xmldb:	coverity_model.c
+	cov-make-library -of libmtev.xmldb coverity_model.c
+
 clean:
 	rm -f *.lo *.o *.hlo *.Slo libmtev_dtrace_probes.h
 	for subdir in aco eventer noitedit utils json-lib; do \

--- a/src/coverity_model.c
+++ b/src/coverity_model.c
@@ -1,0 +1,83 @@
+typedef void (*NoitHashFreeFunc)(void *);
+typedef int (*eventer_func_t)
+             (struct _event *e, int mask, void *closure, struct timeval *tv);
+
+int mtev_conf_get_string(void *base, char *path, char **val) {
+  int is_ok;
+  if(is_ok) {
+    *val = __coverity_alloc_nosize__();
+    return 1;
+  }
+  return 0;
+}
+void mtev_skiplist_insert(void *list, void *entry) {
+  __coverity_escape__(entry);
+}
+
+int mtev_hash_store(void *h, void *k, int klen, void *data) {
+  __coverity_escape__(k);
+  __coverity_escape__(data);
+}
+
+int mtev_hash_replace(void *h, void *k, int klen, void *data,
+                      NoitHashFreeFunc keyfree, NoitHashFreeFunc datafree) {
+  __coverity_escape__(k);
+  __coverity_escape__(data);
+}
+
+int mtev_hash_set(void *h, void *k, int klen, void *data, void **oldk, void **olddata) {
+  int is_ok;
+  __coverity_escape__(k);
+  __coverity_escape__(data);
+  if(is_ok) {
+    *oldk = __coverity_alloc__(klen);
+    *olddata = __coverity_alloc_nosize__();
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
+struct _event *eventer_alloc_asynch(eventer_func_t f, void *cl) {
+  __coverity_escape__(cl);
+  return __coverity_alloc__(32);
+}
+struct _event *eventer_alloc_recurrent(eventer_func_t f, void *cl) {
+  __coverity_escape__(cl);
+  return __coverity_alloc__(32);
+}
+void eventer_add(struct _event *e) {
+  __coverity_escape__(e);
+}
+void eventer_add_recurrent(struct _event *e) {
+  __coverity_escape__(e);
+}
+void eventer_add_timed(struct _event *e) {
+  __coverity_escape__(e);
+}
+void eventer_add_asynch(void *q, struct _event *e) {
+  __coverity_escape__(e);
+}
+void eventer_add_asynch_subqueue(void *q, struct _event *e, size_t sq) {
+  __coverity_escape__(e);
+}
+void eventer_add_asynch_dep(void *q, struct _event *e) {
+  __coverity_escape__(e);
+}
+void eventer_add_asynch_dep_subqueue(void *q, struct _event *e, size_t sq) {
+  __coverity_escape__(e);
+}
+
+void ck_fifo_spsc_enqueue(void *q, void *e, void  *v) {
+  __coverity_escape__(e);
+  __coverity_escape__(v);
+}
+
+int ck_fifo_spsc_dequeue(void *q, void **v) {
+  int is_ok;
+  if(is_ok) {
+    *v = __coverity_alloc_nosize__();
+    return 1;
+  }
+  return 0;
+}

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -739,21 +739,21 @@ int eventer_run_callback(eventer_func_t f, eventer_t e, int m, void *c, struct t
     \brief Add an event object to the eventer system.
     \param e an event object to add.
 */
-#define eventer_add           __eventer->add
+static inline void eventer_add(eventer_t e) { __eventer->add(e); }
 
 /*! \fn eventer_t eventer_remove(eventer_t e)
     \brief Remove an event object from the eventer system.
     \param e an event object to add.
     \return the event object removed if found; NULL if not found.
 */
-#define eventer_remove        __eventer->remove
+static inline eventer_t eventer_remove(eventer_t e) { return __eventer->remove(e); }
 
 /*! \fn void eventer_update(evneter_t e, int mask)
     \brief Change the activity mask for file descriptor events.
     \param e an event object
     \param mask a new mask that is some bitwise or of `EVENTER_READ`, `EVENTER_WRITE`, and `EVENTER_EXCEPTION`
 */
-#define eventer_update        __eventer->update
+static inline void eventer_update(eventer_t e, int mask) { __eventer->update(e,mask); }
 
 /*! \fn void void eventer_update_whence(eventer_t e, struct timeval whence)
     \brief Change the time at which a registered timer event should fire.
@@ -767,14 +767,15 @@ void eventer_update_whence(eventer_t e, struct timeval w);
     \param fd a file descriptor
     \return the event object removed if found; NULL if not found.
 */
-#define eventer_remove_fd     __eventer->remove_fd
+
+static inline eventer_t eventer_remove_fd(int fd) { return __eventer->remove_fd(fd); }
 
 /*! \fn eventer_t eventer_find_fd(int e)
     \brief Find an event object in the eventer system by file descriptor.
     \param fd a file descriptor
     \return the event object if it exists; NULL if not found.
 */
-#define eventer_find_fd       __eventer->find_fd
+static inline eventer_t eventer_find_fd(int fd) { return __eventer->find_fd(fd); }
 
 /*! \fn void eventer_trigger(eventer_t e, int mask)
     \brief Trigger an unregistered eventer and incorporate the outcome into the eventer.
@@ -784,7 +785,7 @@ void eventer_update_whence(eventer_t e, struct timeval w);
     This is often used to "start back up" an event that has been removed from the
     eventer for any reason.
 */
-#define eventer_trigger       __eventer->trigger
+static inline void eventer_trigger(eventer_t e, int mask) { __eventer->trigger(e,mask); }
 
 #define eventer_max_sleeptime __eventer->max_sleeptime
 
@@ -805,7 +806,7 @@ void eventer_update_whence(eventer_t e, struct timeval w);
     file descriptor activity.  If, for an external reason, one needs to wake up
     a looping thread, this call is used.
 */
-#define eventer_wakeup        __eventer->wakeup
+static inline void eventer_wakeup(eventer_t e) { __eventer->wakeup(e); }
 
 extern eventer_impl_t registered_eventers[];
 


### PR DESCRIPTION
Add a simple though incomplete coverity model for libmtev consumers.
Change eventers calls that were #define maps into static inline
functions such that coverity models can apply to them.  Add a build
target for the coverity model file.