### PR TITLE
CIRC-9902 - align_watchdog_t

### DIFF
--- a/src/utils/mtev_watchdog.c
+++ b/src/utils/mtev_watchdog.c
@@ -70,7 +70,7 @@
 static int watchdog_tick(eventer_t e, int mask, void *lifeline, struct timeval *now);
 
 struct mtev_watchdog_t {
-  atomic_int_fast32_t ticker;
+  _Alignas(CK_MD_CACHELINE) atomic_int_fast32_t ticker;
   char padding[CK_MD_CACHELINE];
   enum {
     CRASHY_NOTATALL = 0,


### PR DESCRIPTION
Align `mtev_watchdog_t` to a single cache line.  All monitored threads only have a single object that they can write to, it should not be possible in any scenario for one of these threads to stall out another thread via cache line interference

The only thread that can and should stall is the actual monitor thread since that's true sharing