### PR TITLE
CIRC-6997 - Fix Crash On Invalid JSON

### DIFF
--- a/src/json-lib/mtev_json_tokener.c
+++ b/src/json-lib/mtev_json_tokener.c
@@ -220,7 +220,7 @@ struct mtev_json_object* mtev_json_tokener_parse_ex(struct mtev_json_tokener *to
   /* End hacky bit */
   tok->err = mtev_json_tokener_success;
 
-  do {
+  while (POP_CHAR(c, tok)) {
   redo_char:
     switch(state) {
 
@@ -657,7 +657,7 @@ struct mtev_json_object* mtev_json_tokener_parse_ex(struct mtev_json_tokener *to
     }
     if (!ADVANCE_CHAR(str, tok))
       goto out;
-  } while (POP_CHAR(c, tok));
+  } /* while (POP_CHAR) */
 
  out:
   if (!c) { /* We hit an eof char (0) */

--- a/src/json-lib/mtev_json_tokener.h
+++ b/src/json-lib/mtev_json_tokener.h
@@ -81,6 +81,7 @@ struct mtev_json_tokener
   unsigned int ucs_char;
   char quote_char;
   struct mtev_json_tokener_srec stack[MTEV_JSON_TOKENER_MAX_DEPTH];
+  bool started;
 };
 
 extern const char* mtev_json_tokener_errors[];


### PR DESCRIPTION
The JSON parser would crash when invalid JSON was passed into it that did not start with a valid JSON leading character. Added code to validate that we're starting with one off those before processing.