### PR TITLE
Improve jemalloc heap profile docs

### DIFF
--- a/docs-md/development/jemalloc.md
+++ b/docs-md/development/jemalloc.md
@@ -1,20 +1,16 @@
-# jemalloc
+# Jemalloc
 
-libmtev has some special support available if you are running with the jemalloc
-allocator loaded.
+libmtev has some special support available if you are running with the jemalloc allocator loaded.
 
-> Note that if your application isn't directly linked with jemalloc, libmtev will
-> still notice its presence at run-time if loaded via `LD_PRELOAD`.  So, the following
-> can be used in conjunction with an operator's force loading of libjemalloc.so
+> Note that if your application isn't statically linked with jemalloc, libmtev will still notice its presence at run-time if loaded via `LD_PRELOAD`.  So, the following can be used in conjunction with an operator's forced preloading of libjemalloc.so
 
-## malloc statistics.
+## General malloc statistics.
 
 Malloc statistics (in JSON) are available at the URL: `/mtev/memory.json`
 
-## Activating jemalloc profiling
+## Activating jemalloc heap profiling
 
-To perform heap profiling you must have jemalloc heap profiling enabled 
-via environment variable:
+To perform heap profiling you must have jemalloc heap profiling enabled via environment variable:
 
 `export MALLOC_CONF="prof:true,prof_active:false"`
 
@@ -24,28 +20,29 @@ Or via the special `/etc/malloc.conf` string file:
 
 You can then flip on heap profiling in your mtev app by curling:
 
-`/mtev/heap_profile?active=true`
+`curl yourmachine:yourport/mtev/heap_profile?active=true`
 
 This will turn on profiling from that moment until you disable it via:
 
-`/mtev/heap_profile?active=false`
+`curl yourmachine:yourport/mtev/heap_profile?active=false`
 
-In a variety of cases, it might be desirable to have profiling active from the point
-of application start.  To do this set `prof_active:true` in the `MALLOC_CONF`.
-However keep in mind that there is some performance cost while profiling is active,
-so you may only want to keep profiling active when you are gathering memory usage
-information.  And you may also want to adjust the sampling if performance is adversely
-affected (see the jemalloc link below if this is a concern).
+In a variety of cases, it might be desirable to have profiling active from the point of application start.  To do this set `prof_active:true` in the `MALLOC_CONF`.  However keep in mind that there is some performance cost while profiling is active, so you may only want to keep profiling active when you are gathering memory usage information.  And you may also want to adjust the sampling if performance is adversely affected (see the jemalloc link below if this is a concern).
 
-NOTE: It is a good idea to confirm these settings changes and check status (at any
-time) by simply curling:
+**NOTE:** It is a good idea to confirm these settings changes and check status (at any time) by simply curling:
 
-`/mtev/heap_profile`
+`curl yourmachine:yourport/mtev/heap_profile`
 
