### PR TITLE
Safer Usage Of eventer_remove_fd

### DIFF
--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -259,7 +259,7 @@ static void eventer_epoll_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_epoll_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e && fd >= 0) {
+  if(fd >= 0 && master_fds[fd].e) {
     struct epoll_spec *spec;
     struct epoll_event _ev;
     memset(&_ev, 0, sizeof(_ev));

--- a/src/eventer/eventer_epoll_impl.c
+++ b/src/eventer/eventer_epoll_impl.c
@@ -259,7 +259,7 @@ static void eventer_epoll_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_epoll_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e) {
+  if(master_fds[fd].e && fd >= 0) {
     struct epoll_spec *spec;
     struct epoll_event _ev;
     memset(&_ev, 0, sizeof(_ev));

--- a/src/eventer/eventer_kqueue_impl.c
+++ b/src/eventer/eventer_kqueue_impl.c
@@ -265,7 +265,7 @@ static void eventer_kqueue_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_kqueue_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e && fd >= 0) {
+  if(fd >= 0 && master_fds[fd].e) {
     mtevL(eventer_deb, "kqueue: remove_fd(%d)\n", fd);
     lockstate = acquire_master_fd(fd);
     eiq = master_fds[fd].e;

--- a/src/eventer/eventer_kqueue_impl.c
+++ b/src/eventer/eventer_kqueue_impl.c
@@ -265,7 +265,7 @@ static void eventer_kqueue_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_kqueue_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e) {
+  if(master_fds[fd].e && fd >= 0) {
     mtevL(eventer_deb, "kqueue: remove_fd(%d)\n", fd);
     lockstate = acquire_master_fd(fd);
     eiq = master_fds[fd].e;

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -204,7 +204,7 @@ static void eventer_ports_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_ports_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e && fd >= 0) {
+  if(fd >= 0 && master_fds[fd].e) {
     lockstate = acquire_master_fd(fd);
     /* Looks redundant, but we need to make sure we didn't lose
      * the event between checking and acquiring the lock */

--- a/src/eventer/eventer_ports_impl.c
+++ b/src/eventer/eventer_ports_impl.c
@@ -204,7 +204,7 @@ static void eventer_ports_impl_update(eventer_t e, int mask) {
 static eventer_t eventer_ports_impl_remove_fd(int fd) {
   eventer_t eiq = NULL;
   ev_lock_state_t lockstate;
-  if(master_fds[fd].e) {
+  if(master_fds[fd].e && fd >= 0) {
     lockstate = acquire_master_fd(fd);
     /* Looks redundant, but we need to make sure we didn't lose
      * the event between checking and acquiring the lock */

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -620,8 +620,12 @@ mtev_reverse_socket_wakeup(eventer_t e, int mask, void *closure, struct timeval 
   (void)tv;
   reverse_socket_t *rc = closure;
   if (rc->data.e) {
-    eventer_remove_fde(rc->data.e);
-    eventer_trigger(rc->data.e, EVENTER_READ|EVENTER_WRITE);
+    if (eventer_remove_fde(rc->data.e)) {
+      eventer_trigger(rc->data.e, EVENTER_READ|EVENTER_WRITE);
+    }
+    else {
+      mtevL(nldeb, "%s: failed to remove fde from eventer object %p\n", __func__, rc->data.e);
+    }
   }
   mtev_reverse_socket_deref(rc);
   return 0;


### PR DESCRIPTION
Check the fd in eventer_remove_fd and return NULL if it's less than zero. Add a check into reverse socket handling to check this.