### PR TITLE
 CIRC-5074 - Make mtev_cluster Config Update Synchronous

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
  * Add backtrace/ptrace pretty-printers for `mtev_hash_table` and
    `mtev_http*_request` values
  * Fix NPE when freeing a broken SSL context.
+ * Change `/cluster` endpoint to write mtev_cluster config changes
+   synchronously rather than asynchronously
 
 ### 1.10.7
 

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -576,6 +576,7 @@ mtev_cluster_write_config(mtev_cluster_t *cluster) {
     xmlAddChild(parent, node);
   }
   if(container) xmlAddChild(container, parent);
+  CONF_DIRTY(n);
   mtev_conf_mark_changed();
   if(mtev_conf_write_file(NULL) != 0) {
     mtev_conf_release_section_write(n);

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -578,9 +578,12 @@ mtev_cluster_write_config(mtev_cluster_t *cluster) {
   if(container) xmlAddChild(container, parent);
   CONF_DIRTY(n);
   mtev_conf_mark_changed();
-  mtev_conf_request_write();
+  if(mtev_conf_write_file(NULL) != 0) {
+    mtev_conf_release_section_write(n);
+    mtevL(cerror, "Failed to write config file in mtev_cluster_write_config\n");
+    return 0;
+  }
   mtev_conf_release_section_write(n);
-
   return 1;
 }
 

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -576,7 +576,6 @@ mtev_cluster_write_config(mtev_cluster_t *cluster) {
     xmlAddChild(parent, node);
   }
   if(container) xmlAddChild(container, parent);
-  CONF_DIRTY(n);
   mtev_conf_mark_changed();
   if(mtev_conf_write_file(NULL) != 0) {
     mtev_conf_release_section_write(n);


### PR DESCRIPTION
When calling mtev_cluster_write_config, we were marking the config dirty
and returning success before actually writing out the config. This could
cause the config change to be lost if there's an ill-timed crash. Change
to force writing the config.