### PR TITLE
Quiet SSL layer not understood messages.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ## 1.12
 
+ * Make the 'SSL layer X not understood' a debug message if X is being
+   explicitly disabled.
+
 ### 1.12.13
 
  * Ensure enough bchain space for over-sized headers. Large headers would

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -986,7 +986,7 @@ eventer_ssl_ctx_new_ex(eventer_ssl_orientation_t type,
       else SETBITOPT("cipher_server_preference", neg, SSL_OP_CIPHER_SERVER_PREFERENCE)
 #endif
       else {
-        mtevL(eventer_err, "SSL layer part '%s' not understood.\n", optname);
+        mtevL(neg ? eventer_deb : eventer_err, "SSL layer part '%s' not understood.\n", optname);
       }
     }
 


### PR DESCRIPTION
If !sslv2 is specified and SSLv2 isn't available, then not being able
to turn it off isn't an error-worthy message.  If a "not understood"
SSL layer is encountered, use debug logging if negation is requested.