### PR TITLE
CIRC-5074 - Add Flag To Cluster Endpoint To Force Conf Flush

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,10 @@
  * Add backtrace/ptrace pretty-printers for `mtev_hash_table` and
    `mtev_http*_request` values
  * Fix NPE when freeing a broken SSL context.
+ * Add optional header to `/cluster` PUT endpoint, "x-mtev-conf-synch", that, if
+   set to "1", will force writing the mtev conf file upon successful completion
+   rather than just scheduling it for writing. The default is still
+   to not force writing; the force write will only happen if the header is set.
 
 ### 1.10.7
 

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -1233,16 +1233,15 @@ rest_update_cluster(mtev_http_rest_closure_t *restc, int n, char **p) {
     FAIL("bad root node: not cluster");
   headers = mtev_http_request_headers_table(mtev_http_session_request(ctx));
   if (headers) {
-    char *force_conf_str = NULL;
-    char *hash_retr = "x-mtev-conf-sync";
-    if (mtev_hash_retrieve(headers, hash_retr, strlen(hash_retr), (void **)&force_conf_str)) {
+    char *force_conf_str = mtev_hash_dict_get(headers, "x-mtev-conf-sync");
+    if (force_conf_str) {
       int val = atoi(force_conf_str);
       if (val == 1) {
         force_conf_write = mtev_true;
       }
       else if (val != 0) {
-        mtevL(cerror, "bad %s param (%s) sent to /cluster endpoint - must be zero or one... defaulting to off\n",
-          hash_retr, force_conf_str);
+        mtevL(cerror, "bad x-mtev-conf-sync param (%s) sent to /cluster endpoint - must be zero or one... defaulting to off\n",
+          force_conf_str);
       }
     }
   }


### PR DESCRIPTION
Add an optional flag, "x-mtev-conf-sync", that will allow forcing
cluster configuration changes to be written to disk immediately rather
than waiting for the scheduled write.