### PR TITLE
Make `mtev_http_rest_register` secure-by-defualt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@
 ## 1.9
 
  * Protect against invalid watchdog retry and span settings.
+ * Make `mtev_http_rest_register` use the default ACL auth such
+   that configured ACL will apply.  This prevents a classic coding
+   mistake that produces unsecurable endpoints.
 
 ### 1.9.6
 

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -549,13 +549,13 @@ skipto:
 struct rest_url_dispatcher *
 mtev_http_rest_new_rule(const char *method, const char *base,
                         const char *expr, rest_request_handler f) {
-  return mtev_http_rest_new_rule_auth_closure(method, base, expr, f, NULL, NULL, NULL, NULL);
+  return mtev_http_rest_new_rule_auth_closure(method, base, expr, f, NULL, NULL, mtev_http_rest_client_cert_auth, NULL);
 }
 
 int
 mtev_http_rest_register(const char *method, const char *base,
                         const char *expr, rest_request_handler f) {
-  return mtev_http_rest_register_auth_closure(method, base, expr, f, NULL, NULL, NULL, NULL);
+  return mtev_http_rest_register_auth_closure(method, base, expr, f, NULL, NULL, mtev_http_rest_client_cert_auth, NULL);
 }
 void
 mtev_http_rest_disclose_endpoints(const char *base, const char *expr) {
@@ -564,7 +564,7 @@ mtev_http_rest_disclose_endpoints(const char *base, const char *expr) {
 int
 mtev_http_rest_register_closure(const char *method, const char *base,
                         const char *expr, rest_request_handler f, void *c) {
-  return mtev_http_rest_register_auth_closure(method, base, expr, f, NULL, NULL, NULL, c);
+  return mtev_http_rest_register_auth_closure(method, base, expr, f, NULL, NULL, mtev_http_rest_client_cert_auth, c);
 }
 int
 mtev_http_rest_register_auth(const char *method, const char *base,


### PR DESCRIPTION
Make it so that the most commonly used rest registration routine
uses the built-in auth by default such that programmers don't
accidentaly register endpoints that aren't securable.