-In order to be able to get a heap profile snapshot, you must have `opt.prof` set to
-`true` (or you'll get an error when trying to trigger a dump).  While profiling is
-active, `prof.active` will also be `true` (and this is also required to get a valid
-capture in the next step).
+The output from that curl will look something like the following:
+
+```
+opt.prof: true
+prof.active: false
+prof.thread_active_init: true
+```
+
+The first setting `opt.prof: true` will be displayed if `prof:true` was properly set in the MALLOC_CONF or /etc/malloc.conf as shown above.
+
+The second setting `prof.active` is initialized by the MALLOC_CONF or /etc/malloc.conf, and it can be toggled to `true` or `false` at runtime by using the `heap_profile` curl shown above.  Both settings must be `true` or nothing will be captured when triggering a heap profile.
 
 ## Heap Profiling
 
@@ -53,17 +50,12 @@ To get periodic heap profile dumps from your running application do:
 
 `curl yourmachine:yourport/mtev/heap_profile?trigger_dump=true > profile.prof`
 
-This will spit back jeprof format heap information which can then be passed
-to the `jeprof` analysis program for further analysis.  For example, to show
-allocations by source code line, but from a perspective outside of libmtev's use of
-SMR (`mtev_memory_`) and libck's hash tables (`ck_hs_`), one could run:
+This will spit back jeprof format heap information which can then be passed to the `jeprof` analysis program for further analysis.  For example, to show allocations by source code line, but from a perspective outside of libmtev's use of SMR (`mtev_memory_`) and libck's hash tables (`ck_hs_`), one could run:
 
 `jeprof --text --lines --exclude='(mtev_memory_|ck_hs_)' /path/to/your/executable profile.prof`
 
-To compare two heap profiles (which helps reduce the noise) you can use the "--base" switch:
+To compare two heap profiles (which helps reduce the noise) you can add the `--base=baseline.prof` switch to the commandline.
 
-`jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; --base=baseline.prof /path/to/your/executable profile.prof`
-
-For more information on jemalloc heap profiling, see here: [jemalloc heap profiling](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling)
+For more information on jemalloc heap profiling, see: [jemalloc heap profiling](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling)
 
 

--- a/docs-md/development/jemalloc.md
+++ b/docs-md/development/jemalloc.md
@@ -32,6 +32,20 @@ This will turn on profiling from that moment until you disable it via:
 
 In a variety of cases, it might be desirable to have profiling active from the point
 of application start.  To do this set `prof_active:true` in the `MALLOC_CONF`.
+However keep in mind that there is some performance cost while profiling is active,
+so you may only want to keep profiling active when you are gathering memory usage
+information.  And you may also want to adjust the sampling if performance is adversely
+affected (see the jemalloc link below if this is a concern).
+
+NOTE: It is a good idea to confirm these settings changes and check status (at any
+time) by simply curling:
+
+`/mtev/heap_profile`
+
+In order to be able to get a heap profile snapshot, you must have `opt.prof` set to
+`true` (or you'll get an error when trying to trigger a dump).  While profiling is
+active, `prof.active` will also be `true` (and this is also required to get a valid
+capture in the next step).
 
 ## Heap Profiling
 
@@ -45,6 +59,10 @@ allocations by source code line, but from a perspective outside of libmtev's use
 SMR (`mtev_memory_`) and libck's hash tables (`ck_hs_`), one could run:
 
 `jeprof --text --lines --exclude='(mtev_memory_|ck_hs_)' /path/to/your/executable profile.prof`
+
+To compare two heap profiles (which helps reduce the noise) you can use the "--base" switch:
+
+`jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; --base=baseline.prof /path/to/your/executable profile.prof`
 
 For more information on jemalloc heap profiling, see here: [jemalloc heap profiling](https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling)
 

--- a/docs/development/jemalloc.html
+++ b/docs/development/jemalloc.html
@@ -656,15 +656,15 @@
     
                                 <section class="normal markdown-section">
                                 
-                                <h1 id="jemalloc">Jemalloc</h1>
+                                <h1 id="jemalloc">jemalloc</h1>
 <p>libmtev has some special support available if you are running with the jemalloc
 allocator loaded.</p>
 <blockquote>
-<p>Note that if your application isn&apos;t statically linked with jemalloc, libmtev will
+<p>Note that if your application isn&apos;t directly linked with jemalloc, libmtev will
 still notice its presence at run-time if loaded via <code>LD_PRELOAD</code>.  So, the following
-can be used in conjunction with an operator&apos;s forced preloading of libjemalloc.so</p>
+can be used in conjunction with an operator&apos;s force loading of libjemalloc.so</p>
 </blockquote>
-<h2 id="malloc-statistics">General malloc statistics.</h2>
+<h2 id="malloc-statistics">malloc statistics.</h2>
 <p>Malloc statistics (in JSON) are available at the URL: <code>/mtev/memory.json</code></p>
 <h2 id="activating-jemalloc-profiling">Activating jemalloc profiling</h2>
 <p>To perform heap profiling you must have jemalloc heap profiling enabled 
@@ -673,28 +673,19 @@ via environment variable:</p>
 <p>Or via the special <code>/etc/malloc.conf</code> string file:</p>
 <p><code>sudo ln -s &apos;prof:true,prof_active:false&apos; /etc/malloc.conf</code></p>
 <p>You can then flip on heap profiling in your mtev app by curling:</p>
-<p><code>curl yourmachine:yourport/mtev/heap_profile?active=true</code></p>
+<p><code>/mtev/heap_profile?active=true</code></p>
 <p>This will turn on profiling from that moment until you disable it via:</p>
-<p><code>curl yourmachine:yourport/mtev/heap_profile?active=false</code></p>
+<p><code>/mtev/heap_profile?active=false</code></p>
 <p>In a variety of cases, it might be desirable to have profiling active from the point
-of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.  However keep in mind that there is some performance cost while profiling is active, so you may only want to keep profiling active when you are gathering memory usage information.  And you may also want to adjust the sampling if performance is adversely affected (see the jemalloc link below if this is a concern).</p>
-<p><b>NOTE:</b> It is a good idea to confirm these settings changes and check status (at any time) by simply curling:</p>
-<p><code>curl yourmachine:yourport/mtev/heap_profile</code></p>
-<p>The output from that curl will look something like the following:</p>
-<p><code>opt.prof: true</code><br>
-  <code>prof.active: false</code><br>
-  <code>prof.thread_active_init: true</code></p>
-<p>The first setting <code>opt.prof: true</code> will be displayed if <code>prof:true</code> was properly set in the <code>MALLOC_CONF</code> or <code>/etc/malloc.conf</code> as shown above.</p>
-<p>The second setting <code>prof.active</code> is initialized by the <code>MALLOC_CONF</code> or <code>/etc/malloc.conf</code>, and it can be toggled to <code>true</code> or <code>false</code> at runtime by using the <code>heap_profile</code> curl shown above.  Both settings must be <code>true</code> or nothing will be captured when triggering a heap profile.</p>
+of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.</p>
 <h2 id="heap-profiling">Heap Profiling</h2>
 <p>To get periodic heap profile dumps from your running application do:</p>
 <p><code>curl yourmachine:yourport/mtev/heap_profile?trigger_dump=true &gt; profile.prof</code></p>
-<p>This will send back jeprof format heap information which can then be passed
+<p>This will spit back jeprof format heap information which can then be passed
 to the <code>jeprof</code> analysis program for further analysis.  For example, to show
 allocations by source code line, but from a perspective outside of libmtev&apos;s use of
 SMR (<code>mtev_memory_</code>) and libck&apos;s hash tables (<code>ck_hs_</code>), one could run:</p>
 <p><code>jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; /path/to/your/executable profile.prof</code></p>
-<p>To compare two heap profiles (which helps reduce the noise) you can add the <code>--base=baseline.prof</code> switch to the commandline.</p>
 <p>For more information on jemalloc heap profiling, see here: <a href="https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling" target="_blank">jemalloc heap profiling</a></p>
 
                                 

--- a/docs/development/jemalloc.html
+++ b/docs/development/jemalloc.html
@@ -677,7 +677,10 @@ via environment variable:</p>
 <p>This will turn on profiling from that moment until you disable it via:</p>
 <p><code>/mtev/heap_profile?active=false</code></p>
 <p>In a variety of cases, it might be desirable to have profiling active from the point
-of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.</p>
+of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.  However keep in mind that there is some performance cost while profiling is active, so you may only want to keep profiling active when you are gathering memory usage information, and you may also want to adjust the sampling if performance is adversely affected (see the jemalloc link below if this is a concern).</p>
+<p>NOTE: It is a good idea to confirm these settings changes and check status (at any time) by simply curling:</p>
+<p><code>/mtev/heap_profile</code></p>
+<p>In order to be able to get a heap profile snapshot, you must have "opt.prof" set to "true" (or you'll get an error when trying to trigger a dump).  While profiling is active, "prof.active" will also be "true" (and this is also required to get a valid capture in the next step).</p>
 <h2 id="heap-profiling">Heap Profiling</h2>
 <p>To get periodic heap profile dumps from your running application do:</p>
 <p><code>curl yourmachine:yourport/mtev/heap_profile?trigger_dump=true &gt; profile.prof</code></p>
@@ -686,6 +689,8 @@ to the <code>jeprof</code> analysis program for further analysis.  For example, 
 allocations by source code line, but from a perspective outside of libmtev&apos;s use of
 SMR (<code>mtev_memory_</code>) and libck&apos;s hash tables (<code>ck_hs_</code>), one could run:</p>
 <p><code>jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; /path/to/your/executable profile.prof</code></p>
+<p>To compare two heap profiles (which helps reduce the noise) you can use the "--base" switch:</p>
+<p><code>jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; --base=/path/to/your/baseline.prof /path/to/your/executable profile.prof</code></p>
 <p>For more information on jemalloc heap profiling, see here: <a href="https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling" target="_blank">jemalloc heap profiling</a></p>
 
                                 

--- a/docs/development/jemalloc.html
+++ b/docs/development/jemalloc.html
@@ -656,15 +656,15 @@
     
                                 <section class="normal markdown-section">
                                 
-                                <h1 id="jemalloc">jemalloc</h1>
+                                <h1 id="jemalloc">Jemalloc</h1>
 <p>libmtev has some special support available if you are running with the jemalloc
 allocator loaded.</p>
 <blockquote>
-<p>Note that if your application isn&apos;t directly linked with jemalloc, libmtev will
+<p>Note that if your application isn&apos;t statically linked with jemalloc, libmtev will
 still notice its presence at run-time if loaded via <code>LD_PRELOAD</code>.  So, the following
-can be used in conjunction with an operator&apos;s force loading of libjemalloc.so</p>
+can be used in conjunction with an operator&apos;s forced preloading of libjemalloc.so</p>
 </blockquote>
-<h2 id="malloc-statistics">malloc statistics.</h2>
+<h2 id="malloc-statistics">General malloc statistics.</h2>
 <p>Malloc statistics (in JSON) are available at the URL: <code>/mtev/memory.json</code></p>
 <h2 id="activating-jemalloc-profiling">Activating jemalloc profiling</h2>
 <p>To perform heap profiling you must have jemalloc heap profiling enabled 
@@ -673,24 +673,28 @@ via environment variable:</p>
 <p>Or via the special <code>/etc/malloc.conf</code> string file:</p>
 <p><code>sudo ln -s &apos;prof:true,prof_active:false&apos; /etc/malloc.conf</code></p>
 <p>You can then flip on heap profiling in your mtev app by curling:</p>
-<p><code>/mtev/heap_profile?active=true</code></p>
+<p><code>curl yourmachine:yourport/mtev/heap_profile?active=true</code></p>
 <p>This will turn on profiling from that moment until you disable it via:</p>
-<p><code>/mtev/heap_profile?active=false</code></p>
+<p><code>curl yourmachine:yourport/mtev/heap_profile?active=false</code></p>
 <p>In a variety of cases, it might be desirable to have profiling active from the point
-of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.  However keep in mind that there is some performance cost while profiling is active, so you may only want to keep profiling active when you are gathering memory usage information, and you may also want to adjust the sampling if performance is adversely affected (see the jemalloc link below if this is a concern).</p>
-<p>NOTE: It is a good idea to confirm these settings changes and check status (at any time) by simply curling:</p>
-<p><code>/mtev/heap_profile</code></p>
-<p>In order to be able to get a heap profile snapshot, you must have "opt.prof" set to "true" (or you'll get an error when trying to trigger a dump).  While profiling is active, "prof.active" will also be "true" (and this is also required to get a valid capture in the next step).</p>
+of application start.  To do this set <code>prof_active:true</code> in the <code>MALLOC_CONF</code>.  However keep in mind that there is some performance cost while profiling is active, so you may only want to keep profiling active when you are gathering memory usage information.  And you may also want to adjust the sampling if performance is adversely affected (see the jemalloc link below if this is a concern).</p>
+<p><b>NOTE:</b> It is a good idea to confirm these settings changes and check status (at any time) by simply curling:</p>
+<p><code>curl yourmachine:yourport/mtev/heap_profile</code></p>
+<p>The output from that curl will look something like the following:</p>
+<p><code>opt.prof: true</code><br>
+  <code>prof.active: false</code><br>
+  <code>prof.thread_active_init: true</code></p>
+<p>The first setting <code>opt.prof: true</code> will be displayed if <code>prof:true</code> was properly set in the <code>MALLOC_CONF</code> or <code>/etc/malloc.conf</code> as shown above.</p>
+<p>The second setting <code>prof.active</code> is initialized by the <code>MALLOC_CONF</code> or <code>/etc/malloc.conf</code>, and it can be toggled to <code>true</code> or <code>false</code> at runtime by using the <code>heap_profile</code> curl shown above.  Both settings must be <code>true</code> or nothing will be captured when triggering a heap profile.</p>
 <h2 id="heap-profiling">Heap Profiling</h2>
 <p>To get periodic heap profile dumps from your running application do:</p>
 <p><code>curl yourmachine:yourport/mtev/heap_profile?trigger_dump=true &gt; profile.prof</code></p>
-<p>This will spit back jeprof format heap information which can then be passed
+<p>This will send back jeprof format heap information which can then be passed
 to the <code>jeprof</code> analysis program for further analysis.  For example, to show
 allocations by source code line, but from a perspective outside of libmtev&apos;s use of
 SMR (<code>mtev_memory_</code>) and libck&apos;s hash tables (<code>ck_hs_</code>), one could run:</p>
 <p><code>jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; /path/to/your/executable profile.prof</code></p>
-<p>To compare two heap profiles (which helps reduce the noise) you can use the "--base" switch:</p>
-<p><code>jeprof --text --lines --exclude=&apos;(mtev_memory_|ck_hs_)&apos; --base=/path/to/your/baseline.prof /path/to/your/executable profile.prof</code></p>
+<p>To compare two heap profiles (which helps reduce the noise) you can add the <code>--base=baseline.prof</code> switch to the commandline.</p>
 <p>For more information on jemalloc heap profiling, see here: <a href="https://github.com/jemalloc/jemalloc/wiki/Use-Case%3A-Heap-Profiling" target="_blank">jemalloc heap profiling</a></p>
 
                                 


### PR DESCRIPTION
The docs were missing how you check to make sure you are configured properly with just `/mtev/heap_profile` and how to do a differential heap report.