### PR TITLE
CIRC-5027 Add log-volume statistics

### DIFF
--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -2943,7 +2943,7 @@ mtev_conf_log_init(const char *toplevel,
     mtev_log_stream_t ls;
     char name[256], type[256], path[256], format[16];
     mtev_hash_table *config;
-    mtev_boolean disabled, debug, timestamps, facility;
+    mtev_boolean disabled, debug, timestamps, facility, stats;
 
     if(!mtev_conf_get_stringbuf(log_configs[i],
                                 "ancestor-or-self::node()/@name",
@@ -3043,6 +3043,15 @@ mtev_conf_log_init(const char *toplevel,
         }
       }
     }
+
+    if(mtev_conf_get_boolean(log_configs[i],
+                             "ancestor-or-self::node()/@stats",
+                             &stats)) {
+      if(stats) {
+        mtev_log_stream_stats_enable(ls);
+      }
+    }
+
     mtev_conf_release_sections_read(outlets, ocnt);
   }
   mtev_conf_release_sections_read(log_configs, cnt);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -2846,7 +2846,7 @@ mtev_log_init_globals(void) {
 
     mtev_stats_init();
     mtev_log_lines_stats_ns = mtev_stats_ns(
-      mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log", "lines");
+      mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log"), "lines");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "framework", "libmtev");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "mtev", "log");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "units", STATS_UNITS_MESSAGES);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1604,7 +1604,6 @@ mtev_log_stream_new_internal(const char *name, const char *type, const char *pat
   }
   /* This is for things that don't open on paths */
   if(ctx) ls->op_ctx = ctx;
-
   mtev_log_rematerialize();
   return ls;
 

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -2845,10 +2845,9 @@ mtev_log_init_globals(void) {
     filter_runtime = mtev_logic_exec_alloc(&flatbuffer_log_filter_ops);
 
     mtev_stats_init();
-    mtev_log_lines_stats_ns = mtev_stats_ns(
-      mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log"), "lines");
-    stats_ns_add_tag(mtev_log_lines_stats_ns, "framework", "libmtev");
-    stats_ns_add_tag(mtev_log_lines_stats_ns, "mtev", "log");
+    stats_ns_t *mtev_log_stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log");
+    stats_ns_add_tag(mtev_log_stats_ns, "mtev", "log");
+    mtev_log_lines_stats_ns = mtev_stats_ns(mtev_log_stats_ns, "lines");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "units", STATS_UNITS_MESSAGES);
   }
 }

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -2845,7 +2845,8 @@ mtev_log_init_globals(void) {
     filter_runtime = mtev_logic_exec_alloc(&flatbuffer_log_filter_ops);
 
     mtev_stats_init();
-    mtev_log_lines_stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log");
+    mtev_log_lines_stats_ns = mtev_stats_ns(
+      mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log", "lines");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "framework", "libmtev");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "mtev", "log");
     stats_ns_add_tag(mtev_log_lines_stats_ns, "units", STATS_UNITS_MESSAGES);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -83,7 +83,7 @@ static __thread uint32_t recursion_block = 0;
 static pthread_mutex_t resize_lock;
 static int min_flush_seconds = ((MTEV_LOG_DEFAULT_DEDUP_S-1) / 2) + 1;
 static mtev_logic_exec_t *filter_runtime;
-static stats_ns_t *mtev_log_stats_ns;
+static stats_ns_t *mtev_log_lines_stats_ns;
 
 MTEV_HOOK_IMPL(mtev_log_plain,
                (mtev_log_stream_t ls, const struct timeval *whence,
@@ -1626,7 +1626,7 @@ mtev_boolean
 mtev_log_stream_stats_enable(mtev_log_stream_t ls) {
   if (!ls) return mtev_false;
   if (ls->stats) return mtev_true; /* already enabled */
-  ls->stats = stats_register_fanout(mtev_log_stats_ns, strdup(ls->name), STATS_TYPE_COUNTER, 16);
+  ls->stats = stats_register_fanout(mtev_log_lines_stats_ns, strdup(ls->name), STATS_TYPE_COUNTER, 16);
   if (!ls->stats) return mtev_false; /* failed allocating a stats handle */
   return mtev_true;
 }
@@ -2845,10 +2845,10 @@ mtev_log_init_globals(void) {
     filter_runtime = mtev_logic_exec_alloc(&flatbuffer_log_filter_ops);
 
     mtev_stats_init();
-    mtev_log_stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log");
-    stats_ns_add_tag(mtev_log_stats_ns, "framework", "libmtev");
-    stats_ns_add_tag(mtev_log_stats_ns, "mtev", "log");
-    stats_ns_add_tag(mtev_log_stats_ns, "units", "lines");
+    mtev_log_lines_stats_ns = mtev_stats_ns(mtev_stats_ns(NULL, "mtev"), "log");
+    stats_ns_add_tag(mtev_log_lines_stats_ns, "framework", "libmtev");
+    stats_ns_add_tag(mtev_log_lines_stats_ns, "mtev", "log");
+    stats_ns_add_tag(mtev_log_lines_stats_ns, "units", STATS_UNITS_MESSAGES);
   }
 }
 

--- a/src/utils/mtev_log.h
+++ b/src/utils/mtev_log.h
@@ -196,6 +196,7 @@ API_EXPORT(int) mtev_log_stream_rename(mtev_log_stream_t ls, const char *);
 API_EXPORT(void) mtev_log_stream_close(mtev_log_stream_t ls);
 API_EXPORT(size_t) mtev_log_stream_size(mtev_log_stream_t ls);
 API_EXPORT(size_t) mtev_log_stream_written(mtev_log_stream_t ls);
+API_EXPORT(mtev_boolean) mtev_log_stream_stats_enable(mtev_log_stream_t ls);
 API_EXPORT(const char *) mtev_log_stream_get_property(mtev_log_stream_t ls,
                                                       const char *);
 API_EXPORT(void) mtev_log_stream_set_property(mtev_log_stream_t ls,


### PR DESCRIPTION
This PR enables the operator can configure log outlets to emit metrics to mtev/stats:

Example Config: 
```
    <log name="error" facility="true" stats="true"/>
```

Result:
```
> curl -s 'localhost:8081/mtev/stats.json?format=tagged' | jq .

...
  "error|ST[app:noit,framework:libmtev,mtev:log,units:lines]": {
    "_type": "L",
    "_value": 11
  },
...
```

Currently there is no logic to disable/free stats counters, once they are enabled.