### PR TITLE
Update license list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -35,12 +35,76 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Source code included in this distribution have varying (but compatible)
 licenses.  They are listed here in brief form.  Their licenses can be
-found in full form with their code within the source tree.
+found in full form with their code within the source tree, or below.
 
-noitedit: (libedit: new-BSD w/advert) [http://labs.omniti.com/labs/reconnoiter]
-eventer: new-BSD [http://labs.omniti.com/labs/reconnoiter]
+* aklomp-base64: BSD-2-Clause [https://github.com/aklomp/base64]
+* android-demangle: GCC-exception-2.0 [https://android.googlesource.com/platform/external/gcc-demangle/]
+* bootstrap: MIT [https://github.com/twbs/bootstrap]
+* bootstrap-toggle: MIT [https://github.com/minhur/bootstrap-toggle]
+* json-c: MIT [https://github.com/json-c/json-c]
+* libaco: Apache-2.0 [https://github.com/hnes/libaco]
+* libedit: BSD-4-Clause-UC [http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libedit/] (noitedit)
+* libslz: MIT [https://github.com/wtarreau/libslz]
+* LuaJIT: MIT [https://luajit.org/luajit.html]
+* plock: MIT [https://github.com/wtarreau/plock]
+* rabbitmq-c: MIT [https://github.com/alanxz/rabbitmq-c]
+* telnetd: BSD-4-Clause-UC [http://cvsweb.netbsd.org/bsdweb.cgi/src/libexec/telnetd/] (mtev console)
+* xxHash: BSD-2-Clause [https://cyan4973.github.io/xxHash/]
 
-Portions of yajl are included in this distribution:
+
+=== Portions of NetBSD are included in this distribution ===
+
+(libedit, telnetd)
+
+This product includes software developed by the University of California, Berkeley and its contributors.
+
+
+=== Portions of json-c are included in this distribution ===
+
+Copyright (c) 2009-2012 Eric Haszlakiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+----------------------------------------------------------------
+
+Copyright (c) 2004, 2005 Metaparadigm Pte Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+=== Portions of yajl are included in this distribution ===
 
 Copyright (c) 2007-2014, Lloyd Hilaiel <me@lloyd.io>
 
@@ -56,6 +120,9 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+
+=== Portions of the OpenEvidence Toolkit are included in this distribution ===
+
  *    "This product includes software developed by the OpenEvidence Project
  *    for use in the OpenEvidence Toolkit (http://www.openevidence.org/)
  *    This product includes software developed by the OpenSSL Project
@@ -63,34 +130,3 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *    This product includes cryptographic software written by Eric Young
  *    (eay@cryptsoft.com).  This product includes software written by Tim
  *    Hudson (tjh@cryptsoft.com)."
-
-aklomp/base64 is included in this distribution:
-
-Copyright (c) 2005-2007, Nick Galbreath
-Copyright (c) 2013-2017, Alfred Klomp
-Copyright (c) 2015-2017, Wojciech Mula
-Copyright (c) 2016-2017, Matthieu Darbois
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-- Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-
-- Redistributions in binary form must reproduce the above copyright
-  notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Remove redundant full text for aklomp-base64, which appears in its
source directory.

Audit for all external sources imported into the tree, and list each
with its SPDX identifier and home page link.