### PR TITLE
Make POST/PUT payload visible in backtrace and requests.json

### DIFF
--- a/src/backtrace-support/mtev-http-observer-module.lua
+++ b/src/backtrace-support/mtev-http-observer-module.lua
@@ -117,8 +117,8 @@ end
 --   uint64_t response_complete_ns;
 --   uint64_t inbytes;
 --   uint64_t outbytes;
---   mtev_hash_table info;                     128
---   void *payload;
+--   mtev_hash_table info;                     128 (vasu got 80d (0x50) for this)
+--   void *payload;                            144d (0x90)
 --   int64_t payload_length;
 -- } http_entry_t;
 --

--- a/src/backtrace-support/mtev-http-observer-module.lua
+++ b/src/backtrace-support/mtev-http-observer-module.lua
@@ -118,6 +118,8 @@ end
 --   uint64_t inbytes;
 --   uint64_t outbytes;
 --   mtev_hash_table info;                     128
+--   void *payload;
+--   int64_t payload_length;
 -- } http_entry_t;
 --
 local function walk_hash(a_hash)

--- a/src/backtrace-support/mtev-http2-module.lua
+++ b/src/backtrace-support/mtev-http2-module.lua
@@ -2,9 +2,10 @@ local function L(...)
   pmodule.log(pmodule.log_level.info, string.format(...))
 end
 
-local function bt2str(bt_var)
+local function bt2str(bt_var, len)
+  len = len or 256
   local addr = pmodule.variable_from_bt(bt_var):value()
-  return pmodule.address_read_string(addr, 256)
+  return pmodule.address_read_string(addr, len)
 end
 
 local function bt2val(bt_var)
@@ -18,13 +19,18 @@ local function variable_http2_cb(pt_var, bt_var)
   local qs = bt2str(bt_var.orig_qs)
   qs = qs and ("?" .. qs) or ""
   local length = bt2val(bt_var.content_length) or -1
+  local payload_len = bt2val(bt_var.upload.size)
+  local payload = bt2str(bt_var.upload.data, payload_len + 1)
   pt_var:thread():annotate(
     pmodule.annotation.comment,
     string.format("mtev_http2_request: %s %s%s (%d)", method, uri, qs, length))
   pt_var:backtrace():add_kv_string(
     "mtev_http_request",
     string.format("%s %s%s (%d)", method, uri, qs, length))
-end
+  pt_var:backtrace():add_kv_string(
+    "mtev_http_payload_in",
+    string.format("%s", payload))
+  end
 
 local function pm_mtev_http2_req()
   L("module-mtev-http2: load")

--- a/src/modules/http_observer.c
+++ b/src/modules/http_observer.c
@@ -97,6 +97,8 @@ allocate_entry(mtev_http_session_ctx *ctx) {
   newe->request_complete_ns = timeofday_nanos();
   newe->id = ck_pr_faa_64(&global_id, 1);
   mtev_hash_init(&newe->info);
+// VASU DEBUG
+mtevL(mtev_error, "Entry %p, info %p, payload %p, length %p\n", newe, &newe->info, &newe->payload, &newe->payload_length);
   newe->payload = NULL;
   newe->payload_length = 0;
   mtev_hash_replace(&lookup, (const char *)&newe->ctx, sizeof(newe->ctx), newe, NULL, mtev_memory_safe_free);

--- a/src/modules/http_observer.c
+++ b/src/modules/http_observer.c
@@ -187,19 +187,19 @@ static mtev_hook_return_t
 http_observer_prpr(void *closure, mtev_http_request *req, const void *payload, int64_t payload_length) {
   (void)closure;
   if (payload_length <= 0) {
-    payload = NULL;
-    payload_length = 0;
+    payload = "(empty)";
+    payload_length = 7;
   }
   const int64_t payload_limit = 1024*1024;
   if (payload_length > payload_limit) {
     payload_length = payload_limit;
   }
   char *payload_ptr = (char *)payload;
-  for (int64_t i = 0; i < payload_length;  i++)
+  for (int64_t i = 0; i < payload_length;  i++, payload_ptr++)
   {
-    if (!isprint(payload_ptr++)) {
-      payload = NULL;
-      payload_length = 0;
+    if (!isprint(*payload_ptr)) {
+      payload = "(binary)";
+      payload_length = 8;
       break;
     }
   }
@@ -208,13 +208,13 @@ http_observer_prpr(void *closure, mtev_http_request *req, const void *payload, i
     payload_ptr = malloc(payload_length);
     memcpy(payload_ptr, payload, payload_length);
   }
-  mtev_memory_begin();
 
+  mtev_memory_begin();
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   while(mtev_hash_adv_spmc(&lookup, &iter)) {
-    mtev_http_session_ctx *ctx = (mtev_http_session_ctx *)iter.key.ptr;
+    http_entry_t *entry = (http_entry_t *)iter.value.ptr;
+    mtev_http_session_ctx *ctx = entry->ctx;
     if (req == mtev_http_session_request(ctx)) {
-      http_entry_t *entry = (http_entry_t *)iter.value.ptr;
       if (entry->payload) {
         free(entry->payload);
       }

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -68,6 +68,12 @@ MTEV_HOOK_IMPL(http_post_request_read_payload,
   (void *closure, mtev_http_session_ctx *ctx),
   (closure, ctx))
 
+MTEV_HOOK_IMPL(http_post_request_payload_retrieved,
+  (mtev_http_request *req, const void *payload, int64_t payload_length),
+  void *, closure,
+  (void *closure, mtev_http_request *req, const void *payload, int64_t payload_length),
+  (closure, req, payload, payload_length))
+
 MTEV_HOOK_IMPL(http_response_starting,
   (mtev_http_session_ctx *ctx),
   void *, closure,

--- a/src/mtev_http.h
+++ b/src/mtev_http.h
@@ -279,6 +279,11 @@ MTEV_HOOK_PROTO(http_post_request_read_payload,
                 void *, closure,
                 (void *closure, mtev_http_session_ctx *ctx))
 
+MTEV_HOOK_PROTO(http_post_request_payload_retrieved,
+                (mtev_http_request *req, const void *payload, int64_t payload_length),
+                void *, closure,
+                (void *closure, mtev_http_request *req, const void *payload, int64_t payload_length))
+
 MTEV_HOOK_PROTO(http_response_starting,
                 (mtev_http_session_ctx *ctx),
                 void *, closure,

--- a/src/mtev_http1.c
+++ b/src/mtev_http1.c
@@ -371,6 +371,7 @@ mtev_http1_request_set_upload(mtev_http1_request *req,
 const void *
 mtev_http1_request_get_upload(mtev_http1_request *req, int64_t *size) {
   if(size) *size = req->upload.size;
+  (void)http_post_request_payload_retrieved_hook_invoke((mtev_http_request *)req, req->upload.data, req->upload.size);
   return req->upload.data;
 }
 const char *

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -402,6 +402,7 @@ mtev_http2_request_set_upload(mtev_http2_request *req,
 const void *
 mtev_http2_request_get_upload(mtev_http2_request *req, int64_t *size) {
   if(size) *size = req->upload.size;
+  (void)http_post_request_payload_retrieved_hook_invoke((mtev_http_request *)req, req->upload.data, req->upload.size);
   return req->upload.data;
 }
 const char *


### PR DESCRIPTION
The libmtev HTTP observer module and a backtrace Lua scripts have been changed to expose the incoming HTTP payload if it is text, so that we can see the incoming fetch REST API request for debugging Redfin.  This can also be useful in the case of other POST/PUT upload REST APIs, as long as the incoming payload is json.  Flatbuffer incoming payloads could be implemented in the future.