### PR TITLE
Conditional setext based on openssl version

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 ## 2.3
 
- * Allow for an `addext` field for lua CSR generation (currently available only on ubuntu 20):
+ * Allow for an `addext` field for lua CSR generation (requires at least openssl 1.1):
    `addext = { subjectAltName = { "DNS:name1", "DNS:name2" } }`
 
 ## 2.3.5

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 ## 2.3
 
- * Allow for an `addext` field for lua CSR generation:
+ * Allow for an `addext` field for lua CSR generation (currently available only on ubuntu 20):
    `addext = { subjectAltName = { "DNS:name1", "DNS:name2" } }`
 
 ## 2.3.5

--- a/src/modules/lua_mtev_crypto.c
+++ b/src/modules/lua_mtev_crypto.c
@@ -435,8 +435,11 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
   if (!X509_REQ_set_version(req,0L)) /* version 1 */
     REQERR("crypto.rsa:gencsr could not set request version");
 
-  X509V3_CTX ext_ctx;
   lua_getfield(L,-1,"addext");
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+  if(!lua_isnil(L,-1)) REQERR("addext requires OpenSSL 1.1 or greater");
+#else
+  X509V3_CTX ext_ctx;
   if(!lua_isnil(L,-1)) {
     if(!lua_istable(L,-1)) REQERR("addext value must be a table");
     else {
@@ -476,6 +479,7 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
       }
     }
   }
+#endif
   lua_pop(L,1);
 
   lua_getfield(L,-1,"subject");


### PR DESCRIPTION
Support for oltphttp extension currently requires OpenSSL 1.1 or above for setext and is not available on el7 at this time, so wrapped the setext code in a conditional compile based on OpenSSL version check.  This is a temporary unblocking until a path is found and prioritized for el7.