### PR TITLE
Check For Null When Cleaning Up Backingstore

### DIFF
--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -1108,16 +1108,18 @@ mtev_conf_shatter_write(xmlDocPtr doc) {
       /* If it is a file, we'll unlink it, otherwise,
        * we need to delete the attributes and the directory.
        */
-      if(unlink(last->path)) {
-        char attrpath[PATH_MAX];
-        snprintf(attrpath, sizeof(attrpath), "%s/.attrs", last->path);
-        unlink(attrpath);
-        if(rmdir(last->path) && errno != ENOENT) {
-          /* This shouldn't happen, but if it does we risk
-           * leaving a mess. Don't do that.
-           */
-          mtevL(c_error, "backingstore mess %s: %s\n",
-                last->path, strerror(errno));
+      if (last->path) {
+        if(unlink(last->path)) {
+          char attrpath[PATH_MAX];
+          snprintf(attrpath, sizeof(attrpath), "%s/.attrs", last->path);
+          unlink(attrpath);
+          if(rmdir(last->path) && errno != ENOENT) {
+            /* This shouldn't happen, but if it does we risk
+             * leaving a mess. Don't do that.
+             */
+            mtevL(c_error, "backingstore mess %s: %s\n",
+                  last->path, strerror(errno));
+          }
         }
       }
       mtev_xml_userdata_free(last);


### PR DESCRIPTION
If last->path is null, we have nothing to do, so skip the work.
Otherwise, we'll print an error that isn't actually an error.