### PR TITLE
Fix Floated HTTP2 Sessions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.5
 
+ * Fix issue where floated HTTP2 connections would resume before being triggered.
+
 ### 2.5.2
 
  * Fix Lua module leaving `nil`s hanging on Lua state.

--- a/src/mtev_http2.c
+++ b/src/mtev_http2.c
@@ -1155,7 +1155,7 @@ mtev_http2_resume_all_unpaused_streams(mtev_http2_parent_session *ctx) {
     /* If we're done, we're done. */
     if(ctx->res.closed) continue;
     /* We can only resume (dispatch) complete requests that are not ACO */
-    if(ctx->req.complete && !ctx->res.complete && ctx->aco_enabled == mtev_false) {
+    if(ctx->req.complete && !ctx->res.complete && ctx->aco_enabled == mtev_false && ctx->floated != H2_ASYNCH) {
       ctx->parent->dispatcher((mtev_http_session_ctx *)ctx);
     }
     if(ctx->paused == H2_UNPAUSED) {


### PR DESCRIPTION
Code was resuming sessions that were explicitly marked asynch, resulting in firing too soon. Check to make sure the connection hasn't been floated before resuming.