### PR TITLE
CIRC-9304 Fix X509 extensions under OpenSSL 1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.3
 
+ * Support `addext` field under OpenSSL 1.0.
+
 ## 2.3.7
 
  * Fix additional use-after-frees in reverse socket code

--- a/src/modules/lua_mtev_crypto.c
+++ b/src/modules/lua_mtev_crypto.c
@@ -436,9 +436,7 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
     REQERR("crypto.rsa:gencsr could not set request version");
 
   lua_getfield(L,-1,"addext");
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-  if(!lua_isnil(L,-1)) REQERR("addext requires OpenSSL 1.1 or greater");
-#else
+
   X509V3_CTX ext_ctx;
   if(!lua_isnil(L,-1)) {
     if(!lua_istable(L,-1)) REQERR("addext value must be a table");
@@ -468,6 +466,9 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
         lua_pop(L,1);
       }
       addext_conf = NCONF_new(NCONF_default());
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+      #define X509V3_CTX_REPLACE 0x2
+#endif
       X509V3_set_ctx(&ext_ctx, NULL, NULL, req, NULL, X509V3_CTX_REPLACE);
       long errorline = -1;
       if(NCONF_load_bio(addext_conf, addext_bio, &errorline) <= 0) {
@@ -479,7 +480,6 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
       }
     }
   }
-#endif
   lua_pop(L,1);
 
   lua_getfield(L,-1,"subject");

--- a/src/modules/lua_mtev_crypto.c
+++ b/src/modules/lua_mtev_crypto.c
@@ -48,6 +48,9 @@
 #ifndef OPENSSL_STACK
 #define OPENSSL_STACK void
 #endif
+#ifndef X509V3_CTX_REPLACE
+#define X509V3_CTX_REPLACE 0x2
+#endif
 #endif
 
 #ifndef sk_OPENSSL_STRING_value
@@ -466,9 +469,6 @@ mtev_lua_crypto_rsa_gencsr(lua_State *L) {
         lua_pop(L,1);
       }
       addext_conf = NCONF_new(NCONF_default());
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-      #define X509V3_CTX_REPLACE 0x2
-#endif
       X509V3_set_ctx(&ext_ctx, NULL, NULL, req, NULL, X509V3_CTX_REPLACE);
       long errorline = -1;
       if(NCONF_load_bio(addext_conf, addext_bio, &errorline) <= 0) {


### PR DESCRIPTION
We were just missing a define that didn't exist in 1.0.