### PR TITLE
Various functional fixes for mtev_logic.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 1.12
 
+ * Fix string-matching in `mtev_logic`
+
 ### 1.12.2
 
  * Add functional probability for `mtev_frrh` via `mtev_frrh_set_prob_function`


### PR DESCRIPTION
 * Set the string lenght on node creation.
 * Avoid allocation on tostring
 * Make strllcmp not return zero if lengths vary.