### PR TITLE
Append and flush should "fail" on disconnected clients.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,8 @@
 ## 1.9
 
  * Improve safety of hooked stack traces.
+ * Make http append and flush return false for disconnected clients.
+ * Make foreground stacktraces reliably print.
  * Fix cross-thread trigger on closed events.
 
 ### 1.9.5

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -290,7 +290,7 @@ mtev_http_response_append(mtev_http_session_ctx *ctx,
   mtev_boolean success = mtev_false;
   mtev_http_response *res = mtev_http_session_response(ctx);
   pthread_mutex_lock(&res->output_lock);
-  if(res->closed == mtev_true) goto out;
+  if(res->in_error || res->closed) goto out;
   if(res->output_started == mtev_true &&
      !(res->output_options & (MTEV_HTTP_CLOSE | MTEV_HTTP_CHUNKED)))
     goto out;
@@ -331,7 +331,7 @@ mtev_http_response_append_bchain(mtev_http_session_ctx *ctx,
   mtev_boolean success = mtev_false;
   mtev_http_response *res = mtev_http_session_response(ctx);
   pthread_mutex_lock(&res->output_lock);
-  if(res->closed == mtev_true) goto out;
+  if(res->in_error || res->closed) goto out;
   if(res->output_started == mtev_true &&
      !(res->output_options & (MTEV_HTTP_CHUNKED | MTEV_HTTP_CLOSE)))
     goto out;

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -503,13 +503,13 @@ _http_perform_write(mtev_http1_session_ctx *ctx, int *mask) {
 
   if(!ctx->conn.e || ctx->res.in_error) {
     pthread_mutex_unlock(&ctx->write_lock);
-    return 0;
+    return -1;
   }
   if(!b) {
     if(ctx->res.closed) ctx->res.complete = mtev_true;
     *mask = EVENTER_EXCEPTION;
     pthread_mutex_unlock(&ctx->write_lock);
-    return tlen;
+    return (ctx->res.closed && tlen <= 0) ? -1 : tlen;
   }
 
   if(ctx->res.output_raw_offset >= b->size) {


### PR DESCRIPTION
Make sure that mtev_http_response_flush and mtev_http_response_append
return false when there is an underlying problem with the http session.