### PR TITLE
Add lua mtev.process:status

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@
  * Allow crash stacktraces to be redirected optionally onto
    different log outlet
  * Add file_synch log type
+ * Add lua mtev.process:status to get status of a spawned process
 
 ### 1.9.2
 

--- a/docs-md/apireference/lua.md
+++ b/docs-md/apireference/lua.md
@@ -1068,6 +1068,21 @@ mtev.Proc:start()
   * **RETURN** self
 
 
+#### mtev.Proc:status
+
+> check the status of a spawned process
+
+```lua
+result, status, errno =
+mtev.Proc:status()
+```
+
+
+  * **RETURN** result is the pid if the process changed state, -1 if error (errno will hold the
+ error code), 0 if no change to status; status will be set if process changed state, errno as in
+ mtev.process:wait().  In the case of process state change, status is passed throught the WEXITSTATUS() before returning.
+
+
 #### mtev.Proc:wait
 
 >wait for a process to terminate
@@ -1121,6 +1136,22 @@ mtev.process:pid()
 
 
   * **RETURN** The process id.
+
+
+#### mtev.process:status
+
+> check the status of a spawned process
+
+```lua
+result, status, errno =
+mtev.process:status()
+```
+
+
+  * **RETURN** result is the pid if the process changed state, -1 if error (errno will hold the
+ error code), 0 if no change to status; status will be set if process changed state, errno as in
+ mtev.process:wait().  In the case of process state change, status is passed throught the WEXITSTATUS() before returning.
+
 
 
 #### mtev.process:wait
@@ -1752,5 +1783,3 @@ mtev.xmlnode:next()
 ```
 
   * **RETURN** next sibling xml node
-
-

--- a/docs/apireference/lua.html
+++ b/docs/apireference/lua.html
@@ -1374,6 +1374,17 @@ mtev.Proc:start()
 <ul>
 <li><strong>RETURN</strong> self</li>
 </ul>
+<h4 id="mtevprocstatus">>mtev.Proc:status</h4>
+<blockquote>
+<p>check the status of a spawned process</p>
+</blockquote>
+<pre><code class="lang-lua">result, status, errno =
+mtev.Proc:status()
+</code></pre>
+<ul><li><strong>RETURN</strong> result is the pid if the process changed state, -1 if error (errno will
+hold the error code), 0 if no change to status; status will be set if process changed state, errno
+as in mtev.process:wait().  In the case of process state change, status is passed through the WEXITSTATUS() before returning.</li>
+</ul>
 <h4 id="mtevprocwait">mtev.Proc:wait</h4>
 <blockquote>
 <p>wait for a process to terminate</p>
@@ -1416,6 +1427,17 @@ mtev.process:pid()
 </code></pre>
 <ul>
 <li><strong>RETURN</strong> The process id.</li>
+</ul>
+<h4 id="mtevprocstatus">>mtev.process:status</h4>
+<blockquote>
+<p>check the status of a spawned process</p>
+</blockquote>
+<pre><code class="lang-lua">result, status, errno =
+mtev.process:status()
+</code></pre>
+<ul><li><strong>RETURN</strong> result is the pid if the process changed state, -1 if error (errno will
+hold the error code), 0 if no change to status; status will be set if process changed state, errno
+as in mtev.process:wait().  In the case of process state change, status is passed through the WEXITSTATUS() before returning.</li>
 </ul>
 <h4 id="mtevprocesswait">mtev.process:wait</h4>
 <blockquote>
@@ -1940,4 +1962,3 @@ mtev.xmlnode:<span class="hljs-built_in">next</span>()
 
     </body>
 </html>
-

--- a/test/mtevbusted/child.lua
+++ b/test/mtevbusted/child.lua
@@ -233,6 +233,11 @@ function TestProc:pid()
   return self.proc:pid()
 end
 
+function TestProc:status()
+  if self.proc == nil then return -1 end
+  return self.proc:status()
+end
+
 function start_child(props)
   local proc = TestProc:new(props)
   proc:start()


### PR DESCRIPTION
A process spawned by libmtev lua mtev.spawn may crash, and if the parent process is waiting for it to finish something lengthy, there was previously no function to just check status.  This PR adds a lua function mtev.process:status which allows a lua client to check the status so that it can be polled for a crash during a lengthy operation, especially useful in busted tests (right now the timeout is 5 minutes unless otherwise specified).