### PR TITLE
Make ENV: and consul: fallback greedy.

### DIFF
--- a/src/modules/consul.c
+++ b/src/modules/consul.c
@@ -882,7 +882,7 @@ mtev_consul_conf_fixup(void *closure, mtev_conf_section_t section, const char *x
   if(set && *value && !strncmp(*value, "consul:", 7)) {
     char *fallback = *value + 7;
     tofree = *value;
-    char *key = strchr(fallback, ':');
+    char *key = strrchr(fallback, ':');
     if(key) *key++ = '\0';
     else {
       key = fallback;

--- a/src/mtev_conf.c
+++ b/src/mtev_conf.c
@@ -3882,6 +3882,7 @@ mtev_conf_OLD_env_fixup(void *closure, mtev_conf_section_t section, const char *
   if(set && *value && !strncmp(*value, "ENV:", 4)) {
     char *fallback = *value + 4;
     char *key = strchr(fallback, ':');
+    while(key && key[1] != '{') key = strchr(key+1, ':');
     if(key){
       key++;
       if(*key == '{' && key[strlen(key)-1] == '}') {


### PR DESCRIPTION
This will allow fallback values to have colons.