### PR TITLE
CIRC-7041 - UBSan mtev_hash

### DIFF
--- a/src/utils/mtev_hash.h
+++ b/src/utils/mtev_hash.h
@@ -74,7 +74,8 @@ typedef struct mtev_hash_table {
       char pad[sizeof(ck_hs_t)];
       void *locks;
     } locks;
-  } u CK_CC_CACHELINE;
+    char cache[CK_MD_CACHELINE];
+  } u;
 } mtev_hash_table;
 
 typedef struct mtev_hash_iter {


### PR DESCRIPTION
The size of an object is not its alignment.  Neither ``malloc``, or in this
case, ``mtev_memory_safe_malloc_cleanup``, can determine what the proper
alignment should be since all they get is a request that contains only a number
of bytes.

For example:

```
./seq/filters/workspace/noit.out:SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior noit_check.c:3054:5 in
./seq/filters/workspace/noit.out:noit_check.c:2416:32: runtime error: member access within misaligned address 0x7fcb840040a0 for type 'stats_t' (aka 'struct stats_t'), which requires 64 byte alignment
```

Usually, ``malloc`` only aligns at an 8 byte boundary or ``max_align_t``,
neither of which are 64 bytes

Preserves backwards compatibility without hitting undefined behavior