### PR TITLE
Add env variable to configure where to send stdout/stdout

### DIFF
--- a/src/mtev_main.c
+++ b/src/mtev_main.c
@@ -667,12 +667,16 @@ mtev_main(const char *appname,
   lockfd = -1;
 
   if(foreground == 0) {
+    char *default_background_redirect = "/dev/null";
+    char *redirect_path = getenv("MTEV_OUTPUT_REDIRECT");
+    if (!redirect_path) { redirect_path = default_background_redirect; }
+
     fd = open("/dev/null", O_RDONLY);
     if(fd < 0 || dup2(fd, STDIN_FILENO) < 0) {
       mtevStartupTerminate(mtev_error, "Failed to setup stdin: %s\n", strerror(errno));
     }
     close(fd);
-    fd = open("/dev/null", O_WRONLY);
+    fd = open(redirect_path, O_WRONLY);
     if(fd < 0 || dup2(fd, STDOUT_FILENO) < 0 || dup2(fd, STDERR_FILENO) < 0) {
       mtevStartupTerminate(mtev_error, "Failed to setup std{out,err}: %s\n", strerror(errno));
     }


### PR DESCRIPTION
Currently libmtev always sends stdout and stderr to /dev/null unless the mtev client specifies foreground (with snowth this is -D switch).  However, there are rare cases where we want to be able to see what was directly output from the mtev client to stour or stderr.  This change allows configuring of the output path by simply setting the env variable MTEV_OUTPUT_REDIRECT to the desired path (usually would be a log file).  This can allow things like allocator messages, debug tools messages, or other error or output messages etc. to be saved to a log file.