### PR TITLE
Two-stage the predicate matching to avoid vprintf.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 ## 1.10
 
  * Revert a behavior change in jobqs introduced in 1.10.3
+ * Further optimize `mtev_log` filtering.
 
 ### 1.10.6
 

--- a/src/utils/mtev_logic.c
+++ b/src/utils/mtev_logic.c
@@ -613,6 +613,19 @@ mtev_logic_exec_node(mtev_logic_exec_t *exec, mtev_logic_node_t *node, void *con
   return mtev_false;
 }
 
+static mtev_boolean
+mtev_logic_node_has_predicate(mtev_logic_node_t *n, const char *lval) {
+  if(n->logical_op == LOP_PREDICATE && !strcmp(n->predicate->left, lval)) return mtev_true;
+  for(int i=0; i<n->nelems; i++) {
+    if(mtev_logic_node_has_predicate(n->elems[i], lval)) return mtev_true;
+  }
+  return mtev_false;
+}
+mtev_boolean
+mtev_logic_has_predicate(mtev_logic_ast_t *ast, const char *lval) {
+  return mtev_logic_node_has_predicate(ast->root, lval);
+}
+
 mtev_boolean
 mtev_logic_exec(mtev_logic_exec_t *exec, mtev_logic_ast_t *ast, void *context) {
   return mtev_logic_exec_node(exec, ast->root, context);

--- a/src/utils/mtev_logic.h
+++ b/src/utils/mtev_logic.h
@@ -47,6 +47,8 @@ API_EXPORT(mtev_logic_exec_t *) mtev_logic_exec_alloc(const mtev_logic_ops_t *);
 API_EXPORT(void) mtev_logic_exec_free(mtev_logic_exec_t *);
 API_EXPORT(mtev_boolean) mtev_logic_exec(mtev_logic_exec_t *, mtev_logic_ast_t *, void *);
 
+API_EXPORT(mtev_boolean) mtev_logic_has_predicate(mtev_logic_ast_t *, const char *);
+
 API_EXPORT(void) mtev_logic_var_set_string(mtev_logic_var_t *, const char *);
 API_EXPORT(void) mtev_logic_var_set_stringn(mtev_logic_var_t *, const char *, size_t);
 API_EXPORT(void) mtev_logic_var_set_string_copy(mtev_logic_var_t *, const char *);


### PR DESCRIPTION
If the predicate for a filter doesn't include "message" then
we can do the evaluation without constructing the message and
it turns out that the vprintf can be quite expensive.  This will
break the predicate matching into two phases with the first phase
bailing early with an indicator if it cannot complete due to
needing the message constructed.

This bumps non-message predicates evaluation to 5.6mm/sec/core
on my test machine (from 2.6mm/sec/core).