### PR TITLE
CIRC-7160 GCC 11 array-bounds warning

### DIFF
--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -94,7 +94,7 @@ struct bchain *bchain_alloc(size_t size, int line) {
   struct bchain *n;
   /* mmap is greater than 1MB, inline otherwise */
   if (size >= 1048576) {
-    n = malloc(offsetof(struct bchain, _buff));
+    n = malloc(sizeof(struct bchain));
     if(!n) {
       mtevL(mtev_error, "failed to alloc bchain in bchain_alloc (size %zd)\n", size);
       return NULL;


### PR DESCRIPTION
This change fixes the array-bounds warning by allocating the entirety of the bchain structure. 

CI Has passed