### PR TITLE
CIRC-9904 - on/off switch for watchdogs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.4
 
+ * API to disable and enable all watchdogs
+
 ### 2.4.2
 
  * Thread/Process safe counter for watchdog

--- a/src/utils/mtev_watchdog.h
+++ b/src/utils/mtev_watchdog.h
@@ -138,6 +138,13 @@ API_EXPORT(eventer_t)
 API_EXPORT(void)
   mtev_watchdog_enable(mtev_watchdog_t *hb);
 
+/*! \fn void mtev_watchdog_enable_all(void)
+
+    mtev_watchdog_enable_all will make the parent respect and act on all failed heartbeats.
+ */
+API_EXPORT(void)
+  mtev_watchdog_enable_all(void);
+
 /*! \fn void mtev_watchdog_disable(mtev_watchdog_t *hb)
     \param hb the heart on which to act
 
@@ -145,6 +152,13 @@ API_EXPORT(void)
  */
 API_EXPORT(void)
   mtev_watchdog_disable(mtev_watchdog_t *hb);
+
+/*! \fn void mtev_watchdog_disable_all(mtev_watchdog_t *hb)
+
+    mtev_watchdog_disable_all will make the parent ignore all failed heartbeats.
+ */
+API_EXPORT(void)
+  mtev_watchdog_disable_all(void);
 
 /*! \fn void mtev_watchdog_override_timeout(mtev_watchdog_t *hb, double timeout)
     \param hb the heart on which to act


### PR DESCRIPTION
Add an API to disable and enable all watchdogs in one shot,
including those that have yet to be created.
    
This is to support startup scenarios.