### PR TITLE
Make the lua mtev integration watchdog aware.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,7 @@
 
  * Move eventer SSL debug logging to `debug/eventer/ssl`
  * Fix use-after-free in http logging when HTTP/2 sessions are interrupted.
+ * Make the lua subsystem interrupt as it approaches a watchdog timeout.
 
 ### 1.9.9
 

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -1296,6 +1296,14 @@ API_EXPORT(double) eventer_watchdog_timeout(void);
 */
 API_EXPORT(mtev_boolean) eventer_watchdog_timeout_timeval(struct timeval *);
 
+/*! \fn mtev_boolean eventer_heartbeat_deadline(struct timeval *now, struct timeval *delta)
+    \brief Return the remaining time before the watchdog timeout on this thread.
+    \param now the current time (NULL means now)
+    \param delta the relative time remaining before a watchdog
+    \return mtev_true if the timeout was successfully calculated.
+*/
+API_EXPORT(mtev_boolean) eventer_heartbeat_deadline(struct timeval *now, struct timeval *delta);
+
 /*! \fn pthread_t eventer_choose_owner(int n)
     \brief Find a thread in the default eventer pool.
     \param n an integer.

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -361,6 +361,10 @@ void eventer_heartbeat(void) {
   mtevAssert(my_impl_data);
   mtev_watchdog_heartbeat(my_impl_data->hb);
 }
+mtev_boolean eventer_heartbeat_deadline(struct timeval *now, struct timeval *delta) {
+  mtevAssert(my_impl_data);
+  return mtev_watchdog_remaining(my_impl_data->hb, now, delta);
+}
 pthread_t eventer_choose_owner(int i) {
   return eventer_choose_owner_pool(&default_pool, i);
 }

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -283,7 +283,6 @@ mtev_lua_resume(lua_State *L, int a, mtev_lua_resume_info_t *ri) {
   }
   if(ri && ri->lmc && !(ri->lmc->interrupt_time.tv_sec == 0 && ri->lmc->interrupt_time.tv_usec == 0)) {
     /* if we have an interrupt time specified for this lmc, then we should potentially reduce to it */
-    mtevL(mtev_error, "interrupt_time set...\n");
     if((diff.tv_sec == 0 && diff.tv_usec == 0) ||
         compare_timeval(ri->lmc->interrupt_time, diff) < 0) {
       diff = ri->lmc->interrupt_time;

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -37,6 +37,9 @@
 #include <ck_pr.h>
 
 #include <unistd.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/syscall.h>
 
 #include "mtev_conf.h"
 #include "mtev_dso.h"
@@ -163,6 +166,23 @@ mtev_lua_gc_full(lua_module_closure_t *lmc) {
 }
 
 
+static void
+mtev_lua_timer_setup(lua_module_closure_t *lmc) {
+#if defined(linux) || defined(__linux) || defined(__linux__)
+  struct sigevent sev;
+  sev.sigev_notify = SIGEV_THREAD_ID;
+  sev.sigev_signo = SIGUSR1;
+  sev._sigev_un._tid = syscall(SYS_gettid);
+  sev.sigev_value.sival_ptr = &lmc->_timer;
+  if (timer_create(CLOCK_MONOTONIC, &sev, &lmc->_timer) == -1) {
+    mtevL(mtev_error, "timer_create failed: %s", strerror(errno));
+    return;
+  }
+
+  lmc->timer = &lmc->_timer;
+#endif
+}
+
 lua_module_closure_t *
 mtev_lua_lmc_alloc(mtev_dso_generic_t *self, mtev_lua_resume_t resume) {
   lua_module_closure_t *lmc;
@@ -174,6 +194,7 @@ mtev_lua_lmc_alloc(mtev_dso_generic_t *self, mtev_lua_resume_t resume) {
   lmc->eventer_id = eventer_is_loop(lmc->owner);
   lmc->self = self;
   lmc->resume = resume;
+  mtev_lua_timer_setup(lmc);
   return lmc;
 }
 
@@ -191,6 +212,11 @@ mtev_lua_lmc_free(lua_module_closure_t *lmc) {
                      (const char*)&lmc->lua_state, sizeof(lmc->lua_state),
                      free, NULL);
     pthread_mutex_unlock(&mtev_lua_states_lock);
+    if(lmc->timer) {
+      if (timer_delete(lmc->_timer) == -1) {
+        mtevL(mtev_error, "timer_delete failed: %s", strerror(errno));
+      }
+    }
   }
   free(lmc);
 }
