### PR TITLE
Better ACO support for Zipkin.

### DIFF
--- a/src/modules/zipkin_jaeger.c
+++ b/src/modules/zipkin_jaeger.c
@@ -115,10 +115,10 @@ jaeger_publish_thrift(unsigned char *buff, size_t buflen, uint32_t retries) {
   CURLcode code;
   long httpcode;
   static CURL *curl;
+  static char url[1024];
   char error[CURL_ERROR_SIZE];
 
   if(!curl) {
-    char url[1024];
     struct curl_slist *headers=NULL;
     snprintf(url, sizeof(url), "http://%s:%d/api/v1/spans", zc_host, zc_port);
     headers = curl_slist_append(headers, "Content-Type: application/x-thrift");
@@ -143,7 +143,7 @@ jaeger_publish_thrift(unsigned char *buff, size_t buflen, uint32_t retries) {
       curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpcode);
   } while(retries > 0 && (httpcode < 200 || httpcode > 299));
   if(httpcode < 200 || httpcode > 299) {
-    mtevL(errorls, "zipkin submit to jaeger failed: %s\n", error);
+    mtevL(errorls, "zipkin submit to jaeger (%s) failed: %s/%ld/%s\n", url, curl_easy_strerror(code), httpcode, error);
     return -1;
   }
   return 0;

--- a/src/utils/mtev_zipkin.h
+++ b/src/utils/mtev_zipkin.h
@@ -60,6 +60,8 @@ extern const char *ZIPKIN_SERVER_SEND;
 extern const char *ZIPKIN_SERVER_SEND_DONE;
 extern const char *ZIPKIN_SERVER_RECV;
 extern const char *ZIPKIN_SERVER_RECV_DONE;
+extern const char *ZIPKIN_INTERNAL_START;
+extern const char *ZIPKIN_INTERNAL_DONE;
 
 #define HEADER_ZIPKIN_MTEV_EVENT "X-mtev-Trace-Event"
 #define HEADER_ZIPKIN_MTEV_EVENT_L "x-mtev-trace-event"
@@ -122,6 +124,23 @@ API_EXPORT(int64_t)
 API_EXPORT(Zipkin_Span *)
   mtev_zipkin_span_new(int64_t *, int64_t *, int64_t *, const char *,
                        bool, bool *, bool );
+
+/*! \fn Zipkin_Span * mtev_zipkin_new_child(Zipkin_Span *span, const char *name)
+    \brief Create a new child span.
+    \param span The parent
+    \param name The name of the new span
+    \return A new span
+ */
+API_EXPORT(Zipkin_Span *)
+  mtev_zipkin_new_child(Zipkin_Span *span, const char *name);
+
+/*! \fn Zipkin_Span * mtev_zipkin_aco_swap_span(Zipkin_Span *span)
+    \brief Swap an existing ACO's span for a new one, returning old
+    \param span The new span
+    \return The old span
+ */
+API_EXPORT(Zipkin_Span *)
+  mtev_zipkin_aco_swap_span(Zipkin_Span *span);
 
 /*! \fn bool mtev_zipkin_span_get_ids(Zipkin_Span *span, int64_t *traceid, int64_t *parent_id, int64_t *id)
     \brief Fetch the various IDs from a span.
@@ -457,6 +476,16 @@ API_EXPORT(void) mtev_zipkin_client_drop(struct _event *e);
     \param e An event object (or NULL for the current event)
 */
 API_EXPORT(void) mtev_zipkin_client_publish(struct _event *e);
+
+/*! \fn void mtev_zipkin_attach_named_to_aco(Zipkin_Span *span, const char *child_name, mtev_zipkin_event_trace_level_t *track)
+    \brief Attach a new child span to an aco thread.
+    \param span An existing zipkin span.
+    \param child_name The name of the new child span.
+    \param track Specifies how event activity should be tracked.
+*/
+API_EXPORT(void)
+  mtev_zipkin_attach_named_to_aco(Zipkin_Span *span, const char *child_name,
+                                  mtev_zipkin_event_trace_level_t *track);
 
 /*! \fn void mtev_zipkin_attach_to_aco(Zipkin_Span *span, bool new_child, mtev_zipkin_event_trace_level_t *track)
     \brief Attach an active span (or new child span) to an aco thread.


### PR DESCRIPTION
* Allow for creation of simple children
* Allow ACO context span swapping
  `old = swap(new); do something; swap(old);`
* Integrate ACO awareness into all calls.
* Improve error message on jaeger span submission failure.