### PR TITLE
CIRC-5039 - Fixed missing top of crash stacktrace when using libunwind

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 # 1
 
+ * Fix missing top of crash stacktrace when libunwind is being used.
+
 ## 1.12
 
  * Make the 'SSL layer X not understood' a debug message if X is being

--- a/src/utils/mtev_stacktrace.c
+++ b/src/utils/mtev_stacktrace.c
@@ -987,13 +987,15 @@ int mtev_backtrace_ucontext(void **callstack, ucontext_t *ctx, int cnt) {
   }
   unw_init_local(&cursor, (unw_context_t *)ctx);
 
-  while (unw_step(&cursor) > 0 && frames<cnt) {
+  int step_result = 1;
+  while (step_result > 0 && frames<cnt) {
     unw_word_t pc;
     unw_get_reg(&cursor, UNW_REG_IP, &pc);
     if (pc == 0) {
       break;
     }
     callstack[frames++] = (void *)pc;
+    step_result = unw_step(&cursor);
   }
 #else
   frames = backtrace(callstack, cnt);
@@ -1001,6 +1003,7 @@ int mtev_backtrace_ucontext(void **callstack, ucontext_t *ctx, int cnt) {
 #endif
   return frames;
 }
+
 void mtev_log_backtrace(mtev_log_stream_t ls, void **callstack, int cnt) {
   mtev_stacktrace_internal(ls, mtev_stacktrace, NULL, NULL, callstack, cnt);
 }

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -540,7 +540,14 @@ void mtev_self_diagnose(int sig, siginfo_t *si, void *uc) {
   mtev_stacktrace_ucontext(mtev_error_stacktrace, uc);
 #else
   (void)si;
-  mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, 3);
+// the number of top frames to ignore depends on how we get the backtrace
+// if we got a non-NULL uc and have libunwind then we don't need to ignore any frames
+// otherwise, we need to strip out the top 4 frames to get to the client callstack
+#if defined(HAVE_LIBUNWIND)
+  mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, uc ? 0 : 4);
+#else
+  mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, 4);
+#endif
 #endif
   mtev_log_leave_sighandler();
   raise(sig);

--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -542,11 +542,12 @@ void mtev_self_diagnose(int sig, siginfo_t *si, void *uc) {
   (void)si;
 // the number of top frames to ignore depends on how we get the backtrace
 // if we got a non-NULL uc and have libunwind then we don't need to ignore any frames
-// otherwise, we need to strip out the top 4 frames to get to the client callstack
+// otherwise, we need to strip out the top 3 (with backtrace) or 4 (with libunwind) frames
+// to get to the client callstack
 #if defined(HAVE_LIBUNWIND)
   mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, uc ? 0 : 4);
 #else
-  mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, 4);
+  mtev_stacktrace_ucontext_skip(mtev_error_stacktrace, uc, 3);
 #endif
 #endif
   mtev_log_leave_sighandler();


### PR DESCRIPTION
https://circonus.atlassian.net/browse/CIRC-5039
When we have a crash we get a context where the crash happened, and when that is given to libunwind it is already in the function context where the crash occurred, even before ignoring the top 3 frames or calling unw_step().
So there were two fixes here, one is to detect whether we are using libunwind vs. calling backtrace directly and whether we already have an incoming context (and so avoid ignoring valid stackframes), and the other is to avoid calling unw_step prematurely.