### PR TITLE
Include "seconds" after the time given

### DIFF
--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -658,7 +658,7 @@ mtev_main(const char *appname,
     watchdog_timeout_str = getenv("WATCHDOG_TIMEOUT");
   if(watchdog_timeout_str) {
     watchdog_timeout = atoi(watchdog_timeout_str);
-    mtevL(mtev_notice, "Setting watchdog timeout to %d\n",
+    mtevL(mtev_notice, "Setting watchdog timeout to %d seconds\n",
           watchdog_timeout);
   }
 


### PR DESCRIPTION
I think many users will be troubleshooting watchdog periods based on this error message, so writing out "seconds" is likely to save other people time.