### PR TITLE
Respect `segment_size` and `precommit` jlog config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,12 +2,13 @@
 
 # 1
 
- * Fix missing top of crash stacktrace when libunwind is being used.
 
 ## 1.12
 
+ * Fix missing top of crash stacktrace when libunwind is being used.
  * Make the 'SSL layer X not understood' a debug message if X is being
    explicitly disabled.
+ * Fix `segment_size` and `precommit` config processing for `jlog` logs.
 
 ### 1.12.13
 

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -1208,23 +1208,6 @@ one_more_time:
   if(!log) return -1;
   jlog_set_error_func(log, mtev_log_jlog_err, ls);
 
-  const char *segment_size = mtev_hash_dict_get(ls->config, "segment_size");
-  if(segment_size) {
-    int ss = atoi(segment_size);
-    /* if it is nonsensical, leave it unchanged */
-    if(ss > 0 && ss <= MAX_JLOG_SEGMENT_SIZE) {
-      jlog_ctx_alter_journal_size(log, ss);
-    }
-  }
-  const char *precommit = mtev_hash_dict_get(ls->config, "precommit");
-  size_t precommit_size = 0;
-  if(precommit) precommit_size = strtoull(precommit, NULL, 10);
-  /* if it is too large, cap it */
-  if(precommit_size > MAX_JLOG_PRECOMMIT_SIZE) {
-    precommit_size = MAX_JLOG_PRECOMMIT_SIZE;
-  }
-  jlog_ctx_set_pre_commit_buffer_size(log, precommit_size);
-
   /* Open the writer. */
   if(jlog_ctx_open_writer(log)) {
     /* If that fails, we'll give one attempt at initiailizing it. */
@@ -1248,6 +1231,23 @@ one_more_time:
     jlog_ctx_close(log);
     goto one_more_time;
   }
+
+  const char *segment_size = mtev_hash_dict_get(ls->config, "segment_size");
+  if(segment_size) {
+    int ss = atoi(segment_size);
+    /* if it is nonsensical, leave it unchanged */
+    if(ss > 0 && ss <= MAX_JLOG_SEGMENT_SIZE) {
+      jlog_ctx_alter_journal_size(log, ss);
+    }
+  }
+  const char *precommit = mtev_hash_dict_get(ls->config, "precommit");
+  size_t precommit_size = 0;
+  if(precommit) precommit_size = strtoull(precommit, NULL, 10);
+  /* if it is too large, cap it */
+  if(precommit_size > MAX_JLOG_PRECOMMIT_SIZE) {
+    precommit_size = MAX_JLOG_PRECOMMIT_SIZE;
+  }
+  jlog_ctx_set_pre_commit_buffer_size(log, precommit_size);
 
   /* Add or remove subscribers according to the current configuration. */
   listed = jlog_ctx_list_subscribers(log, &subs);


### PR DESCRIPTION
The metadata alteration was done prior to the opening of the writer
which made it not work.  Delay the alteration until after the writer is
open.

CIRC-6004