### PR TITLE
Make lua auto-preemption stable.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.2
 
+ * Make lua auto-preemption stable.
+
 ### 2.2.3
 
  * Avoid stack overflow in `mtev_hash_retrieve` and `mtev_hash_delete` when the

--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -374,7 +374,7 @@ mtev_lua_timer_fire(int sig, siginfo_t *info, void *c) {
   mtevL(nldeb, "timer fired: lua %p\n", tls_active_lua_state);
 
   if(tls_active_lua_state) {
-    lua_sethook(tls_active_lua_state, lstop, LUA_MASKCALL | LUA_MASKRET | LUA_MASKCOUNT,1);
+    lua_sethook(tls_active_lua_state, lstop, LUA_MASKCOUNT, 1);
   }
 }
 


### PR DESCRIPTION
We were registering the hook as CALL|RET|COUNT and lua does not support
C yields from CALL or RET hooks.  Only use the COUNT hook.