### PR TITLE
Add mtev_lfu_release_f

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.3
 
+ * Add `mtev_lfu_release_f` for releasing a cached item from a potentially destroyed cache.
+
 ### 2.3.3
 
  * Fix forensic HTTP logging in both HTTP/1 and HTTP/2.

--- a/src/utils/mtev_lfu.c
+++ b/src/utils/mtev_lfu.c
@@ -381,7 +381,7 @@ mtev_lfu_get(mtev_lfu_t *c, const char *key, size_t key_len, void **value)
 }
 
 void
-mtev_lfu_release(mtev_lfu_t *c, mtev_lfu_entry_token token)
+mtev_lfu_release_f(void (*free_fn)(void *), mtev_lfu_entry_token token)
 {
   bool zero = false;
   if (token == NULL) {
@@ -392,9 +392,15 @@ mtev_lfu_release(mtev_lfu_t *c, mtev_lfu_entry_token token)
   ck_pr_dec_64_zero(&r->ref_cnt, &zero);
   if (zero) {
     /* free it */
-    c->free_fn(r->entry);
+    free_fn(r->entry);
     free(r);
   }
+}
+
+void
+mtev_lfu_release(mtev_lfu_t *c, mtev_lfu_entry_token token)
+{
+  return mtev_lfu_release_f(c->free_fn, token);
 }
 
 

--- a/src/utils/mtev_lfu.h
+++ b/src/utils/mtev_lfu.h
@@ -121,6 +121,16 @@ API_EXPORT(void)
   mtev_lfu_release(mtev_lfu_t *lfu, mtev_lfu_entry_token token);
 
 /*!
+  \fn void mtev_lfu_release_f(void (*free_fn)(void *), mtev_lfu_entry_token token)
+  \brief Surrender an item back to the LFU (event if the LFU is potentially freed)
+
+  To be memory safe LFU tokens must be released back to the LFU when
+  the user is finished using them.
+ */
+API_EXPORT(void)
+  mtev_lfu_release_f(void (*free_fn)(void *), mtev_lfu_entry_token token);
+
+/*!
   \fn mtev_lfu_remove(mtev_lfu_t *lfu, const char *key, size_t key_len)
   \brief Remove key from the LFU
 


### PR DESCRIPTION
There are cases where a cache might be destroyed and someone still has
and item outstanding.  This function does not require the LFU itself
as an argument (but does require the free function registered to the
LFU).