### PR TITLE
Allow eventer config to be deep descendents

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 1.12
 
+ * Allow `<config>` in `<eventer>` to be a deep descendent.
+
 ### 1.12.11
 
  * Allow OPTIONS in rest layer.

--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -118,7 +118,7 @@ configure_eventer(const char *appname) {
   mtev_hash_table *table, *table2;
   char appscratch[1024];
 
-  snprintf(appscratch, sizeof(appscratch), "/%s/eventer/config|/%s/include/eventer/config",
+  snprintf(appscratch, sizeof(appscratch), "/%s/eventer//config|/%s/include/eventer//config",
            appname, appname);
   table = calloc(1, sizeof(*table));
   mtev_hash_init(table);


### PR DESCRIPTION
This will allow
  <eventer>
    <intermediary>
      <config> ... </config>
    </intermediary>
  </eventer>