### PR TITLE
Fix thread-safety issues with mtev_conf reads.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ## 1.10
 
+ * Fix thread-safey issue using XPath within `mtev_conf`.
  * Fix `mtev.uname` on Solaris/Illummos
  * Fix missed http/1 request count increment.
  * Include -lssl in `mtev_lua/mtev.so`


### PR DESCRIPTION
Multireader support had us reusing a single global XPath
context.  This was completely broken.  Thread-local storage
of context and generational counter is leveraged to maintain
a cached, per-thread XPathContext and recreating it on config
reloads.