### PR TITLE
Clean up improper or obsolete globals so that ASAN won't flag

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.5
 
+ * Clean up of modern ASAN ODR errors due to obsolete global variables during loading in lua ffi.
+
 ### 2.5.1
 
  * Improved reverse socket logging.

--- a/src/eventer/eventer.h
+++ b/src/eventer/eventer.h
@@ -656,12 +656,21 @@ API_EXPORT(uint64_t) eventer_callback_ms(void);
  */
 API_EXPORT(uint64_t) eventer_callback_us(void);
 
-/* These values are set on initialization and are safe to use
- * on any platform.  They will be set to zero on platforms that
- * do not support them.  As such, you can always bit-or them.
+/* These values are fixed and may only require special handling
+ * on very old platforms where this capability is not available.
+ * If we don't see the defined macros, we set to zero.  Otherwise,
+ * we use the defined values.
  */
-API_EXPORT(int) NE_SOCK_CLOEXEC;
-API_EXPORT(int) NE_O_CLOEXEC;
+#ifdef SOCK_CLOEXEC
+  #define NE_SOCK_CLOEXEC SOCK_CLOEXEC
+#else
+  #define NE_SOCK_CLOEXEC 0
+#endif
+#ifdef O_CLOEXEC
+  #define NE_O_CLOEXEC O_CLOEXEC
+#else
+  #define NE_O_CLOEXEC 0
+#endif
 
 typedef struct _eventer_impl {
   const char         *name;

--- a/src/eventer/eventer_impl.c
+++ b/src/eventer/eventer_impl.c
@@ -642,9 +642,6 @@ int eventer_get_epoch(struct timeval *epoch) {
   return 0;
 }
 
-int NE_SOCK_CLOEXEC = 0;
-int NE_O_CLOEXEC = 0;
-
 static void eventer_per_thread_init(struct eventer_impl_data *t) {
   char qname[80];
   eventer_t e;
@@ -934,17 +931,6 @@ int eventer_impl_init(void) {
   ck_pr_inc_32(&init_called);
 
   (void)try;
-#ifdef SOCK_CLOEXEC
-  /* We can test, still might not work */
-  try = socket(AF_INET, SOCK_CLOEXEC|SOCK_STREAM, IPPROTO_TCP);
-  if(try >= 0) {
-    close(try);
-    NE_SOCK_CLOEXEC = SOCK_CLOEXEC;
-  }
-#endif
-#ifdef O_CLOEXEC
-  NE_O_CLOEXEC = O_CLOEXEC;
-#endif
 
   if(__default_loop_concurrency == 0) {
     int sockets = 0, cores = 0;

--- a/src/mtev_http.c
+++ b/src/mtev_http.c
@@ -50,7 +50,6 @@ static const char *zipkin_http_bytes_out = "http.bytes_out";
 static struct in_addr zipkin_ip_host;
 static mtev_log_stream_t http_access = NULL;
 static mtev_log_stream_t http_access_forensic = NULL;
-int LIBMTEV_HTTP_DEFAULT_MAXWRITE = 1<<19; /* 512k */
 
 MTEV_HOOK_IMPL(http_request_log,
   (mtev_http_session_ctx *ctx),

--- a/src/mtev_http_private.h
+++ b/src/mtev_http_private.h
@@ -99,7 +99,7 @@ struct bchain {
   char _buff[1]; /* over allocate as needed */
 };
 
-extern int LIBMTEV_HTTP_DEFAULT_MAXWRITE;
+static const int LIBMTEV_HTTP_DEFAULT_MAXWRITE = 1<<19; /* 512k */
 #define DEFAULT_BCHAINSIZE ((1 << 15)-(offsetof(struct bchain, _buff)))
 /* 64k - delta */
 #define DEFAULT_BCHAINMINREAD (DEFAULT_BCHAINSIZE/4)

--- a/src/noitedit/readline.c
+++ b/src/noitedit/readline.c
@@ -77,55 +77,50 @@ extern int el_gets_dispatch(EditLine *el, el_action_t cmdnum, char ch, int *num)
 
 /* readline compatibility stuff - look at readline sources/documentation */
 /* to see what these variables mean */
-const char *rl_library_version = "EditLine wrapper";
-char *rl_readline_name = "";
-FILE *rl_instream = NULL;
-FILE *rl_outstream = NULL;
-int rl_point = 0;
-int rl_end = 0;
-char *rl_line_buffer = NULL;
+static char *rl_readline_name = "";
+static FILE *rl_instream = NULL;
+static FILE *rl_outstream = NULL;
+static int rl_point = 0;
+static int rl_end = 0;
+static char *rl_line_buffer = NULL;
 
-int history_base = 1;		/* probably never subject to change */
-int history_length = 0;
-int max_input_history = 0;
-char history_expansion_char = '!';
-char history_subst_char = '^';
-char *history_no_expand_chars = " \t\n=(";
-Function *history_inhibit_expansion_function = NULL;
+static int history_length = 0;
+static int max_input_history = 0;
+static char history_expansion_char = '!';
+static char history_subst_char = '^';
+static char *history_no_expand_chars = " \t\n=(";
+static Function *history_inhibit_expansion_function = NULL;
 
-int rl_inhibit_completion = 0;
-int rl_attempted_completion_over = 0;
-char *rl_basic_word_break_characters = " \t\n\"\\'`@$><=;|&{(";
-char *rl_completer_word_break_characters = NULL;
-char *rl_completer_quote_characters = NULL;
-CPFunction *rl_completion_entry_function = NULL;
-CPPFunction *rl_attempted_completion_function = NULL;
+static int rl_inhibit_completion = 0;
+static char *rl_basic_word_break_characters = " \t\n\"\\'`@$><=;|&{(";
+static CPFunction *rl_completion_entry_function = NULL;
+static CPPFunction *rl_attempted_completion_function = NULL;
 
 /*
  * This is set to character indicating type of completion being done by
  * rl_complete_internal(); this is available for application completion
  * functions.
  */
-int rl_completion_type = 0;
+static int rl_completion_type = 0;
 
 /*
  * If more than this number of items results from query for possible
  * completions, we ask user if they are sure to really display the list.
  */
-int rl_completion_query_items = 100;
+static int rl_completion_query_items = 100;
 
 /*
  * List of characters which are word break characters, but should be left
  * in the parsed text when it is passed to the completion function.
  * Shell uses this to help determine what kind of completing to do.
  */
-char *rl_special_prefixes = (char *)NULL;
+static char *rl_special_prefixes = (char *)NULL;
 
 /*
  * This is the character appended to the completed words if at the end of
  * the line. Default is ' ' (a space).
  */
-int rl_completion_append_character = ' ';
+static int rl_completion_append_character = ' ';
 
 /* stuff below is used internally by libedit for readline emulation */
 

--- a/src/noitedit/readline/readline.h
+++ b/src/noitedit/readline/readline.h
@@ -68,23 +68,27 @@ typedef struct _hist_entry {
 
 /* global variables used by readline enabled applications */
 __BEGIN_DECLS
-extern const char	*rl_library_version;
-extern char		*rl_readline_name;
-extern FILE		*rl_instream;
-extern FILE		*rl_outstream;
-extern char		*rl_line_buffer;
-extern int		 rl_point, rl_end;
-extern int		 history_base, history_length;
-extern int		 max_input_history;
-extern char		*rl_basic_word_break_characters;
-extern char		*rl_completer_word_break_characters;
-extern char		*rl_completer_quote_characters;
-extern CPFunction	*rl_completion_entry_function;
-extern CPPFunction	*rl_attempted_completion_function;
-extern int		rl_completion_type;
-extern int		rl_completion_query_items;
-extern char		*rl_special_prefixes;
-extern int		rl_completion_append_character;
+// NOTE: Removed global externs because they are not needed in our usage
+// and they cause ASAN ODR violations.
+// they are left here for reference, because this file
+// is mostly third-party code.
+//extern const char	*rl_library_version;
+//extern char		*rl_readline_name;
+//extern FILE		*rl_instream;
+//extern FILE		*rl_outstream;
+//extern char		*rl_line_buffer;
+//extern int		 rl_point, rl_end;
+//extern int		 history_base, history_length;
+//extern int		 max_input_history;
+//extern char		*rl_basic_word_break_characters;
+//extern char		*rl_completer_word_break_characters;
+//extern char		*rl_completer_quote_characters;
+//extern CPFunction	*rl_completion_entry_function;
+//extern CPPFunction	*rl_attempted_completion_function;
+//extern int		rl_completion_type;
+//extern int		rl_completion_query_items;
+//extern char		*rl_special_prefixes;
+//extern int		rl_completion_append_character;
 
 /* supported functions */
 char		*readline(const char *);


### PR DESCRIPTION
https://circonus.atlassian.net/browse/CIRC-10457
When attempting to enable ASAN for lua ffi busted tests, it would fail with ODR violations.  Attempting to disable ODR checking did not work, despite googling and trying things, but looking into the libmtev code revealed that some of these globals were abusing good practices of encapsulation and obsolete in the case of a check that was only required if we expected to see a very very old Linux kernel which we could not support anyway because of OpenSSL versioning and other libmtev changes.  These have been cleaned up in this PR.