### PR TITLE
allowed space(s) between number and unit string in duration parsing

### DIFF
--- a/src/utils/mtev_confstr.c
+++ b/src/utils/mtev_confstr.c
@@ -159,7 +159,6 @@ mtev_confstr_parse_duration(const char *input, uint64_t *output,
     /* white-space separated, null-terminated */
     while(*input && isspace(*input))
       input++;
-
     if(! *input)
       break;
 

--- a/src/utils/mtev_confstr.c
+++ b/src/utils/mtev_confstr.c
@@ -157,19 +157,8 @@ mtev_confstr_parse_duration(const char *input, uint64_t *output,
   *output = 0;
   while(true) {
     /* white-space separated, null-terminated */
-    /* sinse space(s) allowed between number and unit string */
-    /* the problem is if a user pass like "10 sec    " */
-    /* we are in infinitive loop according to the new logic line 169 - 170 */
-    /* assumption is to allow 5 times try before exit */
-    int count = 0;
-    while(*input && isspace(*input)) {
+    while(*input && isspace(*input))
       input++;
-      /* restore if space between number and unit string */
-      if(*input && !isdigit(*input) && count < 5) {
-        input--;
-        ++count;
-      }
-    }
 
     if(! *input)
       break;

--- a/src/utils/mtev_confstr.c
+++ b/src/utils/mtev_confstr.c
@@ -170,7 +170,8 @@ mtev_confstr_parse_duration(const char *input, uint64_t *output,
       return MTEV_CONFSTR_PARSE_ERR_FORMAT;
 
     /* remove space(s) between number and unit string */
-    while(!isalpha(*unit_str)){
+    while(*unit_str && !isalpha(*unit_str)){
+      if(isdigit(*unit_str)) return MTEV_CONFSTR_PARSE_ERR_FORMAT;
       unit_str++;
     }
 

--- a/src/utils/mtev_confstr.c
+++ b/src/utils/mtev_confstr.c
@@ -170,10 +170,8 @@ mtev_confstr_parse_duration(const char *input, uint64_t *output,
       return MTEV_CONFSTR_PARSE_ERR_FORMAT;
 
     /* remove space(s) between number and unit string */
-    while(*unit_str && !isalpha(*unit_str)){
-      if(isdigit(*unit_str)) return MTEV_CONFSTR_PARSE_ERR_FORMAT;
+    while(*unit_str && isspace(*unit_str))
       unit_str++;
-    }
 
     /* unit string */
     input = unit_str;


### PR DESCRIPTION
[Jira ticket - CIRC-7085](https://circonus.atlassian.net/browse/CIRC-7085)

Currently, libmtev parsing function mtev_confstr_parse_duration can recognize only spaces between different time units like "1day 20min 10sec". New logic will allow end-users to use spaces freely everywhere like "1 day 20 min 10 sec". 
