### PR TITLE
Fix logging zipkin with ACO and http2.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 1.8
 
+ * Add zipkin context to flatbuffer logs.
+ * Make zipkin work with http2 and ACO.
  * If the app name is unset do not add app:unknown to stats.
  * Fix sign issues in jobq statistics.
  * Add `total_jobs` to jobq statistics.

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -1402,6 +1402,8 @@ void eventer_add_recurrent(eventer_t e) {
 int eventer_run_callback(eventer_func_t f, eventer_t e, int m, void *c, struct timeval *n, uint64_t *dur) {
   int rmask;
   uint64_t start;
+  /* tracking callback latency on aco events makes no sense. */
+  if(eventer_is_aco(e)) dur = NULL;
   if(dur) start = mtev_gethrtime();
   eventer_t previous_event = eventer_get_this_event();
   eventer_ref(e);

--- a/src/examples/aco.c
+++ b/src/examples/aco.c
@@ -199,7 +199,7 @@ listen_to_me(void) {
 static void
 ping(void) {
   while(1) {
-    mtevEL(mtev_error, MLKV { MLKV_STR("key1", "a string"), MLKV_END }, "ping...\n");
+    mtevEL(mtev_debug, MLKV { MLKV_STR("key1", "a string"), MLKV_END }, "ping...\n");
     eventer_aco_sleep(&(struct timeval){ 1UL, 0UL });
   }
 }

--- a/src/examples/aco.conf
+++ b/src/examples/aco.conf
@@ -4,6 +4,7 @@
   <watchdog glider="/opt/local/bin/bt"
             tracedir="/var/cores/example"/>
   -->
+  <zipkin><probability new="1"/></zipkin>
   <eventer>
     <config>
       <concurrency>1</concurrency>

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -488,10 +488,12 @@ mtev_http_begin_span(mtev_http_session_ctx *ctx) {
   ctx->zipkin_span =
     mtev_zipkin_span_new(trace_id, parent_span_id, span_id,
                          mtev_http_request_uri_str(req), true, sampled, false);
+  mtevL(mtev_error, "BEGIN_SPAN(%p)\n", ctx->zipkin_span);
   mtev_http_connection *conn = mtev_http_session_connection(ctx);
   if(conn) {
     eventer_t e = mtev_http_connection_event(conn);
     if(e) {
+  mtevL(mtev_error, "ATTACH_SPAN(%p -> %p)\n", ctx->zipkin_span, e);
       mtev_zipkin_attach_to_eventer(e, ctx->zipkin_span, false, trace_events);
     }
   }

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -488,12 +488,10 @@ mtev_http_begin_span(mtev_http_session_ctx *ctx) {
   ctx->zipkin_span =
     mtev_zipkin_span_new(trace_id, parent_span_id, span_id,
                          mtev_http_request_uri_str(req), true, sampled, false);
-  mtevL(mtev_error, "BEGIN_SPAN(%p)\n", ctx->zipkin_span);
   mtev_http_connection *conn = mtev_http_session_connection(ctx);
   if(conn) {
     eventer_t e = mtev_http_connection_event(conn);
     if(e) {
-  mtevL(mtev_error, "ATTACH_SPAN(%p -> %p)\n", ctx->zipkin_span, e);
       mtev_zipkin_attach_to_eventer(e, ctx->zipkin_span, false, trace_events);
     }
   }

--- a/src/utils/mtev_zipkin.h
+++ b/src/utils/mtev_zipkin.h
@@ -454,6 +454,16 @@ API_EXPORT(void) mtev_zipkin_client_drop(struct _event *e);
 */
 API_EXPORT(void) mtev_zipkin_client_publish(struct _event *e);
 
+/*! \fn void mtev_zipkin_attach_to_aco(Zipkin_Span *span, bool new_child, mtev_zipkin_event_trace_level_t *track)
+    \brief Attach an active span (or new child span) to an aco thread.
+    \param span An existing zipkin span.
+    \param new_child Whether or not a child should be created under the provided span.
+    \param track Specifies how event activity should be tracked.
+*/
+API_EXPORT(void)
+  mtev_zipkin_attach_to_aco(Zipkin_Span *span, bool new_child,
+                            mtev_zipkin_event_trace_level_t *track);
+
 /*! \fn void mtev_zipkin_attach_to_eventer(eventer_t e, Zipkin_Span *span, bool new_child, mtev_zipkin_event_trace_level_t *track)
     \brief Attach an active span (or new child span) to an event.
     \param e An event object (or NULL for the current event)


### PR DESCRIPTION
 * Add zipkin metadata to flatbuffer logs.
 * Fix zipkin traces if they move into ACO thread in mtev_rest.
 * Fix zipkin traces in http2.