### PR TITLE
Change MLKV{ } to MLKV( )

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -627,7 +627,7 @@ mtev_http_log_request(mtev_http_session_ctx *ctx) {
     free(logline_dynamic);
   }
   mtevEL(http_access,
-        MLKV{ MLKV_STR("ip", ip), MLKV_STR("user", user ? user : "-"),
+        MLKV( MLKV_STR("ip", ip), MLKV_STR("user", user ? user : "-"),
               MLKV_STR("method", mtev_http_request_method_str(req)),
               MLKV_STR("protocol", mtev_http_request_protocol_str(req)),
               MLKV_STR("uri", mtev_http_request_uri_str(req)),
@@ -636,7 +636,7 @@ mtev_http_log_request(mtev_http_session_ctx *ctx) {
               MLKV_DOUBLE("latency", (double)diff.tv_sec + (double)diff.tv_usec/1000000.0),
               MLKV_INT64("bytes_written", mtev_http_response_bytes_written(res)),
               MLKV_INT64("bytes_read", mtev_http_request_content_length_read(req)),
-              MLKV_END },
+              MLKV_END ),
         "%s - %s [%s] \"%s %s%s%s %s\" %d %llu|%llu %.3f\n",
         ip, user ? user : "-", timestr,
         mtev_http_request_method_str(req), mtev_http_request_uri_str(req),

--- a/src/mtev_listener.c
+++ b/src/mtev_listener.c
@@ -366,11 +366,11 @@ mtev_listener_acceptor(eventer_t e, int mask,
 #endif
 #endif
         if(proto_n < 0) {
-          mtevEL(nldeb, MLKV{ MLKV_INT64("errno", errno), MLKV_END }, "getprotobyname_r(\"tcp\") failed: %s\n",
+          mtevEL(nldeb, MLKV( MLKV_INT64("errno", errno), MLKV_END ), "getprotobyname_r(\"tcp\") failed: %s\n",
                  strerror(errno));
         } else {
           if(setsockopt(conn, proto_n, TCP_NODELAY, (void *)&nodelay, sizeof(nodelay)) < 0) {
-            mtevEL(nldeb, MLKV{ MLKV_INT64("errno", errno), MLKV_END }, "setsockopt TCP_NODELAY failed: %s\n",
+            mtevEL(nldeb, MLKV( MLKV_INT64("errno", errno), MLKV_END ), "setsockopt TCP_NODELAY failed: %s\n",
                    strerror(errno));
           }
         }

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -259,20 +259,20 @@ mtev_main_terminate(const char *appname,
 
   if((lockfd = mtev_lockfile_acquire_owner(lockfile, &owner)) < 0) {
     if(owner == -1) {
-      mtevEL(mtev_debug, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+      mtevEL(mtev_debug, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
              "mtev_lockfile_acquire_owner error: %s\n", strerror(errno));
       return -1;
     }
     pid_t groupid = getpgid(owner);
     if(groupid < 0) {
-      mtevEL(mtev_debug, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+      mtevEL(mtev_debug, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
             "getpgid error: %s\n", strerror(errno));
       return -1;
     }
     mtevL(mtev_debug, "Terminating process group %d.\n", groupid);
     if(kill(-groupid, SIGCONT) < 0 ||
        kill(-groupid, SIGTERM) < 0) {
-      mtevEL(mtev_debug, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+      mtevEL(mtev_debug, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
             "Failed to kill progress group: %s.\n", strerror(errno));
       return -1;
     }
@@ -316,14 +316,14 @@ mtev_main_status(const char *appname,
 
   if((lockfd = mtev_lockfile_acquire_owner(lockfile, &owner)) < 0) {
     if(owner == -1) {
-      mtevEL(mtev_debug, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+      mtevEL(mtev_debug, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
              "mtev_lockfile_acquire_owner error: %s\n", strerror(errno));
       return -1;
     }
     if(pid) *pid = owner;
     pid_t groupid = getpgid(owner);
     if(groupid < 0) {
-      mtevEL(mtev_debug, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+      mtevEL(mtev_debug, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
              "getpgid error: %s\n", strerror(errno));
       return -1;
     }
@@ -603,11 +603,11 @@ mtev_main(const char *appname,
       pid_t owner;
       if((lockfd = mtev_lockfile_acquire_owner(lockfile, &owner)) < 0) {
         if(!wait_for_lock) {
-          mtevEL(mtev_stderr, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+          mtevEL(mtev_stderr, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
                  "Failed to acquire lock: %s\n", lockfile);
           if(owner != -1) {
             pid_t groupid = getpgid(owner);
-            mtevEL(mtev_stderr, MLKV{ MLKV_NUM("pid", owner), MLKV_NUM("pgid", groupid), MLKV_END },
+            mtevEL(mtev_stderr, MLKV( MLKV_INT64("pid", owner), MLKV_INT64("pgid", groupid), MLKV_END ),
                    "%s already running pid: %d, pgid: %d\n",
                   appname, owner, groupid);
           }
@@ -615,7 +615,7 @@ mtev_main(const char *appname,
         }
         if(wait_for_lock == 1) {
           pid_t pid = getpid();
-          mtevEL(mtev_stderr, MLKV{ MLKV_NUM("pid", pid), MLKV_NUM("errno", errno), MLKV_END },
+          mtevEL(mtev_stderr, MLKV( MLKV_INT64("pid", pid), MLKV_INT64("errno", errno), MLKV_END ),
                  "%d failed to acquire lock(%s), waiting...\n",
                  (int)pid, lockfile);
           wait_for_lock++;
@@ -632,7 +632,7 @@ mtev_main(const char *appname,
   if(foreground == 1) {
     mtev_time_start_tsc();
     pid_t pid = getpid();
-    mtevEL(mtev_notice, MLKV{ MLKV_NUM("pid",pid), MLKV_END },
+    mtevEL(mtev_notice, MLKV( MLKV_INT64("pid",pid), MLKV_END ),
            "%s booting [unmanaged, pid: %d]\n", appname, (int)pid);
     external_diagnose = getenv("MTEV_DIAGNOSE_CRASH");
     if(!external_diagnose || strcmp(external_diagnose,"0")) {
@@ -690,7 +690,7 @@ mtev_main(const char *appname,
   if(*lockfile) {
     if (lock) {
       if((lockfd = mtev_lockfile_acquire(lockfile)) < 0) {
-        mtevEL(mtev_stderr, MLKV{ MLKV_NUM("errno", errno), MLKV_END },
+        mtevEL(mtev_stderr, MLKV( MLKV_INT64("errno", errno), MLKV_END ),
                "Failed to acquire lock: %s\n", lockfile);
         exit(-1);
       }
@@ -699,7 +699,7 @@ mtev_main(const char *appname,
 
   signal(SIGHUP, SIG_IGN);
   pid_t pid = getpid();
-  mtevEL(mtev_notice, MLKV{ MLKV_NUM("pid", pid), MLKV_END }, "%s booting [manager, pid: %d]\n", appname, (int)pid);
+  mtevEL(mtev_notice, MLKV( MLKV_INT64("pid", pid), MLKV_END ), "%s booting [manager, pid: %d]\n", appname, (int)pid);
   pthread_atfork(NULL, NULL, mtev_memory_gc_asynch);
   rv = mtev_watchdog_start_child(appname, passed_child_main, watchdog_timeout);
   mtev_lockfile_release(lockfd);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -174,7 +174,7 @@ static int DEBUG_LOG_ENABLED(void) {
 struct _mtev_log_stream_outlet_list {
   mtev_log_stream_t outlet;
   mtev_boolean filter_needs_message;
-  mtev_boolean (*filter)(void *, mtev_log_kv_t ***, mtev_LogLine_fb_t);
+  mtev_boolean (*filter)(void *, const mtev_log_kv_t * const *, mtev_LogLine_fb_t);
   void (*filter_free)(void *);
   void *filter_closure;
   struct _mtev_log_stream_outlet_list *next;
@@ -1784,10 +1784,10 @@ mtev_log_stream_add_stream(mtev_log_stream_t ls, mtev_log_stream_t outlet) {
 }
 
 static mtev_boolean
-mtev_log_filter_exec(void *closure, mtev_log_kv_t ***attrs, mtev_LogLine_fb_t ll) {
+mtev_log_filter_exec(void *closure, const mtev_log_kv_t * const *attrs, mtev_LogLine_fb_t ll) {
   mtev_logic_ast_t *ast = closure;
   if(!filter_runtime) return mtev_false;
-  if(attrs) return mtev_logic_exec(filter_kv_runtime, ast, attrs);
+  if(attrs) return mtev_logic_exec(filter_kv_runtime, ast, (void *)attrs);
   return mtev_logic_exec(filter_runtime, ast, ll);
 }
 
@@ -1795,9 +1795,9 @@ static mtev_boolean
 mtev_log_kvset_logic_lookup(void *closure, const char *name, mtev_logic_var_t *out) {
   int i, j;
   char id_str[UUID_STR_LEN+1];
-  mtev_log_kv_t ***kvsets = closure;
-  for(mtev_log_kv_t **kvset = kvsets[i=0]; kvset; kvset = kvsets[++i]) {
-    for(mtev_log_kv_t *kv = kvset[j=0]; kv->key; kv = kvset[++j]) {
+  mtev_log_kv_t **kvsets = closure;
+  for(mtev_log_kv_t *kvset = kvsets[i=0]; kvset; kvset = kvsets[++i]) {
+    for(mtev_log_kv_t *kv = &kvset[j=0]; kv->key; kv = &kvset[++j]) {
       if(!strcmp(name, kv->key)) {
         switch(kv->value_type) {
           case MTEV_LOG_KV_TYPE_INT64:
@@ -2415,9 +2415,8 @@ inline int
 mtev_vlog(mtev_log_stream_t ls, const struct timeval *now,
           const char *file, int line,
           const char *format, va_list arg) {
-  return mtev_ex_vlog(ls, now, file, line,
-      (mtev_log_kv_t *[]){ &(mtev_log_kv_t){ NULL, 0, .value = { .v_string = NULL } } },
-      format, arg);
+  const mtev_log_kv_t meta[] = MLKV( MLKV_END );
+  return mtev_ex_vlog(ls, now, file, line, meta, format, arg);
 }
 
 /* flatbuffers construction can alloc a lot, this is problematic for both
@@ -2586,7 +2585,7 @@ enum construction_required_t {
 };
 
 static inline enum construction_required_t
-mtev_log_construction_needed(mtev_log_stream_t ls, mtev_log_kv_t ***kvsets,
+mtev_log_construction_needed(mtev_log_stream_t ls, const mtev_log_kv_t * const *kvsets,
                              mtev_boolean has_message,
                              struct filter_reuse_tracker *tracker) {
   struct _mtev_log_stream_outlet_list *node;
@@ -2625,7 +2624,7 @@ mtev_log_construction_needed(mtev_log_stream_t ls, mtev_log_kv_t ***kvsets,
 int
 mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
              const char *file, int line,
-             mtev_log_kv_t **kvs,
+             const mtev_log_kv_t * const kvs,
              const char *format, va_list arg) {
   /* These will track filter evals so we don't do them twice */
   struct filter_reuse_tracker filter_reuse;
@@ -2664,17 +2663,18 @@ mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
     const char *tname = eventer_get_thread_name();
     uint32_t threadid = mtev_thread_id();
 
-    mtev_log_kv_t *message_kv = MLKV_STR("message", "");
-    mtev_log_kv_t ***kvsets = (mtev_log_kv_t **[]){ kvs,
-      MLKV{ MLKV_NUM("timestamp", (double)now->tv_sec + (double)now->tv_usec / 1000000.0),
-            MLKV_NUM("threadid", threadid),
-            MLKV_STR("threadname", tname),
-            MLKV_STR("file", file),
-            MLKV_NUM("line", line),
-            MLKV_STR("facility", ls->name),
-            message_kv,
-            MLKV_END },
-      NULL };
+    buffer[0] = '\0';
+    const mtev_log_kv_t builtin_kvs[] = MLKV(
+      MLKV_STR("message", buffer),
+      MLKV_DOUBLE("timestamp", (double)now->tv_sec + (double)now->tv_usec / 1000000.0),
+      MLKV_INT64("threadid", threadid),
+      MLKV_STR("threadname", tname),
+      MLKV_STR("file", file),
+      MLKV_INT64("line", line),
+      MLKV_STR("facility", ls->name),
+      MLKV_END
+    );
+    const mtev_log_kv_t * const kvsets[] = { kvs, builtin_kvs, NULL };
 
     enum construction_required_t cr = 
       mtev_log_construction_needed(ls, kvsets, mtev_false, &filter_reuse);
@@ -2709,7 +2709,9 @@ mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
       if(len > (ssize_t)MTEV_MAYBE_SIZE(buffer)) len = MTEV_MAYBE_SIZE(buffer);
     }
 
-    message_kv->value.v_string = buffer;
+    if(builtin_kvs[0].value.v_string != buffer) {
+      *((char **)&builtin_kvs[0].value.v_string) = buffer;
+    }
     if(cr == MESSAGE_NEEDED_TO_DETERMINE) {
       cr = mtev_log_construction_needed(ls, kvsets, mtev_true, &filter_reuse);
       if(cr != YES_CONSTRUCTION_REQUIRED) {
@@ -2728,7 +2730,7 @@ mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
     if(file) mtev_LogLine_file_create_str(B, file);
     if(tname) mtev_LogLine_threadname_create_str(B, tname);
     if(ls->name) mtev_LogLine_facility_create_str(B, ls->name);
-    if(activespan || (kvs && kvs[0]->key != NULL)) {
+    if(activespan || (kvs && kvs[0].key != NULL)) {
       int kvi = 0;
       mtev_LogLine_kv_start(B);
 
@@ -2751,7 +2753,7 @@ mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
       }
 #undef FB_ZIPID
 
-      for(mtev_log_kv_t *kv = kvs[kvi]; (kv = kvs[kvi])->key != NULL; kvi++) {
+      for(const mtev_log_kv_t *kv = &kvs[kvi]; (kv = &kvs[kvi])->key != NULL; kvi++) {
         mtev_LogLine_kv_push_start(B);
         mtev_KVPair_key_create_str(B, kv->key);
         switch(kv->value_type) {
@@ -2832,7 +2834,7 @@ mtev_ex_vlog(mtev_log_stream_t ls, const struct timeval *now,
 
 int
 mtev_ex_log(mtev_log_stream_t ls, const struct timeval *now,
-            const char *file, int line, mtev_log_kv_t **ex, const char *format, ...) {
+            const char *file, int line, const mtev_log_kv_t * const ex, const char *format, ...) {
   int rv;
   va_list arg;
   va_start(arg, format);


### PR DESCRIPTION
This worked before mostly by accident because of the way CPP tokens
were pasted together.  Any subsequent array members were actually seen
as the varargs.  MLKV must take arguments to treat it as one parameter.
This changes the ABI and will break old compiles.  We now pass an array
of mtev_log_kv_t's to the logging functions instead of an array of
mtev_log_kv_t pointers.  Notably, this works within c++ now.