@@ -198,12 +224,76 @@ mtev_lua_lmc_free(lua_module_closure_t *lmc) {
 static __thread lua_State *tls_active_lua_state = NULL;
 static __thread bool assist_fired;
 
+static void
+mtev_lua_timer_start(timer_t *lua_timer, struct timeval *diff) {
+  if(lua_timer == NULL) return;
+
+  mtevL(nldeb, "Starting lua timer: %p for %ld.%06ld\n", lua_timer, diff->tv_sec, diff->tv_usec);
+  struct itimerspec ispec;
+  memset(&ispec, 0, sizeof(ispec));
+  ispec.it_value.tv_sec = diff->tv_sec;
+  ispec.it_value.tv_nsec = diff->tv_usec * 1000;
+  if(timer_settime(*lua_timer, 0, &ispec, NULL) != 0)
+    mtevL(mtev_error, "timer_settime failed: %s\n", strerror(errno));
+}
+
+static void
+mtev_lua_timer_stop(timer_t *lua_timer) {
+  if(lua_timer == NULL) return;
+
+  mtevL(nldeb, "Stopping lua timer: %p\n", lua_timer);
+  struct itimerspec ispec;
+  memset(&ispec, 0, sizeof(ispec));
+  if(timer_settime(*lua_timer, 0, &ispec, NULL) != 0)
+    mtevL(mtev_error, "timer_settime failed: %s\n", strerror(errno));
+}
+static void lstop (lua_State *L, lua_Debug *ar) {
+  (void)ar;  /* unused arg. */
+  lua_sethook(L, NULL, 0, 0);  /* reset hook */
+  mtev_stacktrace(mtev_error);
+  luaL_error(L, "interrupted!");
+}
+
+static void
+mtev_lua_timer_fire(int sig, siginfo_t *info, void *c) {
+  (void)sig;
+  (void)info;
+  (void)c;
+  mtevL(nldeb, "timer fired: lua %p\n", tls_active_lua_state);
+
+  if(tls_active_lua_state) {
+    lua_sethook(tls_active_lua_state, lstop, LUA_MASKCALL | LUA_MASKRET | LUA_MASKCOUNT,1);
+  }
+}
+
 int
-mtev_lua_resume(lua_State *L, int a) {
+mtev_lua_resume(lua_State *L, int a, mtev_lua_resume_info_t *ri) {
   int rv;
+  struct timeval diff = { .tv_sec = 0, .tv_usec = 0 };
   lua_State *previous = tls_active_lua_state;
   tls_active_lua_state = L;
+  if(eventer_heartbeat_deadline(NULL, &diff)) {
+    sub_timeval(diff, (struct timeval){ .tv_sec = 2, .tv_usec = 0 }, &diff);
+    if(diff.tv_sec < 0 || diff.tv_usec < 0) {
+      mtevL(nlerr, "lua attempting to resume with no time left before watchdog\n");
+      mtev_stacktrace(nlerr);
+      diff.tv_sec = 0;
+      diff.tv_usec = 1;
+    }
+  }
+  if(ri && ri->lmc && !(ri->lmc->interrupt_time.tv_sec == 0 && ri->lmc->interrupt_time.tv_usec == 0)) {
+    /* if we have an interrupt time specified for this lmc, then we should potentially reduce to it */
+    mtevL(mtev_error, "interrupt_time set...\n");
+    if((diff.tv_sec == 0 && diff.tv_usec == 0) ||
+        compare_timeval(ri->lmc->interrupt_time, diff) < 0) {
+      diff = ri->lmc->interrupt_time;
+    }
+  }
+  if(diff.tv_sec >= 0 && diff.tv_usec >= 0) {
+    mtev_lua_timer_start(ri->lmc->timer, &diff);
+  }
   rv = lua_resume(L, a);
+  mtev_lua_timer_stop(ri->lmc->timer);
   tls_active_lua_state = previous;
   return rv;
 }
@@ -1239,4 +1329,18 @@ mtev_lua_init_globals(void) {
   stats_handle_units(gc_total, STATS_UNITS_TRANSACTIONS);
   gc_latency = stats_register(lua_stats_ns, "gc_latency", STATS_TYPE_HISTOGRAM_FAST);
   stats_handle_units(gc_latency, STATS_UNITS_SECONDS);
+
+  struct sigaction sa;
+  sa.sa_flags = SA_SIGINFO;
+  sa.sa_sigaction = mtev_lua_timer_fire;
+  sigemptyset(&sa.sa_mask);
+  if (sigaction(SIGUSR1, &sa, NULL) == -1)
+    mtevL(mtev_error, "sigaction failed: %s\n", strerror(errno));
+
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGUSR1);
+  if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1)
+    mtevL(mtev_error, "sigprocmask failed: %s\n", strerror(errno));
+
 }

