### PR TITLE
Allow rest_auth_denied hook to "undeny".

### DIFF
--- a/src/modules/lua_mtev_http.c
+++ b/src/modules/lua_mtev_http.c
@@ -546,6 +546,12 @@ mtev_lua_setup_restc(lua_State *L,
   lua_setmetatable(L, -2);
 }
 
+void
+mtev_lua_va_mtev_http_restc(lua_State *L, va_list ap) {
+  mtev_http_rest_closure_t *restc = va_arg(ap, mtev_http_rest_closure_t *);
+  mtev_lua_setup_restc(L, restc);
+}
+
 static void
 mtev_lua_va_mtev_http_session_ctx(lua_State *L, va_list ap) {
   mtev_http_session_ctx *ctx = va_arg(ap, mtev_http_session_ctx *);
@@ -554,6 +560,8 @@ mtev_lua_va_mtev_http_session_ctx(lua_State *L, va_list ap) {
 int
 luaopen_mtev_http(lua_State *L) {
   (void)L;
+  mtev_lua_register_dynamic_ctype("mtev_http_rest_closure_t *",
+                                  mtev_lua_va_mtev_http_restc);
   mtev_lua_register_dynamic_ctype("mtev_http_session_ctx *",
                                   mtev_lua_va_mtev_http_session_ctx);
   mtev_lua_register_dynamic_ctype("mtev_http1_session_ctx *",

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -391,11 +391,11 @@ mtev_http_get_handler(mtev_http_rest_closure_t *restc, mtev_boolean *migrate) {
       restc->fastpath = NULL;
       restc->aco_enabled = mtev_false;
       switch(rest_auth_denied_hook_invoke(restc, &denied)) {
-        case MTEV_HOOK_DONE: return denied;
+        case MTEV_HOOK_DONE: break;
         case MTEV_HOOK_CONTINUE: break;
         case MTEV_HOOK_ABORT: return mtev_http_rest_error;
       }
-      return denied;
+      if(denied) return denied;
     }
       /* We match, set 'er up */
     mtev_zipkin_span_rename(mtev_http_zipkip_span(restc->http_ctx),


### PR DESCRIPTION
 * rest_auth_denied hooks can set the deny function to NULL to
   reverse a denial decision.
 * lua should register the rest closure as a vararg cimpl