### PR TITLE
Fix predicate in mtev_reverse.

### DIFF
--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -1152,7 +1152,7 @@ int mtev_reverse_socket_connect(const char *id, int existing_fd) {
         }
       }
       rc->data.last_allocated_channel = chan;
-      if(existing_fd) {
+      if(existing_fd >= 0) {
         eventer_t e;
         channel_closure_t *cct;
         mtev_gettimeofday(&rc->data.channels[chan].create_time, NULL);


### PR DESCRIPTION
`if(fd >= 0)` instead of `if(fd)`.  The default `mtev_main` startup
process always either leaves stdin open or dups /dev/null to fd 0, so
this bug should never manifest under prescribed conditions, but this is
certainly a bug.