### PR TITLE
MTEV_DIAGNOSE_CRASH can be set to an external tool path to be invoked with tid

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ## 1.9
 
+ * If MTEV_DIAGNOSE_CRASH is set to an external tool path, then the tool
+   will be invoked on a crash with the faulting thread id as a parameter.
+
 ### 1.9.8
 
  * Convey the client CN into the rest closure for `http_rest_api` listeners.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,8 +4,9 @@
 
 ## 1.9
 
- * If MTEV_DIAGNOSE_CRASH is set to an external tool path, then the tool
-   will be invoked on a crash with the faulting thread id as a parameter.
+ * If MTEV_DIAGNOSE_CRASH is set to an external tool path, then the
+   tool will be invoked on a crash with the faulting thread id (pid
+   on non-linux) as a parameter.
 
 ### 1.9.8
 

--- a/docs-md/operations/env.md
+++ b/docs-md/operations/env.md
@@ -37,8 +37,13 @@ any libmtev application.
 
  * ##### MTEV_DIAGNOSE_CRASH
 
-   If set to 0 or non-numeric, libmtev's internal crash handling code will not
-   be run.
+   If set to 0, libmtev's internal crash handling code will not
+   be run.  If set to 1, will run libmtev's internal crash handling code.
+   If set to a file path for a script or external tool, this will be invoked
+   on a crash with the thread id as a parameter (pid on non-linux).  Use a
+   wrapper script with execution rights and sudoers as needed to give sudo
+   permissions or additional calling parameters when invoking the external
+   tool.
 
  * ##### MTEV_LOG_DEBUG
 
@@ -62,4 +67,3 @@ any libmtev application.
    does not heartbeat from each thread within this number of seconds,
    the monitor will terminate and restart the child.  Non-integral
    numbers are allowed.
-

--- a/docs/operations/env.html
+++ b/docs/operations/env.html
@@ -674,7 +674,12 @@ for libmtev&apos;s &quot;faster time&quot; support.</p>
 </li>
 <li><h5 id="mtevdiagnosecrash">MTEV_DIAGNOSE_CRASH</h5>
 <p>If set to 0 or non-numeric, libmtev&apos;s internal crash handling code will not
-be run.</p>
+be run.  If set to 1, will run libmtev&apos;s internal crash handling code.
+If set to a file path for a script or external tool, this will be invoked
+on a crash with the thread id as a parameter (pid on non-linux).  Use a
+wrapper script with execution rights and sudoers as needed to give sudo
+permissions or additional calling parameters when invoking the external
+tool.</p>
 </li>
 <li><h5 id="mtevlogdebug">MTEV_LOG_DEBUG</h5>
 <p>If numeric and non-zero, this turns on debug logging for the logging system.
@@ -787,4 +792,3 @@ numbers are allowed.</p>
 
     </body>
 </html>
-

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -39,6 +39,8 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
 #include <dirent.h>
 #include <execinfo.h>
 #if defined(__sun__)
@@ -414,6 +416,24 @@ void mtev_self_diagnose(int sig, siginfo_t *si, void *uc) {
   mtev_stacktrace_skip(mtev_error_stacktrace, 3);
 #endif
   mtev_log_leave_sighandler();
+  raise(sig);
+}
+
+char *external_diagnose = NULL;
+void mtev_external_diagnose(int sig, siginfo_t *si, void *uc) {
+  (void)si;
+  (void)uc;
+  pid_t pid = syscall(SYS_gettid);
+  char pidstr[32];
+  snprintf(pidstr, sizeof(pidstr), "%u", pid);
+  int childpid = fork();
+  if (!childpid) {
+    execlp(external_diagnose, external_diagnose, pidstr);
+    mtevL(mtev_error, "Unable to launch external diagnosis\n");
+  }
+  else {
+    waitpid(childpid, NULL, 0);
+  }
   raise(sig);
 }
 

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -423,7 +423,11 @@ char *external_diagnose = NULL;
 void mtev_external_diagnose(int sig, siginfo_t *si, void *uc) {
   (void)si;
   (void)uc;
+#if defined(linux) || defined(__linux) || defined(__linux__)
   pid_t pid = syscall(SYS_gettid);
+#else
+  pid_t pid = getpid();
+#endif
   char pidstr[32];
   snprintf(pidstr, sizeof(pidstr), "%u", pid);
   int childpid = fork();

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -223,6 +223,9 @@ API_EXPORT(void)
 API_EXPORT(void)
   mtev_self_diagnose(int sig, siginfo_t *si, void *uc);
 
+API_EXPORT(void)
+  mtev_external_diagnose(int sig, siginfo_t *si, void *uc);
+
 API_EXPORT(int)
   mtev_setup_crash_signals(void (*)(int, siginfo_t *, void *));
 


### PR DESCRIPTION
In development and test, it can be convenient without requiring a parent to launch one of a number of debugging or reporting tools directly or via a script for mtev diagnose of a crash (instead of the internal stacktrace or backtrace coroner).  A small change allows this via MTEV_DIAGNOSE_CRASH directly.