### PR TITLE
Fix short HTTP/1 payload reads.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 ## 1.9
 
  * Pass the siginfo context into the stacktrace for self-diagnosis.
+ * Fix short HTTP/1 payload reads.
 
 ### 1.9.10
 

--- a/src/mtev_rest.c
+++ b/src/mtev_rest.c
@@ -1208,13 +1208,13 @@ rest_get_raw_upload(mtev_http_rest_closure_t *restc,
       *complete = 1;
       return NULL;
     }
-    if(mtev_http_request_payload_complete(req)) {
+    if(len == 0) {
+      if(!mtev_http_request_payload_complete(req)) {
+        *complete = 1;
+        return NULL;
+      }
       *size = rxc->len;
       rxc->complete = 1;
-    }
-    if(len == 0) {
-      *complete = 1;
-      return NULL;
     }
   }
 


### PR DESCRIPTION
We should only mark a payload complete when we have nothing left to
read.