### PR TITLE
libmtev asan confuses linker with wrong SONAME and links to normal liblmdb causing a double dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,6 @@ AC_ARG_ENABLE(rdtsc,
 
 : ${CFLAGS="-g -O2 -fno-omit-frame-pointer"}
 : ${CXXFLAGS="-g -O2 -fno-omit-frame-pointer"}
-
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG([-std=c11],
   [AX_APPEND_FLAG([-std=c11])],

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,7 @@ CPPFLAGS="$CPPFLAGS -D_REENTRANT "'-I$(top_srcdir)/src'
 DTRACEHDR=libmtev_dtrace_probes.h
 DTRACEHDR_TRANSFORM="copy"
 DOTSO=.so
-LD_LIBMTEV_VERSION='-Wl,-soname,libmtev.so.$(SEMVER_MAJOR)'
+LD_LIBMTEV_VERSION='-Wl,-soname,$(TGT_NAME).so.$(SEMVER_MAJOR)'
 MAPFLAGS=""
 AKLOMPENV="AVX2_CFLAGS=-mavx2 SSSE3_CFLAGS=-mssse3 SSE41_CFLAGS=-msse4.1 SSE42_CFLAGS=-msse4.2 AVX_CFLAGS=-mavx"
 DEFAULT_ENABLE_RDTSC=yes
@@ -1059,7 +1059,7 @@ AC_MSG_RESULT([
   FQ module:          $FQ_BUILT
   Zipkin-fq module:   $ZIPKIN_FQ_BUILT
 
-	== Target ==
-	Target module:      $TGT_NAME
+  == Target ==
+  Target library:      $TGT_NAME
 
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,13 @@ AC_ARG_ENABLE(rdtsc,
 
 : ${CFLAGS="-g -O2 -fno-omit-frame-pointer"}
 : ${CXXFLAGS="-g -O2 -fno-omit-frame-pointer"}
+
+if test "x$BUILD_ASAN" = "x"; then
+  TGT_NAME="libmtev"
+else
+  TGT_NAME="libmtev-asan"
+fi
+
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG([-std=c11],
   [AX_APPEND_FLAG([-std=c11])],
@@ -349,6 +356,7 @@ AC_SUBST(DOTDYLIB)
 AC_SUBST(LD_LIBMTEV_VERSION)
 AC_SUBST(MDB_MODS)
 AC_SUBST(FAST_TIME_PRELOAD)
+AC_SUBST(TGT_NAME)
 
 AC_DEFINE_UNQUOTED(CAP_PLATFORM, "$CAP_PLATFORM", [Capabilities platform.])
 AS_IF([test "x$CAP_SUPPORTED" = "x1"],
@@ -566,11 +574,15 @@ AC_CHECK_FUNC(fdwalk, [AC_DEFINE(HAVE_FDWALK, [1], [have fdwalk])], )
 AC_CHECK_LIB(util, openpty, , )
 AC_CHECK_LIB(termcap, tputs, , )
 AC_CHECK_LIB(curses, clear, , [AC_MSG_ERROR([curses not found, but required])])
+
 if test "$enable_lmdb" != "no"; then
-AC_CHECK_LIB(lmdb, mdb_dbi_open,[
-  AC_DEFINE(HAVE_LMDB, [1], [have LMDB])
-  LIBS="-llmdb $LIBS"
-  ], [AC_MSG_ERROR([lmdb not found, but required])])
+  if test "x$BUILD_ASAN" = "x"; then
+      AC_CHECK_LIB(lmdb, mdb_dbi_open,[AC_DEFINE(HAVE_LMDB, [1], [have LMDB])
+  LIBS="-llmdb $LIBS"], [AC_MSG_ERROR([lmdb not found, but required])])
+  else
+      AC_CHECK_LIB(lmdb-asan, mdb_dbi_open,[AC_DEFINE(HAVE_LMDB, [1], [have LMDB])
+  LIBS="-llmdb-asan $LIBS"], [AC_MSG_ERROR([lmdb-asan not found, but required])])
+  fi
 fi
 
 CPPFLAGS="$CPPFLAGS `pcre-config --cflags`"

--- a/configure.ac
+++ b/configure.ac
@@ -62,12 +62,6 @@ AC_ARG_ENABLE(rdtsc,
 : ${CFLAGS="-g -O2 -fno-omit-frame-pointer"}
 : ${CXXFLAGS="-g -O2 -fno-omit-frame-pointer"}
 
-if test "x$BUILD_ASAN" = "x"; then
-  TGT_NAME="libmtev"
-else
-  TGT_NAME="libmtev-asan"
-fi
-
 AC_PROG_CC
 AX_CHECK_COMPILE_FLAG([-std=c11],
   [AX_APPEND_FLAG([-std=c11])],
@@ -127,7 +121,13 @@ CPPFLAGS="$CPPFLAGS -D_REENTRANT "'-I$(top_srcdir)/src'
 DTRACEHDR=libmtev_dtrace_probes.h
 DTRACEHDR_TRANSFORM="copy"
 DOTSO=.so
-LD_LIBMTEV_VERSION='-Wl,-soname,$(TGT_NAME).so.$(SEMVER_MAJOR)'
+if test "x$BUILD_ASAN" = "x"; then
+  TGT_NAME="libmtev"
+  LD_LIBMTEV_VERSION='-Wl,-soname,libmtev.so.$(SEMVER_MAJOR)'
+else
+  TGT_NAME="libmtev-asan"
+  LD_LIBMTEV_VERSION='-Wl,-soname,libmtev-asan.so.$(SEMVER_MAJOR)'
+fi
 MAPFLAGS=""
 AKLOMPENV="AVX2_CFLAGS=-mavx2 SSSE3_CFLAGS=-mssse3 SSE41_CFLAGS=-msse4.1 SSE42_CFLAGS=-msse4.2 AVX_CFLAGS=-mavx"
 DEFAULT_ENABLE_RDTSC=yes

--- a/configure.ac
+++ b/configure.ac
@@ -1059,4 +1059,7 @@ AC_MSG_RESULT([
   FQ module:          $FQ_BUILT
   Zipkin-fq module:   $ZIPKIN_FQ_BUILT
 
+	== Target ==
+	Target module:      $TGT_NAME
+
 ])

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -86,10 +86,10 @@ NOWHOLE_ARCHIVE=@NOWHOLE_ARCHIVE@
 DTRACEOBJ=@DTRACEOBJ@
 LIBMTEV_DTRACEOBJ=$(DTRACEOBJ:%dtrace_stub.o=libmtev_%dtrace_stub.lo)
 LIBMTEVA_DTRACEOBJ=$(DTRACEOBJ:%dtrace_stub.o=libmtev_%dtrace_stub.o)
-LIBMTEV_V=libmtev@DOTSO@.$(LIBMTEV_VERSION)@DOTDYLIB@
-LIBMTEV_MAJOR=libmtev@DOTSO@.$(SEMVER_MAJOR)@DOTDYLIB@
-LIBMTEV=libmtev@DOTSO@@DOTDYLIB@
-LIBMTEVA=libmtev.a
+LIBMTEV_V=@TGT_NAME@@DOTSO@.$(LIBMTEV_VERSION)@DOTDYLIB@
+LIBMTEV_MAJOR=@TGT_NAME@@DOTSO@.$(SEMVER_MAJOR)@DOTDYLIB@
+LIBMTEV=@TGT_NAME@@DOTSO@@DOTDYLIB@
+LIBMTEVA=@TGT_NAME@.a
 FAST_TIME_PRELOAD=@FAST_TIME_PRELOAD@
 
 TARGETS=$(LIBMTEVA) $(LIBMTEV) $(LIBMTEV_MAJOR) $(FAST_TIME_PRELOAD) @LUA_LUAMTEV@ @MDB_MODS@
@@ -307,7 +307,7 @@ $(LIBMTEV_MAJOR):	$(LIBMTEV_V)
 
 $(LIBMTEVA):	$(FINAL_LIBMTEVA_OBJS) $(LIBMTEVA_DTRACEOBJ)
 	@echo "- linking $@"
-	$(Q)rm -f libmtev.o libmtev.a 
+	$(Q)rm -f libmtev.o $(LIBMTEVA)
 	$(Q)$(LD) $(LDEXTRAFLAGS) $(LDOVERRIDE) -r -o libmtev.o $(FINAL_LIBMTEVA_OBJS) $(LIBMTEVA_DTRACEOBJ)
 	$(Q)if test -x "$(CTFMERGE)" ; then \
 		echo "- merging CTF ($@)" ; \
@@ -485,7 +485,7 @@ coverage.xml:	libmtev.info
 	$(PYTHON) $(top_srcdir)/buildtools/lcov_cobertura.py libmtev.info -b . -o coverage.xml
 
 clean:
-	rm -f *.lo *.o *.hlo *.Slo *.ho *.So libmtev.a libmtev_dtrace_probes.h
+	rm -f *.lo *.o *.hlo *.Slo *.ho *.So $(LIBMTEVA) libmtev_dtrace_probes.h
 	rm -f *.gcov *.gcda *.gcno
 	for subdir in aco eventer noitedit utils json-lib; do \
 		rm -f $$subdir/*.lo $$subdir/*.o $$subdir/*.hlo $$subdir/*.Slo $$subdir/*.So $$subdir/*.ho ; \


### PR DESCRIPTION
libmtev-asan had SONAME set to normal libmtev and so -lmtev-asan was actually causing linkage to non-asap libmtev, also it was always linking to non-asan liblmdb, which causes a target ASAN client to link to both liblmdb and liblmdb-asan