### PR TITLE
CIRC-9483 - heap use after free

### DIFF
--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -560,7 +560,6 @@ mtev_reverse_socket_channel_handler(eventer_t e, int mask, void *closure,
     else if (parent_eventer && eventer_deref(parent_eventer)) {
       cct->parent->data.e = NULL;
     }
-
     free(cct);
     return 0;
   }

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -816,9 +816,8 @@ socket_error:
         channel_closure_t *cct;
         cct = malloc(sizeof(*cct));
         cct->channel_id = rc->data.incoming_inflight.channel_id;
-        // Anchor 'rc' to the life cycle of 'newe'
-        mtev_reverse_socket_ref(rc);
         cct->parent = rc;
+        mtev_reverse_socket_ref(rc);
 
         eventer_t newe =
           eventer_alloc_fd(mtev_reverse_socket_channel_handler, cct, fd,

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -451,7 +451,6 @@ mtev_reverse_socket_channel_shutdown(reverse_socket_t *const rc, const uint16_t 
     channel->pair[0] = channel->pair[1] = AVAILABLE;
   }
 
-
   pthread_mutex_unlock(&rc->lock);
   return mtev_reverse_socket_deref(rc);
 }

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -546,7 +546,7 @@ mtev_reverse_socket_channel_handler(eventer_t e, int mask, void *closure,
       cct->parent->data.e = NULL;
     }
 
-    mtev_reverse_socket_deref(&cct->parent);
+    mtev_reverse_socket_deref(cct->parent);
     free(cct);
     return 0;
   }

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -135,13 +135,13 @@ static void reverse_frame_free(void *vrf) {
   free(f);
 }
 
-static inline reverse_frame_t* reverse_frame_move(reverse_frame_t *frame_to_copy) {
+static inline reverse_frame_t* reverse_frame_move(reverse_frame_t *frame_to_move) {
   reverse_frame_t *frame = malloc(sizeof(*frame));
 
-  memcpy(frame, frame_to_copy, sizeof(*frame));
-  frame_to_copy->buff = NULL;
-  frame_to_copy->buff_len = 0;
-  frame_to_copy->buff_filled = 0;
+  memcpy(frame, frame_to_move, sizeof(*frame));
+  frame_to_move->buff = NULL;
+  frame_to_move->buff_len = 0;
+  frame_to_move->buff_filled = 0;
   return frame;
 }
 

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -1239,8 +1239,8 @@ int mtev_reverse_socket_connect(const char *id, int existing_fd) {
         mtev_gettimeofday(&rc->data.channels[chan].create_time, NULL);
         cct = malloc(sizeof(*cct));
         cct->channel_id = chan;
-        mtev_reverse_socket_ref(rc);
         cct->parent = rc;
+        mtev_reverse_socket_ref(rc);
         e = eventer_alloc_fd(mtev_reverse_socket_channel_handler, cct, existing_fd,
                              EVENTER_READ | EVENTER_EXCEPTION);
         eventer_ref(rc->data.e);

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -324,6 +324,7 @@ static void APPEND_IN(reverse_socket_t *rc, reverse_frame_t *frame_to_copy) {
     }
 
     memset(frame_to_copy, 0, sizeof(*frame_to_copy));
+    pthread_mutex_unlock(&rc->lock);
     e = eventer_find_fd(channel->pair[0]);
 
     if (!e) {

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -135,7 +135,7 @@ static void reverse_frame_free(void *vrf) {
   free(f);
 }
 
-static inline reverse_frame_t* reverse_frame_move(reverse_frame_t *frame_to_move) {
+static inline reverse_frame_t *reverse_frame_move(reverse_frame_t *frame_to_move) {
   reverse_frame_t *frame = malloc(sizeof(*frame));
 
   memcpy(frame, frame_to_move, sizeof(*frame));

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -561,7 +561,6 @@ mtev_reverse_socket_channel_handler(eventer_t e, int mask, void *closure,
       cct->parent->data.e = NULL;
     }
 
-    mtev_reverse_socket_deref(cct->parent);
     free(cct);
     return 0;
   }

--- a/src/mtev_reverse_socket.c
+++ b/src/mtev_reverse_socket.c
@@ -544,7 +544,7 @@ mtev_reverse_socket_channel_handler(eventer_t e, int mask, void *closure,
       cct->parent->data.e = NULL;
     }
 
-    ck_pr_dec_32(&cct->parent->refcnt);
+    mtev_reverse_socket_deref(&cct->parent);
     free(cct);
     return 0;
   }
@@ -800,7 +800,7 @@ socket_error:
         cct = malloc(sizeof(*cct));
         cct->channel_id = rc->data.incoming_inflight.channel_id;
         // Anchor 'rc' to the life cycle of 'newe'
-        ck_pr_inc_32(&rc->refcnt);
+        mtev_reverse_socket_ref(&rc->refcnt);
         cct->parent = rc;
         mtev_reverse_socket_ref(rc);
 
@@ -1225,7 +1225,7 @@ int mtev_reverse_socket_connect(const char *id, int existing_fd) {
         cct = malloc(sizeof(*cct));
         cct->channel_id = chan;
         // Anchor 'rc' to the life cycle of 'newe'
-        ck_pr_inc_32(&rc->refcnt);
+        mtev_reverse_socket_ref(&rc->refcnt);
         cct->parent = rc;
         mtev_reverse_socket_ref(rc);
         e = eventer_alloc_fd(mtev_reverse_socket_channel_handler, cct, existing_fd,


### PR DESCRIPTION
The reverse socket (rc) is passed as a raw pointer via channel_closure_t.  This creates a race where
the rc can be shutdown and thus freed while an event is still pending delivery inside eventer