### PR TITLE
CIRC-10185 Lua module leaving nils hanging on lua state

### DIFF
--- a/src/modules/lua.c
+++ b/src/modules/lua.c
@@ -1066,6 +1066,7 @@ mtev_lua_xcall_reporter(eventer_t e, int mask, void *closure,
     snprintf(state_str, sizeof(state_str), "%p", (void*)L);
     lua_getglobal(L, "mtev_xcall");
     if(lua_isnil(L, -1)) {
+      lua_remove(L, -1);
       continue;
     }
     else {
@@ -1074,6 +1075,7 @@ mtev_lua_xcall_reporter(eventer_t e, int mask, void *closure,
       lua_call(L, 1, 1);
       if(lua_isnil(L, -1)) {
         /* skip lua states that return an explicit nil */
+        lua_remove(L, -1);
         continue;
       }
       /* Convert results to json via mtev.tojson(...):unwrap() */


### PR DESCRIPTION
Any time the `xcall.json` endpoint is hit, if `mtev_xcall` is not assigned or not found, lua places a `nil` on the active lua state. In the event of a `nil`, it simply continues the loop in `mtev_lua_xcall_reporter` without removing the `nil`, which causes it to persist into eternity. In the event this `nil` persists and a `RETURN_INT` is called, it will fail the assert in that macro that expects the lua state to be empty at the point of return. This corrects that behavior as well as the same thing happening in the event the user's implementation of `mtev_xcall` returns a `nil`.