### PR TITLE
This addresses several issues with aco+eventer.

### DIFF
--- a/src/aco/aco.c
+++ b/src/aco/aco.c
@@ -15,9 +15,17 @@
 #include "aco.h"
 #include <stdio.h>
 #include <stdint.h>
+#include <ck_pr.h>
 
 // this header including should be at the last of the `include` directives list
 #include "aco_assert_override.h"
+
+static uint32_t current_tls_max = 0;
+uint32_t aco_tls_assign_idx(void) {
+  uint32_t new_id = ck_pr_faa_32(&current_tls_max, 1);
+  assert(new_id < MAX_TLS_ENTRIES);
+  return new_id;
+}
 
 void aco_runtime_test(void){
 #ifdef __i386__

--- a/src/aco/aco.h
+++ b/src/aco/aco.h
@@ -24,6 +24,8 @@
 #include <time.h>
 #include <sys/mman.h>
 
+#define MAX_TLS_ENTRIES 16
+
 #ifdef ACO_USE_VALGRIND
     #include <valgrind/valgrind.h>
 #endif
@@ -110,7 +112,12 @@ struct aco_s{
     
     aco_save_stack_t  save_stack;
     aco_share_stack_t* share_stack;
+    void *tls[MAX_TLS_ENTRIES];
 };
+
+uint32_t aco_tls_assign_idx(void);
+
+#define aco_tls(co,idx) co->tls[idx]
 
 #define aco_likely(x) (__builtin_expect(!!(x), 1))
 

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -697,20 +697,19 @@ eventer_ssl_ctx_new(eventer_ssl_orientation_t type,
   char ssl_ctx_key[SSL_CTX_KEYLEN];
   eventer_ssl_ctx_t *ctx;
   const char *layer_str;
-  char *ctx_layer, *opts;
+  char *opts, ctx_layer[256], opts_buf[256];
   char *opts_fallback = DEFAULT_OPTS_STRING;
   time_t now;
   ctx = calloc(1, sizeof(*ctx));
   if(!ctx) return NULL;
 
   layer_str = layer ? layer : DEFAULT_LAYER_STRING;
-  ctx_layer = alloca(strlen(layer_str)+1);
-  memcpy(ctx_layer, layer_str, strlen(layer_str)+1);
+  strlcpy(ctx_layer, layer_str, sizeof(ctx_layer));
   opts = strchr(ctx_layer,':');
   if(opts) *opts++ = '\0';
   else {
-    opts = alloca(strlen(opts_fallback)+1);
-    memcpy(opts, opts_fallback, strlen(opts_fallback)+1);
+    strlcpy(opts_buf, opts_fallback, sizeof(opts_buf));
+    opts = opts_buf;
   }
 
   now = time(NULL);

--- a/src/examples/echo_server.c
+++ b/src/examples/echo_server.c
@@ -51,7 +51,7 @@ static int my_post_handler(mtev_http_rest_closure_t *restc, int npats, char **pa
   (void)pats;
   /* intentionally small */
   size_t buffer_size = 98;
-  char *buffer = alloca(buffer_size);
+  char buffer[98];
   int mask = EVENTER_READ | EVENTER_WRITE | EVENTER_EXCEPTION;
   int len;
   int done = 0;

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -37,9 +37,6 @@
 #include <ck_pr.h>
 
 #include <unistd.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
 
 #include "mtev_conf.h"
 #include "mtev_dso.h"
@@ -946,7 +943,7 @@ void
 mtev_lua_pushmodule(lua_State *L, const char *m) {
   int stack_pos = 0;
   char *copy, *part, *brkt = NULL;
-  copy = alloca(strlen(m)+1);
+  copy = malloc(strlen(m)+1);
   mtevAssert(copy);
   memcpy(copy,m,strlen(m)+1);
 
@@ -955,6 +952,7 @@ mtev_lua_pushmodule(lua_State *L, const char *m) {
       part = strtok_r(NULL, ".", &brkt)) {
     if(stack_pos) {
       if(lua_isnil(L, stack_pos)) {
+        free(copy);
         return;
       }
       lua_getfield(L, stack_pos, part);
@@ -963,6 +961,7 @@ mtev_lua_pushmodule(lua_State *L, const char *m) {
     if(stack_pos == -1) lua_remove(L, -2);
     else stack_pos = -1;
   }
+  free(copy);
 }
 mtev_hash_table *
 mtev_lua_table_to_hash(lua_State *L, int idx) {

--- a/src/modules/lua_mtev_dns.c
+++ b/src/modules/lua_mtev_dns.c
@@ -511,6 +511,11 @@ static int mtev_lua_dns_lookup(lua_State *L) {
     return 1;
   }
 
+  if(strlen(ctype) >= sizeof(ctype_buf))
+    luaL_error(L, "ctype parameter too long");
+  if(strlen(rtype) >= sizeof(rtype_buf))
+    luaL_error(L, "rtype parameter too long");
+
   dlc->in_lua = 1;
   /* We own this at least until return */
   ck_pr_inc_32(&dlc->refcnt);

--- a/src/modules/lua_mtev_http.c
+++ b/src/modules/lua_mtev_http.c
@@ -76,13 +76,20 @@ mtev_lua_http_request_headers(lua_State *L) {
     const char *hdr = lua_tostring(L,2);
     if(hdr == NULL) lua_pushnil(L);
     else {
-      char *cp, *lower = alloca(strlen(hdr) + 1);
+      char lower_buf[4096], *allocd = NULL;
+      char *cp, *lower;
+      if(strlen(hdr)+1 <= sizeof(lower_buf)) {
+        lower = lower_buf;
+      } else {
+        lower = allocd = malloc(strlen(hdr)+1);
+      }
       memcpy(lower, hdr, strlen(hdr)+1);
       for(cp=lower; *cp; cp++) *cp = tolower(*cp);
       if(mtev_hash_retr_str(h, lower, strlen(lower), &hdr))
         lua_pushstring(L, hdr);
       else
         lua_pushnil(L);
+      free(allocd);
     }
   }
   else luaL_error(L, "invalid arguments to mtev_http_request:headers()");

--- a/src/mtev_console_state.c
+++ b/src/mtev_console_state.c
@@ -666,7 +666,7 @@ mtev_console_memory_log_opts_ex(mtev_console_closure_t ncct,
     cnt = mtev_log_list(NULL, 0);
     if(cnt < 0 ) {
       cnt = 0 - cnt;
-      loggers = alloca(sizeof(*loggers) * cnt);
+      loggers = malloc(sizeof(*loggers) * cnt);
       cnt = mtev_log_list(loggers, cnt);
       if(cnt > 0) {
         for(i=0;i<cnt;i++) {
@@ -678,6 +678,7 @@ mtev_console_memory_log_opts_ex(mtev_console_closure_t ncct,
           }
         }
       }
+      free(loggers);
     }
   }
   return NULL;

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -287,6 +287,7 @@ eventer_t mtev_http1_connection_event(mtev_http1_connection *conn) {
 eventer_t mtev_http1_connection_event_float(mtev_http1_connection *conn) {
   eventer_t e = conn ? conn->e : NULL;
   if(e) {
+    mtevAssert(!eventer_is_aco_opset(e));
     conn->e = eventer_alloc_copy(e);
   }
   return e;

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -287,13 +287,13 @@ eventer_t mtev_http1_connection_event(mtev_http1_connection *conn) {
 eventer_t mtev_http1_connection_event_float(mtev_http1_connection *conn) {
   eventer_t e = conn ? conn->e : NULL;
   if(e) {
-    mtevAssert(!eventer_is_aco_opset(e));
+    if(eventer_is_aco(e)) return NULL;
     conn->e = eventer_alloc_copy(e);
   }
   return e;
 }
 void mtev_http1_connection_resume_after_float(mtev_http1_connection *conn) {
-  if(conn->e) {
+  if(conn->e && !eventer_is_aco(conn->e)) {
     eventer_trigger(conn->e, EVENTER_READ|EVENTER_WRITE);
   }
 }

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -434,7 +434,9 @@ mtev_http2_connection_resume_after_float(mtev_http2_connection *p) {
   if(p->floated == H2_ASYNCH) {
     p->floated = H2_SYNCH;
     if(p->parent->e) {
-      eventer_trigger(p->parent->e, EVENTER_READ|EVENTER_WRITE);
+      if(!eventer_is_aco(p->parent->e)) {
+        eventer_trigger(p->parent->e, EVENTER_READ|EVENTER_WRITE);
+      }
     }
     mtev_http2_session_ref_dec(p);
   } else {

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -393,9 +393,10 @@ mtev_main(const char *appname,
 
   zipkin_conf();
 
-  char* root_section_path = alloca(strlen(appname)+2);
-  sprintf(root_section_path, "/%s", appname);
+  char* root_section_path = malloc(strlen(appname)+2);
+  snprintf(root_section_path, strlen(appname)+2, "/%s", appname);
   root = mtev_conf_get_sections(MTEV_CONF_ROOT, root_section_path, &cnt);
+  free(root_section_path);
   mtev_conf_release_sections(root, cnt);
   if(cnt==0) {
     mtevStartupTerminate(mtev_error, "The config must have <%s> as its root node\n", appname);

--- a/src/noitedit/readline.c
+++ b/src/noitedit/readline.c
@@ -544,7 +544,7 @@ _history_expand_command(const char *command, size_t cmdlen, char **result)
 
 	*result = NULL;
 
-        if(cmdlen + 1 >= sizeof(cmd)) return (-1);
+        if(cmdlen + 1 >= sizeof(cmd_buf)) return (-1);
         cmd = cmd_buf;
 	(void) strncpy(cmd, command, cmdlen);
 	cmd[cmdlen] = 0;

--- a/src/utils/mtev_lfu.c
+++ b/src/utils/mtev_lfu.c
@@ -297,8 +297,9 @@ mtev_lfu_put(mtev_lfu_t *lfu, const char *key, size_t key_len, void *val)
     return mtev_false;
   }
   struct lfu_key *tempkey = NULL;
+  char tempkey_buf[ALLOCA_LIMIT];
   if (key_len <= ALLOCA_LIMIT) {
-    tempkey = alloca(sizeof(struct lfu_key) + key_len);
+    tempkey = (struct lfu_key *)tempkey_buf;
   } else {
     tempkey = malloc(sizeof(struct lfu_key) + key_len);
   }
@@ -348,8 +349,9 @@ mtev_lfu_get(mtev_lfu_t *c, const char *key, size_t key_len, void **value)
   }
 
   struct lfu_key *tempkey = NULL;
+  char tempkey_buf[ALLOCA_LIMIT];
   if (key_len <= ALLOCA_LIMIT) {
-    tempkey = alloca(sizeof(struct lfu_key) + key_len);
+    tempkey = (struct lfu_key *)tempkey_buf;
   } else {
     tempkey = malloc(sizeof(struct lfu_key) + key_len);
   }
@@ -404,8 +406,9 @@ mtev_lfu_remove(mtev_lfu_t *c, const char *key, size_t key_len)
     return NULL;
   }
   struct lfu_key *tempkey = NULL;
+  char tempkey_buf[ALLOCA_LIMIT];
   if (key_len <= ALLOCA_LIMIT) {
-    tempkey = alloca(sizeof(struct lfu_key) + key_len);
+    tempkey = (struct lfu_key *)tempkey_buf;
   } else {
     tempkey = malloc(sizeof(struct lfu_key) + key_len);
   }

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -854,7 +854,7 @@ posix_logio_cull(mtev_log_stream_t ls, int age, ssize_t bytes) {
   if(size < 0) size = PATH_MAX + 128;
 #endif
   size = MIN(size, PATH_MAX + 128);
-  de = alloca(size);
+  de = malloc(size);
 
   pathlen = strlen(filename);
   now = time(NULL);
@@ -882,6 +882,7 @@ posix_logio_cull(mtev_log_stream_t ls, int age, ssize_t bytes) {
     cnt++;
   }
   closedir(d);
+  free(de);
 
   if(cnt == 0) return 0;
 
@@ -1003,15 +1004,15 @@ jlog_logio_cleanse(mtev_log_stream_t ls) {
     }
     return 0;
   }
+  if(!d) return -1;
 
 #ifdef _PC_NAME_MAX
   size = pathconf(path, _PC_NAME_MAX);
   if(size < 0) size = PATH_MAX + 128;
 #endif
   size = MIN(size, PATH_MAX + 128);
-  de = alloca(size);
+  de = malloc(size);
 
-  if(!d) return -1;
   while(portable_readdir_r(d, de, &entry) == 0 && entry != NULL) {
     uint32_t logid;
     /* the current log file isn't a deletion target. period. */
@@ -1030,6 +1031,7 @@ jlog_logio_cleanse(mtev_log_stream_t ls) {
     }
   }
   closedir(d);
+  free(de);
   return cnt;
 }
 static int

--- a/src/utils/mtev_lru.c
+++ b/src/utils/mtev_lru.c
@@ -208,9 +208,10 @@ mtev_lru_put(mtev_lru_t *lru, const char *key, size_t key_len, void *val)
 mtev_lru_entry_token
 mtev_lru_get(mtev_lru_t *c, const char *key, size_t key_len, void **value)
 {
+  char tempkey_buf[ALLOCA_LIMIT];
   struct lru_key *tempkey = NULL;
   if (key_len <= ALLOCA_LIMIT) {
-    tempkey = alloca(sizeof(struct lru_key) + key_len);
+    tempkey = (struct lru_key *)tempkey_buf;
   } else {
     tempkey = malloc(sizeof(struct lru_key) + key_len);
   }
@@ -258,10 +259,10 @@ mtev_lru_release(mtev_lru_t *c, mtev_lru_entry_token token)
 void *
 mtev_lru_remove(mtev_lru_t *c, const char *key, size_t key_len)
 {
-
+  char tempkey_buf[ALLOCA_LIMIT];
   struct lru_key *tempkey = NULL;
   if (key_len <= ALLOCA_LIMIT) {
-    tempkey = alloca(sizeof(struct lru_key) + key_len);
+    tempkey = (struct lru_key *)tempkey_buf;
   } else {
     tempkey = malloc(sizeof(struct lru_key) + key_len);
   }

--- a/src/utils/mtev_skiplist.c
+++ b/src/utils/mtev_skiplist.c
@@ -25,13 +25,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
 
 #ifndef MIN
 #define MIN(a,b) ((a<b)?(a):(b))
 #endif
+#define MAX_HEIGHT 24
 
 struct _iskiplist {
   mtev_skiplist_comparator_t compare;
@@ -300,8 +298,9 @@ mtev_skiplist_node *mtev_skiplist_insert(mtev_skiplist *sl,
 mtev_skiplist_node *mtev_skiplist_insert_compare(mtev_skiplist *sl,
                                                  const void *data,
                                                  mtev_skiplist_comparator_t comp) {
-  mtev_skiplist_node *m, *p, *tmp, *ret = NULL, **stack;
+  mtev_skiplist_node *m, *p, *tmp, *ret = NULL;
   int nh=1, ch, stacki;
+  mtev_skiplist_node *stack[MAX_HEIGHT+1];
   if (!sl) return NULL;
   if(!sl->top) {
     sl->height = 1;
@@ -310,9 +309,9 @@ mtev_skiplist_node *mtev_skiplist_insert_compare(mtev_skiplist *sl,
     sl->top->sl = sl;
   }
   if(sl->preheight) {
-    while(nh < sl->preheight && get_b_rand()) nh++;
+    while(nh < sl->preheight && nh < MAX_HEIGHT && get_b_rand()) nh++;
   } else {
-    while(nh <= sl->height && get_b_rand()) nh++;
+    while(nh <= sl->height && nh < MAX_HEIGHT && get_b_rand()) nh++;
   }
   /* Now we have the new height at which we wish to insert our new node */
   /* Let us make sure that our tree is a least that tall (grow if necessary)*/
@@ -326,7 +325,6 @@ mtev_skiplist_node *mtev_skiplist_insert_compare(mtev_skiplist *sl,
   /* Find the node (or node after which we would insert) */
   /* Keep a stack to pop back through for insertion */
   m = sl->top;
-  stack = (mtev_skiplist_node **)alloca(sizeof(mtev_skiplist_node *)*(nh));
   stacki=0;
   while(m) {
     int compared=-1;

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -361,7 +361,7 @@ static void stop_other_threads(void) {
   size = pathconf(path, _PC_NAME_MAX);
 #endif
   size = MAX(size, PATH_MAX + 128);
-  de = alloca(size);
+  de = malloc(size);
   root = opendir(path);
   if(!root) return;
   while(portable_readdir_r(root, de, &entry) == 0 && entry != NULL) {
@@ -375,6 +375,7 @@ static void stop_other_threads(void) {
     }
   }
   closedir(root);
+  free(de);
 #endif
 #endif
 }


### PR DESCRIPTION
 * aco and alloca() don't always get along. alloca() is evil.
   Remove all alloca().
 * The eventer uses a TLS variable to track the "current" event
   in a callback, but we really want this tracked per co-routine.
   Extend the aco context to hold some tls-like things and
   store/retrieve the current event in there when we're in an aco
   context.