### PR TITLE
CIRC-5348 Add ck_malloc that uses "regular" memory

### DIFF
--- a/src/utils/mtev_memory.c
+++ b/src/utils/mtev_memory.c
@@ -626,6 +626,18 @@ struct ck_malloc mtev_memory_safe_ck_malloc = {
   .free = mtev_memory_ck_free
 };
 
+static void stdfree_for_ck(void *f, size_t s, bool r) {
+  (void)s;
+  (void)r;
+  free(f);
+}
+
+struct ck_malloc mtev_memory_regular_ck_malloc = {
+  .malloc = malloc,
+  .realloc = NULL,
+  .free = stdfree_for_ck
+};
+
 static uint32_t nallocators;
 struct mtev_allocator_options {
   char name[32];

--- a/src/utils/mtev_memory.h
+++ b/src/utils/mtev_memory.h
@@ -107,6 +107,7 @@ API_EXPORT(void)
   mtev_free(mtev_allocator_t, void *ptr);
 
 API_EXPORT(struct ck_malloc) mtev_memory_safe_ck_malloc;
+API_EXPORT(struct ck_malloc) mtev_memory_regular_ck_malloc;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
`ck_malloc` that doesn't use `mtev_memory` is defined dozens of times already over the source.