### PR TITLE
Crash stack dump improvements.

### DIFF
--- a/src/mtev_console_state.c
+++ b/src/mtev_console_state.c
@@ -44,6 +44,7 @@
 #include "mtev_rest.h"
 #include "mtev_console.h"
 #include "mtev_console_socket.h"
+#include "mtev_stacktrace.h"
 #include "mtev_tokenizer.h"
 #include "mtev_capabilities_listener.h"
 
@@ -1300,6 +1301,8 @@ mtev_console_crash(mtev_console_closure_t ncct, int argc, char **argv,
                    mtev_console_state_t *dstate, void *unused) {
   (void)dstate;
   (void)unused;
+  mtev_stacktrace(mtev_log_stream_find(ncct->feed_path));
+  usleep(10000);
   if(argc == 1) {
     int id = atoi(argv[0]);
     nc_printf(ncct, "crash: %d\n", id);

--- a/src/utils/mtev_stacktrace.h
+++ b/src/utils/mtev_stacktrace.h
@@ -39,6 +39,9 @@
 API_EXPORT(void)
   mtev_stacktrace(mtev_log_stream_t ls);
 
+API_EXPORT(void)
+  mtev_stacktrace_skip(mtev_log_stream_t ls, int ignore);
+
 #if defined(__sun__)
 #include <ucontext.h>
 API_EXPORT(void)
@@ -47,6 +50,9 @@ API_EXPORT(void)
 
 API_EXPORT(int)
   mtev_aco_stacktrace(mtev_log_stream_t ls, aco_t *co);
+
+API_EXPORT(int)
+  mtev_aco_stacktrace_skip(mtev_log_stream_t ls, aco_t *co, int ignore);
 
 API_EXPORT(int)
   mtev_backtrace(void **ips, int cnt);

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -400,14 +400,16 @@ void mtev_watchdog_on_crash_close_add_fd(int fd) {
 }
 
 void mtev_self_diagnose(int sig, siginfo_t *si, void *uc) {
+  mtev_log_enter_sighandler();
 #if defined(__sun__)
   (void)si;
   mtev_stacktrace_ucontext(mtev_error_stacktrace, uc);
 #else
   (void)si;
   (void)uc;
-  mtev_stacktrace(mtev_error_stacktrace);
+  mtev_stacktrace_skip(mtev_error_stacktrace, 3);
 #endif
+  mtev_log_leave_sighandler();
   raise(sig);
 }
 
@@ -444,15 +446,16 @@ void emancipate(int sig, siginfo_t *si, void *uc) {
     mtevL(mtev_error, "Watchdogged on %s, no pthread_sigqueue\n", hb->name);
 #endif
   }
-  mtevL(mtev_error, "emancipate: process %d, monitored %d, signal %d\n", getpid(), mtev_monitored_child_pid, sig);
   if(getpid() == watcher) {
     char sigval[12];
+    mtevL(mtev_error, "[monitor] emancipate: process %d, monitored %d, signal %d\n", getpid(), mtev_monitored_child_pid, sig);
     const char *signame = short_strsignal(sig);
     snprintf(sigval, sizeof(sigval), "%d", sig);
     run_glider(mtev_monitored_child_pid, GLIDE_CRASH, signame ? signame : sigval);
     kill(mtev_monitored_child_pid, sig);
   }
   else if (getpid() == mtev_monitored_child_pid){
+    mtevL(mtev_error, "emancipate: process %d, monitored %d, signal %d\n", getpid(), mtev_monitored_child_pid, sig);
     it_ticks_crash(NULL); /* slow notification path */
     mmap_lifelines[0].sig = sig; /* communicate the signal as it will be hidden by our STOP */
     kill(mtev_monitored_child_pid, SIGSTOP); /* stop and wait for a glide */
@@ -462,7 +465,7 @@ void emancipate(int sig, siginfo_t *si, void *uc) {
     mtev_stacktrace_ucontext(mtev_error_stacktrace, uc);
 #else
     (void)uc;
-    mtev_stacktrace(mtev_error_stacktrace);
+    mtev_stacktrace_skip(mtev_error_stacktrace, 3);
 #endif
 
     if(allow_async_dumps) { 

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -600,17 +600,17 @@ mtev_setup_crash_signals(void (*action)(int, siginfo_t *, void *)) {
   struct sigaction sa;
   stack_t altstack;
   size_t altstack_size = 0, default_altstack_size = 4*1024*1024;
-  static const int signals[] = {
-    SIGSEGV,
-    SIGABRT,
-    SIGBUS,
-    SIGILL,
-    SIGUSR2,
-    SIGTRAP,
+  static const struct { int signo; int block; } signals[] = {
+    { SIGSEGV, 0 },
+    { SIGABRT, 1 },
+    { SIGBUS, 0 },
+    { SIGILL, 0 },
+    { SIGUSR2, 1 },
+    { SIGTRAP, 1 },
 #ifdef SIGIOT
-    SIGIOT,
+    { SIGIOT, 1 },
 #endif
-    SIGFPE
+    { SIGFPE, 1 }
   };
 
   if(NULL != (envcp = getenv("MTEV_ALTSTACK_SIZE"))) {
@@ -642,10 +642,10 @@ mtev_setup_crash_signals(void (*action)(int, siginfo_t *, void *)) {
   sigemptyset(&sa.sa_mask);
 
   for (i = 0; i < sizeof(signals) / sizeof(*signals); i++)
-    sigaddset(&sa.sa_mask, signals[i]);
+    if(signals[i].block) sigaddset(&sa.sa_mask, signals[i].signo);
 
   for (i = 0; i < sizeof(signals) / sizeof(*signals); i++)
-    sigaction(signals[i], &sa, NULL);
+    sigaction(signals[i].signo, &sa, NULL);
 
   return 0;
 }


### PR DESCRIPTION
 * Quiet down dwarf debug
 * Print stacks when crashing in foreground (-D)
 * Attempt to recover from crashes within crashes.