### PR TITLE
Fix use-after-free in HTTP/2 logging.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 ## 1.9
 
  * Move eventer SSL debug logging to `debug/eventer/ssl`
+ * Fix use-after-free in http logging when HTTP/2 sessions are interrupted.
 
 ### 1.9.9
 

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -570,6 +570,9 @@ mtev_http_log_request(mtev_http_session_ctx *ctx) {
   mtev_http_request_start_time(req, &start_time);
   if(start_time.tv_sec == 0) return;
 
+  if(ctx->logged) return;
+  ctx->logged = true;
+
   const char *orig_qs = mtev_http_request_orig_querystring(req);
   mtev_http_response *res = mtev_http_session_response(ctx);
   mtev_gettimeofday(&end_time, NULL);

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -571,7 +571,7 @@ mtev_http_log_request(mtev_http_session_ctx *ctx) {
   if(start_time.tv_sec == 0) return;
 
   if(ctx->logged) return;
-  ctx->logged = true;
+  ctx->logged = mtev_true;
 
   const char *orig_qs = mtev_http_request_orig_querystring(req);
   mtev_http_response *res = mtev_http_session_response(ctx);

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -938,6 +938,7 @@ mtev_http1_request_release(mtev_http1_session_ctx *ctx) {
   mtev_hash_destroy(&ctx->req.querystring, NULL, NULL);
   mtev_hash_destroy(&ctx->req.headers, NULL, NULL);
 
+  ctx->logged = false;
   memset(&ctx->req.state, 0,
          sizeof(ctx->req) - (unsigned long)&(((mtev_http1_request *)0)->state));
 

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -938,7 +938,7 @@ mtev_http1_request_release(mtev_http1_session_ctx *ctx) {
   mtev_hash_destroy(&ctx->req.querystring, NULL, NULL);
   mtev_hash_destroy(&ctx->req.headers, NULL, NULL);
 
-  ctx->logged = false;
+  ctx->logged = mtev_false;
   memset(&ctx->req.state, 0,
          sizeof(ctx->req) - (unsigned long)&(((mtev_http1_request *)0)->state));
 

--- a/src/mtev_http_private.h
+++ b/src/mtev_http_private.h
@@ -38,6 +38,7 @@
 
 #define HTTP_SESSION_BASE \
   uint32_t http_type; \
+  bool logged; \
   Zipkin_Span *zipkin_span; \
   stats_handle_t *record 
 

--- a/src/mtev_http_private.h
+++ b/src/mtev_http_private.h
@@ -38,7 +38,7 @@
 
 #define HTTP_SESSION_BASE \
   uint32_t http_type; \
-  bool logged; \
+  mtev_boolean logged; \
   Zipkin_Span *zipkin_span; \
   stats_handle_t *record 
 


### PR DESCRIPTION
If an HTTP/2 session were snipped the accept consutruct was freed
long before the attempt to use in HTTP logging.  This change moves
HTTP/2 logging up to the connection snip time prior to the accept
construct free.