### PR TITLE
DRAFT: CIRC-4436 - Allow stacktrace across an eventer asynch

### DIFF
--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -49,6 +49,8 @@ extern "C" {
 #include <ck_pr.h>
 #include <ck_spinlock.h>
 
+#define EVENTER_STACKTRACE_SIZE   128
+
 /* We use ETIMEDOUT, which might be ETIME on some platforms */
 #ifndef ETIME
 #define ETIME ETIMEDOUT

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -1029,6 +1029,7 @@ int eventer_impl_init(void) {
 }
 
 void eventer_add_asynch_subqueue(eventer_jobq_t *q, eventer_t e, uint64_t subqueue) {
+  e->frames = mtev_backtrace_ucontext(e->callstack, NULL, EVENTER_STACKTRACE_SIZE, true);
   eventer_job_t *job;
   /* always use 0, if unspecified */
   if(eventer_is_loop(e->thr_owner) < 0) e->thr_owner = eventer_impl_tls_data[0].tid;
@@ -1059,6 +1060,7 @@ void eventer_add_asynch(eventer_jobq_t *q, eventer_t e) {
 }
 
 void eventer_add_asynch_dep_subqueue(eventer_jobq_t *q, eventer_t e, uint64_t subqueue) {
+  e->frames = mtev_backtrace_ucontext(e->callstack, NULL, EVENTER_STACKTRACE_SIZE, true);
   eventer_job_t *job;
   /* always use 0, if unspecified */
   if(eventer_is_loop(e->thr_owner) < 0) e->thr_owner = eventer_impl_tls_data[0].tid;
@@ -1089,6 +1091,7 @@ void eventer_add_asynch_dep(eventer_jobq_t *q, eventer_t e) {
 }
 
 mtev_boolean eventer_try_add_asynch_subqueue(eventer_jobq_t *q, eventer_t e, uint64_t subqueue) {
+  e->frames = mtev_backtrace_ucontext(e->callstack, NULL, EVENTER_STACKTRACE_SIZE, true);
   eventer_t timeout = NULL;
   eventer_job_t *job;
   /* always use 0, if unspecified */
@@ -1125,6 +1128,7 @@ mtev_boolean eventer_try_add_asynch(eventer_jobq_t *q, eventer_t e) {
 }
 
 mtev_boolean eventer_try_add_asynch_dep_subqueue(eventer_jobq_t *q, eventer_t e, uint64_t subqueue) {
+  e->frames = mtev_backtrace_ucontext(e->callstack, NULL, EVENTER_STACKTRACE_SIZE, true);
   eventer_t timeout = NULL;
   eventer_job_t *job;
   /* always use 0, if unspecified */
@@ -1464,6 +1468,7 @@ int eventer_run_callback(eventer_func_t f, eventer_t e, int m, void *c, struct t
   eventer_ref(e);
   eventer_set_this_event(e);
   eventer_callback_prep(e, m, c, n);
+  e->eventer_run_callback_end = &&end;
   rmask = f(e, m, c, n);
   eventer_callback_cleanup(e, rmask);
   mtev_boolean freed = eventer_deref(e);
@@ -1485,6 +1490,8 @@ int eventer_run_callback(eventer_func_t f, eventer_t e, int m, void *c, struct t
     }
   }
   return rmask;
+end:
+  ;
 }
 
 static void *eventer_thread_harness(void *ve) {

--- a/src/eventer/eventer_impl_private.h
+++ b/src/eventer/eventer_impl_private.h
@@ -77,6 +77,9 @@ struct name { \
   pthread_t           thr_owner; \
   uint32_t            refcnt; \
   eventer_context_t   ctx[MAX_EVENT_CTXS]; \
+  int                 frames; \
+  void               *callstack[EVENTER_STACKTRACE_SIZE]; \
+  void               *eventer_run_callback_end; \
 }
 
 EVENTER_STRUCT(_event);

--- a/src/utils/mtev_stacktrace.h
+++ b/src/utils/mtev_stacktrace.h
@@ -68,7 +68,7 @@ API_EXPORT(int)
   mtev_backtrace(void **ips, int cnt);
 
 API_EXPORT(int)
-  mtev_backtrace_ucontext(void **ips, ucontext_t *ucp, int cnt);
+  mtev_backtrace_ucontext(void **ips, ucontext_t *ucp, int cnt, bool cross_eventer);
 
 API_EXPORT(int)
   mtev_aco_backtrace(aco_t *co, void **addrs, int addrs_len);


### PR DESCRIPTION
This branch allows libmtev to stacktrace beyond `mtev_run_callback` and show what the stacktrace was when `eventer_add` was called.  That allows us to get a greater context if a crash occurs.