### PR TITLE
CIRC-5562 - Add Function To Drain Jobqs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
 
  * Revert some internal changes to selection of the active zipkin span.
    These are believe to lead to some hard to track use-after-free issues.
+ * Add function, `eventer_jobq_drain_and_shutdown` to drain all inflight
+   and backlog jobs, then despawn all threads.
 
 ### 1.12.7
 

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -45,6 +45,12 @@ extern "C" {
 
 #include <ck_hs.h>
 
+typedef enum eventer_jobq_shutdown_state {
+  EVENTER_JOBQ_RUNNING = 0,
+  EVENTER_JOBQ_SHUTTING_DOWN,
+  EVENTER_JOBQ_SHUT_DOWN
+} eventer_jobq_shutdown_state_e;
+
 typedef struct eventer_context_t {
   void *data;
 } eventer_context_t;
@@ -152,6 +158,8 @@ struct _eventer_jobq_t {
   uint32_t                max_backlog;
   mtev_log_stream_t       callback_tracker;
   mtev_boolean            *lifo;
+  uint32_t                consumer_threads_running;
+  eventer_jobq_shutdown_state_e shutdown_state;
 };
 
 #ifdef LOCAL_EVENTER

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -45,11 +45,9 @@ extern "C" {
 
 #include <ck_hs.h>
 
-typedef enum eventer_jobq_shutdown_state {
-  EVENTER_JOBQ_RUNNING = 0,
-  EVENTER_JOBQ_SHUTTING_DOWN,
-  EVENTER_JOBQ_SHUT_DOWN
-} eventer_jobq_shutdown_state_e;
+#define EVENTER_JOBQ_RUNNING 0
+#define EVENTER_JOBQ_SHUTTING_DOWN 1
+#define EVENTER_JOBQ_SHUT_DOWN 2
 
 typedef struct eventer_context_t {
   void *data;
@@ -159,7 +157,16 @@ struct _eventer_jobq_t {
   mtev_log_stream_t       callback_tracker;
   mtev_boolean            *lifo;
   uint32_t                consumer_threads_running;
-  eventer_jobq_shutdown_state_e shutdown_state;
+  /* shutdown_state should use one of these defines,
+   * defined above:
+   * EVENTER_JOBQ_RUNNING
+   * EVENTER_JOBQ_SHUTTING_DOWN
+   * EVENTER_JOBQ_SHUT_DOWN
+   * This could be done via an enum, but this is accessed
+   * via multiple threads, so we want to make sure we can
+   * use atomic load/set functions to access this - hence
+   * the uint8_t */
+  uint8_t                 shutdown_state;
 };
 
 #ifdef LOCAL_EVENTER

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -267,6 +267,8 @@ eventer_jobq_create_internal(const char *queue_name, eventer_jobq_memory_safety_
   jobq->mem_safety = mem_safety;
   jobq->isbackq = isbackq;
   jobq->lifo = &jobq_lifo_default;
+  jobq->shutdown_state = EVENTER_JOBQ_RUNNING;
+  jobq->consumer_threads_running = 0;
   if(!jobq->isbackq)
     jobq->callback_tracker = mtev_log_stream_findf("debug/eventer/callbacks/jobq/%s", queue_name);
   if(pthread_mutexattr_init(&mutexattr) != 0) {
@@ -448,6 +450,10 @@ eventer_jobq_enqueue_internal(eventer_jobq_t *jobq, eventer_job_t *job, eventer_
 mtev_boolean
 eventer_jobq_try_enqueue(eventer_jobq_t *jobq, eventer_job_t *job, eventer_job_t *parent) {
   job->next = NULL;
+  if (jobq->shutdown_state != EVENTER_JOBQ_RUNNING) {
+    free(job);
+    return mtev_false;
+  }
   /* Do not increase the concurrency from zero for a noop */
   if(ck_pr_load_32(&jobq->concurrency) == 0 && job->fd_event == NULL) {
     free(job);
@@ -473,6 +479,10 @@ eventer_jobq_try_enqueue(eventer_jobq_t *jobq, eventer_job_t *job, eventer_job_t
 
 void
 eventer_jobq_enqueue(eventer_jobq_t *jobq, eventer_job_t *job, eventer_job_t *parent) {
+  /* If we're shutting down, we shouldn't be attempting to add jobs to it.
+   * If the user isn't using eventer_jobq_try_enqueue to catch errors, we
+   * should just assert */
+  mtevAssert(jobq->shutdown_state == EVENTER_JOBQ_RUNNING);
   job->next = NULL;
   /* Do not increase the concurrency from zero for a noop */
   if(ck_pr_load_32(&jobq->concurrency) == 0 && job->fd_event == NULL) {
@@ -550,6 +560,9 @@ eventer_jobq_dequeue_nowait(eventer_jobq_t *jobq) {
 
 void
 eventer_jobq_destroy(eventer_jobq_t *jobq) {
+  if (jobq->shutdown_state != EVENTER_JOBQ_SHUT_DOWN) {
+    mtevL(mtev_error, "WARNING: Attempting to shut down jobq %s before draining/shutting down\n", jobq->queue_name);
+  }
   pthread_mutex_lock(&all_queues_lock);
   mtev_hash_delete(&all_queues, jobq->queue_name, strlen(jobq->queue_name),
                    (NoitHashFreeFunc) free, 0);
@@ -568,6 +581,45 @@ eventer_jobq_destroy(eventer_jobq_t *jobq) {
   if(jobq->short_name) mtev_memory_safe_free((void *)jobq->short_name);
   free(jobq);
 }
+
+void
+eventer_jobq_drain_and_shutdown(eventer_jobq_t *jobq) {
+  int64_t todo = 0;
+
+  eventer_jobq_set_min_max(jobq, 0, 0);
+  eventer_jobq_set_concurrency(jobq, 0);
+
+  jobq->shutdown_state = EVENTER_JOBQ_SHUTTING_DOWN;
+
+  /* Wait until there's nothing either in flight or in the backlog */
+  while (1) {
+    todo = ck_pr_load_32(&jobq->backlog) + ck_pr_load_32(&jobq->inflight);
+    if (!todo) {
+      break;
+    }
+    usleep(100);
+  }
+
+  /* Wait for concurrency to hit zero */
+  while (1) {
+    todo = ck_pr_load_32(&jobq->concurrency);
+    if (!todo) {
+      break;
+    }
+    usleep(100);
+  }
+
+  /* Wait for all the consumer threads to exit */
+  while (1) {
+    todo = ck_pr_load_32(&jobq->consumer_threads_running);
+    if (!todo) {
+      break;
+    }
+    usleep(100);
+  }
+  jobq->shutdown_state = EVENTER_JOBQ_SHUT_DOWN;
+}
+
 int
 eventer_jobq_execute_timeout(eventer_t e, int mask, void *closure,
                              struct timeval *now) {
@@ -719,6 +771,8 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
   sigjmp_buf env;
   volatile mtev_hrtime_t last_job_hrtime = 0;
 
+  ck_pr_inc_32(&jobq->consumer_threads_running);
+
   current_count = ck_pr_faa_32(&jobq->concurrency, 1) + 1;
   mtevL(eventer_deb, "jobq[%s/%p] -> %d\n", jobq->queue_name, pthread_self_ptr(), current_count);
   if(current_count > jobq->desired_concurrency) {
@@ -729,6 +783,7 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
       eventer_set_thread_name(NULL);
       mtev_memory_fini_thread();
     }
+    ck_pr_dec_32(&jobq->consumer_threads_running);
     pthread_exit(NULL);
     return NULL;
   }
@@ -920,6 +975,7 @@ eventer_jobq_consumer(eventer_jobq_t *jobq) {
   if(ck_pr_load_32(&jobq->backlog) > 0) {
     eventer_jobq_maybe_spawn(jobq, 0);
   }
+  ck_pr_dec_32(&jobq->consumer_threads_running);
   pthread_exit(NULL);
   return NULL;
 }

--- a/src/eventer/eventer_jobq.h
+++ b/src/eventer/eventer_jobq.h
@@ -110,6 +110,12 @@ API_EXPORT(eventer_jobq_t *) eventer_jobq_retrieve(const char *name);
 */
 API_EXPORT(void) eventer_jobq_destroy(eventer_jobq_t *jobq);
 
+/*! \fn void eventer_jobq_drain_and_shutdown(eventer_jobq_t *jobq)
+    \brief Make a jobq unable to accept new jobs and drain all inflight jobs.
+    \param jobq the joqs to drain and shut down
+*/
+API_EXPORT(void) eventer_jobq_drain_and_shutdown(eventer_jobq_t *jobq);
+
 /*! \fn void eventer_jobq_set_shortname(eventer_jobq_t *jobq, const char *name)
     \brief Set a "shorter" name for a jobq to be used in terse displays.
     \param jobq the jobq to modify


### PR DESCRIPTION
Add a new function, "eventer_jobq_drain_and_shutdown", that will wait
for all inflight/backlog jobs to finish, then close all of the jobq
consumer threads. This makes it safe to destroy the jobq.