### PR TITLE
CIRC-9644 - race

### DIFF
--- a/src/mtev_reverse_socket.cpp
+++ b/src/mtev_reverse_socket.cpp
@@ -2038,7 +2038,7 @@ mtev_console_reverse_opts(mtev_console_closure_t ncct,
   if(argc == 1) {
     mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
     int i = 0;
-    reverse_socket_t *ctx;
+    reverse_socket_sp ctx;
 
     pthread_rwlock_rdlock(&reverse_sockets_lock);
     while(mtev_hash_adv(&reverse_sockets, &iter)) {


### PR DESCRIPTION
Pointer can be released after lock is dropped at any time because ref count was not bumped