### PR TITLE
Allow requests to migrate in/out of ACO.

### DIFF
--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -1756,7 +1756,7 @@ mtev_http1_session_drive(eventer_t e, int origmask, void *closure,
     mtev_http1_request_release(ctx);
     mtev_http1_response_release(ctx);
   }
-  if(ctx->req.complete == mtev_false) goto next_req;
+  if(ctx->req.complete == mtev_false && !mtev_http1_session_aco(ctx)) goto next_req;
   if(ctx->conn.e) {
     mtevL(http_debug, "[fd=%d] <- mtev_http1_session_drive() [%x]\n", eventer_get_fd(e), mask|rv);
     return mask | rv;

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -405,9 +405,8 @@ mtev_http_get_handler(mtev_http_rest_closure_t *restc, mtev_boolean *migrate) {
     restc->fastpath = rule->handler;
     restc->closure = rule->closure;
     restc->aco_enabled = rule->aco_enabled;
-    if(migrate) *migrate = mtev_false;
-    if(migrate && !mtev_http_session_aco(restc->http_ctx)) {
-      /* If we've started ACO, we can migrate to a new eventer thread */
+    if(migrate) {
+      *migrate = mtev_false;
       eventer_t e = mtev_http_connection_event(mtev_http_session_connection(restc->http_ctx));
       if(e) {
         if(rule->pool) {


### PR DESCRIPTION
HTTP1 requests should allow migration even when the context
is in ACO.  Migration only happens at request assignment and
those contexts can change.  The core of this is making the http1
session driver not pipeline requests when the context is in aco
mode.