### PR TITLE
Fix accounting issue on static jobq subqueue.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,11 @@
 
 ## 2.2
 
+### 2.2.1
+
+ * Fix inflight accounting issue on eventer jobq subqueues that would cause
+   job lockup after `UINT32_MAX` jobs were run on the static (default) subqueue.
+
 ### 2.2.0
 
  * Deprecate `mtev_atomic` functionality.

--- a/src/eventer/eventer_jobq.c
+++ b/src/eventer/eventer_jobq.c
@@ -208,6 +208,9 @@ mark_squeue_job_completed(eventer_jobq_t *jobq, eventer_job_t *job) {
     }
     pthread_mutex_unlock(&jobq->lock);
   }
+  else {
+    ck_pr_dec_32(&job->squeue->inflight);
+  }
 }
 static void
 eventer_jobq_finished_job(eventer_jobq_t *jobq, eventer_job_t *job) {


### PR DESCRIPTION
We were missing out inflight decrement when jobs were assigned to the
static (default) FSS subqueue of a jobq.  This would cause jobs to not
be scheduled once `UINT32_MAX` (2^32-1) jobs had been scheduled.