### PR TITLE
-DMTEV_MEMORY_DEBUG will turn on debugging support

### DIFF
--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -1001,6 +1001,9 @@ int mtev_backtrace_ucontext(void **callstack, ucontext_t *ctx, int cnt) {
 #endif
   return frames;
 }
+void mtev_log_backtrace(mtev_log_stream_t ls, void **callstack, int cnt) {
+  mtev_stacktrace_internal(ls, mtev_stacktrace, NULL, NULL, callstack, cnt);
+}
 int mtev_backtrace(void **callstack, int cnt) {
   return mtev_backtrace_ucontext(callstack, NULL, cnt);
 }

--- a/src/utils/mtev_stacktrace.h
+++ b/src/utils/mtev_stacktrace.h
@@ -61,6 +61,9 @@ API_EXPORT(int)
 API_EXPORT(int)
   mtev_aco_stacktrace_skip(mtev_log_stream_t ls, aco_t *co, int ignore);
 
+API_EXPORT(void)
+  mtev_log_backtrace(mtev_log_stream_t ls, void **ips, int cnt);
+
 API_EXPORT(int)
   mtev_backtrace(void **ips, int cnt);
 


### PR DESCRIPTION
Captures stack trace at alloc and free and then reports them if the
free looks invalid.