--- a/src/modules/lua_mtev.h
+++ b/src/modules/lua_mtev.h
@@ -65,6 +65,9 @@ typedef struct lua_module_closure {
   mtev_dso_generic_t *self;
   lua_module_gc_params_t *gcparams;
   int ffi_index;
+  timer_t _timer;
+  timer_t *timer;
+  struct timeval interrupt_time;
 } lua_module_closure_t;
 
 API_EXPORT(void) mtev_lua_set_gc_params(lua_module_closure_t *, lua_module_gc_params_t *);
@@ -199,7 +202,7 @@ lua_State *mtev_lua_open(const char *module_name, void *lmc,
                          const char *script_dir, const char *cpath);
 void mtev_lua_init_globals(void);
 void register_console_lua_commands(void);
-int mtev_lua_resume(lua_State *L, int);
+int mtev_lua_resume(lua_State *L, int, mtev_lua_resume_info_t *);
 int mtev_lua_pcall(lua_State *L, int, int, int);
 int mtev_lua_traceback(lua_State *L);
 void mtev_lua_new_coro(mtev_lua_resume_info_t *);

--- a/src/modules/lua_mtev_traceback.c
+++ b/src/modules/lua_mtev_traceback.c
@@ -39,7 +39,7 @@ void mtev_luaL_traceback (void (*cb)(void *, const char *, size_t), void *closur
   if (msg) CBF(closure, "%s\n", msg);
   cb(closure, "stack traceback:", strlen("stack traceback:"));
   while (lua_getstack(L1, level++, &ar)) {
-    GCfunc *fn;
+    GCfunc *fn = NULL;
     if (level > lim) {
       if (!lua_getstack(L1, level + TRACEBACK_LEVELS2, &ar)) {
 	level--;
@@ -52,9 +52,9 @@ void mtev_luaL_traceback (void (*cb)(void *, const char *, size_t), void *closur
       continue;
     }
     lua_getinfo(L1, "Snlf", &ar);
-    if(L1->top == NULL) fn = NULL;
-    else {
-      fn = funcV(L1->top-1);
+    if(L1->top != NULL) {
+      /* Sometimes this returns a bad pointer and tragedy ensues... */
+      /* fn = funcV(L1->top-1); */
       L1->top--;
     }
     if (fn && isffunc(fn) && !*ar.namewhat)

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -957,6 +957,21 @@ double mtev_watchdog_get_timeout(mtev_watchdog_t *lifeline) {
   return global_child_watchdog_timeout;
 }
 mtev_boolean
+mtev_watchdog_remaining(mtev_watchdog_t *lifeline, struct timeval *now, struct timeval *diff) {
+  struct timeval timeout, _now;
+  if(lifeline == NULL) lifeline = mmap_lifelines;
+  if(lifeline->parent_view.last_changed.tv_sec == 0) return mtev_false;
+  if(!mtev_watchdog_get_timeout_timeval(lifeline, &timeout)) return mtev_false;
+  add_timeval(lifeline->parent_view.last_changed, timeout, &timeout);
+  /* timeout is now absolute */
+  if(!now) {
+    mtev_gettimeofday(&_now, NULL);
+    now = &_now;
+  }
+  sub_timeval(timeout, *now, diff);
+  return mtev_true;
+}
+mtev_boolean
 mtev_watchdog_get_timeout_timeval(mtev_watchdog_t *lifeline, struct timeval *dur) {
   if(lifeline == NULL) return mtev_false;
   if(dur == NULL) return mtev_true;

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -169,6 +169,16 @@ API_EXPORT(double)
 API_EXPORT(mtev_boolean)
   mtev_watchdog_get_timeout_timeval(mtev_watchdog_t *hb, struct timeval *dur);
 
+/* \fn mtev_boolean mtev_watchdog_remaining(mtev_watchdog_t *lifeline, struct timeval *now, struct timeval *diff)
+   \brief determines the time remaining on a watchdog.
+   \param lifeline the heartbeat
+   \param now the current time (NULL will result in the current time)
+   \param diff a relative time remaining.
+   \return mtev_true if the calculation could be made.
+ */
+API_EXPORT(mtev_boolean)
+  mtev_watchdog_remaining(mtev_watchdog_t *lifeline, struct timeval *now, struct timeval *diff);
+
 /*! \fn uint32_t mtev_watchdog_number_of_starts(void)
     \brief Determine the number of times a child has been lauched.
     \return The number of times fork has returned in the parent.  In a running server, 0 means you're the first generation.


### PR DESCRIPTION
Use thread-directed (Linux) POSIX timers to trigger a lua_hook
insertion into the state that stack traces and calls luaL_error().
This should prevent long-running lua states in a callback from
triggering the watchdog by breaking them.