### PR TITLE
Collect and display the column within the source line if available

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
  * If MTEV_DIAGNOSE_CRASH is set to an external tool path, then the
    tool will be invoked on a crash with the faulting thread id and
    process pid (pid only on non-linux).
+ * Display source line column numbers in stacktrace (when available) for
+   callstack addresses
 
 ### 1.9.8
 


### PR DESCRIPTION
Small 15 min enhancement to libmtev stacktrace, where we can now show the column number within a source line that corresponds to the callstack address (when it is available).  This can help clarify exactly within the source line what variable had a bad address or where the fault occurred.