### PR TITLE
Add Hooks For Reading/Writing Non-Standard Cluster Fields

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.5
 
+* Add various hooks into `mtev_clustering` to allow applications to use custom fields.
+
 ## 2.5.4
 
  * Fix issue in mtev_net_heartbeat where there would be attempts to use invalid messages

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -140,7 +140,6 @@ struct mtev_cluster_t {
   mtev_net_heartbeat_ctx *hbctx;
   mtev_cluster_node_t *oldest_node;
   mtev_hash_table hb_payloads;
-  void *extra_config;
 };
 
 MTEV_HOOK_IMPL(mtev_cluster_update,
@@ -176,16 +175,10 @@ MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config,
   (closure, cluster, node));
 
 MTEV_HOOK_IMPL(mtev_cluster_read_extra_cluster_config,
-  (mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config),
+  (mtev_cluster_t *cluster, mtev_conf_section_t *conf),
   void *, closure,
-  (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config),
-  (closure, cluster, conf, extra_config));
-
-MTEV_HOOK_IMPL(mtev_cluster_free_extra_cluster_config_members,
-  (mtev_cluster_t *cluster, void *extra_config),
-  void *, closure,
-  (void *closure, mtev_cluster_t *cluster, void *extra_config),
-  (closure, cluster, extra_config));
+  (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf),
+  (closure, cluster, conf));
 
 mtev_boolean
 mtev_cluster_node_is_dead(mtev_cluster_node_t *node) {
@@ -224,11 +217,6 @@ mtev_cluster_free(void *vc) {
     if(c->cht) mtev_memory_safe_free(c->cht);
     if(c->hbctx) mtev_net_heartbeat_destroy(c->hbctx);
     c->hbctx = NULL;
-    if (c->extra_config) {
-      mtev_cluster_free_extra_cluster_config_members_hook_invoke(c, c->extra_config);
-      free(c->extra_config);
-      c->extra_config = NULL;
-    }
     mtev_memory_safe_free(c);
   }
 }
@@ -767,7 +755,7 @@ int mtev_cluster_update_internal(mtev_conf_section_t cluster) {
   new_cluster->period = period;
   new_cluster->timeout = timeout;
   new_cluster->maturity = maturity;
-  mtev_cluster_read_extra_cluster_config_hook_invoke(new_cluster, &cluster, &new_cluster->extra_config);
+  mtev_cluster_read_extra_cluster_config_hook_invoke(new_cluster, &cluster);
   if (nlist != NULL) {
     qsort(nlist, n_nodes, sizeof(*nlist), mtev_cluster_node_compare);
   }

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -162,13 +162,13 @@ MTEV_HOOK_IMPL(mtev_cluster_on_write_extra_cluster_config_cleanup,
   (void *closure, mtev_cluster_t *cluster, xmlNodePtr parent),
   (closure, cluster, node));
 
-MTEV_HOOK_IMPL(mtev_cluster_write_extra_cluster_config,
+MTEV_HOOK_IMPL(mtev_cluster_write_extra_cluster_config_xml,
   (mtev_cluster_t *cluster, xmlNodePtr node),
   void *, closure,
   (void *closure, mtev_cluster_t *cluster, xmlNodePtr node),
   (closure, cluster, node));
 
-MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config,
+MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config_xml,
   (mtev_cluster_t *cluster, xmlNodePtr node),
   void *, closure,
   (void *closure, mtev_cluster_t *cluster, xmlNodePtr node),
@@ -586,7 +586,7 @@ mtev_cluster_write_config(mtev_cluster_t *cluster) {
   xmlSetProp(parent, (xmlChar *)"key", (xmlChar *)cluster->key);
   snprintf(new_seq_str, sizeof(new_seq_str), "%"PRId64, cluster->config_seq);
   xmlSetProp(parent, (xmlChar *)"seq", (xmlChar *)new_seq_str);
-  mtev_cluster_write_extra_cluster_config_hook_invoke(cluster, parent);
+  mtev_cluster_write_extra_cluster_config_xml_hook_invoke(cluster, parent);
   if(cluster->node_cnt > 0) mtevAssert(cluster->nodes);
   for(i=0;i<cluster->node_cnt;i++) {
     xmlNodePtr node;
@@ -609,7 +609,7 @@ mtev_cluster_write_config(mtev_cluster_t *cluster) {
       snprintf(port, sizeof(port), "%d", ntohs(cluster->nodes[i].addr.addr6.sin6_port));
       xmlSetProp(node, (xmlChar *)"port", (xmlChar *)port);
     }
-    mtev_cluster_write_extra_node_config_hook_invoke(cluster, node);
+    mtev_cluster_write_extra_node_config_xml_hook_invoke(cluster, node);
     xmlAddChild(parent, node);
   }
   if(container) xmlAddChild(container, parent);
@@ -1165,7 +1165,7 @@ mtev_cluster_to_xmlnode(mtev_cluster_t *c) {
   xmlSetProp(cluster, (xmlChar *)"timeout", (xmlChar *)timeout);
   snprintf(maturity, sizeof(maturity), "%d", c->maturity);
   xmlSetProp(cluster, (xmlChar *)"maturity", (xmlChar *)maturity);
-  mtev_cluster_write_extra_cluster_config_hook_invoke(c, cluster);
+  mtev_cluster_write_extra_cluster_config_xml_hook_invoke(c, cluster);
 
   if(c->oldest_node && !mtev_uuid_is_null(c->oldest_node->id)) {
     xmlNodePtr node;
@@ -1189,7 +1189,7 @@ mtev_cluster_to_xmlnode(mtev_cluster_t *c) {
     xmlSetProp(node, (xmlChar *)"last_contact", (xmlChar *)time);
     snprintf(time, sizeof(time), "%lu", (unsigned long)n->boot_time.tv_sec);
     xmlSetProp(node, (xmlChar *)"boot_time", (xmlChar *)time);
-    mtev_cluster_write_extra_node_config_hook_invoke(c, node);
+    mtev_cluster_write_extra_node_config_xml_hook_invoke(c, node);
 
     if(n->addr.addr4.sin_family == AF_INET) {
       inet_ntop(AF_INET, &n->addr.addr4.sin_addr,

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -174,6 +174,18 @@ MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config_xml,
   (void *closure, mtev_cluster_t *cluster, xmlNodePtr node),
   (closure, cluster, node));
 
+MTEV_HOOK_IMPL(mtev_cluster_write_extra_cluster_config_json,
+  (mtev_cluster_t *cluster, struct json_object *obj),
+  void *, closure,
+  (void *closure, mtev_cluster_t *cluster, struct json_object *obj),
+  (closure, cluster, obj));
+
+MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config_json,
+  (mtev_cluster_t *cluster, struct json_object *obj),
+  void *, closure,
+  (void *closure, mtev_cluster_t *cluster, struct json_object *obj),
+  (closure, cluster, obj));
+
 MTEV_HOOK_IMPL(mtev_cluster_read_extra_cluster_config,
   (mtev_cluster_t *cluster, mtev_conf_section_t *conf),
   void *, closure,
@@ -1066,6 +1078,7 @@ mtev_cluster_to_json(mtev_cluster_t *c) {
   MJ_KV(obj, "period", MJ_INT(c->period));
   MJ_KV(obj, "timeout", MJ_INT(c->timeout));
   MJ_KV(obj, "maturity", MJ_INT(c->maturity));
+  mtev_cluster_write_extra_cluster_config_json_hook_invoke(c, obj);
 
   char uuid_str[UUID_STR_LEN+1];
   if(c->oldest_node && !mtev_uuid_is_null(c->oldest_node->id)) {
@@ -1085,6 +1098,7 @@ mtev_cluster_to_json(mtev_cluster_t *c) {
     MJ_KV(node, "reference_time", MJ_UINT64(now.tv_sec));
     MJ_KV(node, "last_contact", MJ_UINT64(n->last_contact.tv_sec));
     MJ_KV(node, "boot_time", MJ_UINT64(n->boot_time.tv_sec));
+    mtev_cluster_write_extra_node_config_json_hook_invoke(c, node);
 
     if(n->addr.addr4.sin_family == AF_INET) {
       inet_ntop(AF_INET, &n->addr.addr4.sin_addr,

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -176,10 +176,10 @@ MTEV_HOOK_IMPL(mtev_cluster_write_extra_node_config,
   (closure, cluster, node));
 
 MTEV_HOOK_IMPL(mtev_cluster_read_extra_cluster_config,
-  (mtev_cluster_t *cluster, mtev_conf_section_t *conf),
+  (mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config),
   void *, closure,
-  (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf),
-  (closure, cluster, conf));
+  (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config),
+  (closure, cluster, conf, extra_config));
 
 MTEV_HOOK_IMPL(mtev_cluster_free_extra_cluster_config_members,
   (mtev_cluster_t *cluster, void *extra_config),
@@ -767,7 +767,7 @@ int mtev_cluster_update_internal(mtev_conf_section_t cluster) {
   new_cluster->period = period;
   new_cluster->timeout = timeout;
   new_cluster->maturity = maturity;
-  mtev_cluster_read_extra_cluster_config_hook_invoke(new_cluster, &cluster);
+  mtev_cluster_read_extra_cluster_config_hook_invoke(new_cluster, &cluster, &new_cluster->extra_config);
   if (nlist != NULL) {
     qsort(nlist, n_nodes, sizeof(*nlist), mtev_cluster_node_compare);
   }

--- a/src/mtev_cluster.c
+++ b/src/mtev_cluster.c
@@ -1165,6 +1165,7 @@ mtev_cluster_to_xmlnode(mtev_cluster_t *c) {
   xmlSetProp(cluster, (xmlChar *)"timeout", (xmlChar *)timeout);
   snprintf(maturity, sizeof(maturity), "%d", c->maturity);
   xmlSetProp(cluster, (xmlChar *)"maturity", (xmlChar *)maturity);
+  mtev_cluster_write_extra_cluster_config_hook_invoke(c, cluster);
 
   if(c->oldest_node && !mtev_uuid_is_null(c->oldest_node->id)) {
     xmlNodePtr node;
@@ -1188,6 +1189,7 @@ mtev_cluster_to_xmlnode(mtev_cluster_t *c) {
     xmlSetProp(node, (xmlChar *)"last_contact", (xmlChar *)time);
     snprintf(time, sizeof(time), "%lu", (unsigned long)n->boot_time.tv_sec);
     xmlSetProp(node, (xmlChar *)"boot_time", (xmlChar *)time);
+    mtev_cluster_write_extra_node_config_hook_invoke(c, node);
 
     if(n->addr.addr4.sin_family == AF_INET) {
       inet_ntop(AF_INET, &n->addr.addr4.sin_addr,

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -365,12 +365,8 @@ MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
 MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
-                (mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config), void *, closure,
-                (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config));
-
-MTEV_HOOK_PROTO(mtev_cluster_free_extra_cluster_config_members,
-                (mtev_cluster_t *cluster, void *extra_config), void *, closure,
-                (void *closure, mtev_cluster_t *cluster, void *extra_config));
+                (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf));
 
 #ifdef __cplusplus
 }

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -364,6 +364,14 @@ MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config_xml,
                 (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config_json,
+                (mtev_cluster_t *cluster, struct json_object *obj), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, struct json_object *obj));
+
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config_json,
+                (mtev_cluster_t *cluster, struct json_object *obj), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, struct json_object *obj));
+
 MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
                 (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf));

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -364,6 +364,14 @@ MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config,
                 (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
+MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
+                (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf));
+
+MTEV_HOOK_PROTO(mtev_cluster_free_extra_cluster_config_members,
+                (mtev_cluster_t *cluster, void *extra_config), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, void *extra_config));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -368,6 +368,10 @@ MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
                 (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf));
 
+MTEV_HOOK_PROTO(mtev_cluster_read_extra_node_config,
+                (mtev_cluster_t *cluster, uuid_t node_uuid, mtev_conf_section_t *conf), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, uuid_t node_uuid, mtev_conf_section_t *conf));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -365,8 +365,8 @@ MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
 MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
-                (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,
-                (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf));
+                (mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, mtev_conf_section_t *conf, void **extra_config));
 
 MTEV_HOOK_PROTO(mtev_cluster_free_extra_cluster_config_members,
                 (mtev_cluster_t *cluster, void *extra_config), void *, closure,

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -361,16 +361,16 @@ MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config_xml,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
 MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config_xml,
-                (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
-                (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
+                (mtev_cluster_t *cluster, uuid_t node_id, xmlNodePtr node), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, uuid_t node_id, xmlNodePtr node));
 
 MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config_json,
                 (mtev_cluster_t *cluster, struct json_object *obj), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, struct json_object *obj));
 
 MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config_json,
-                (mtev_cluster_t *cluster, struct json_object *obj), void *, closure,
-                (void *closure, mtev_cluster_t *cluster, struct json_object *obj));
+                (mtev_cluster_t *cluster, uuid_t node_id, struct json_object *obj), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, uuid_t node_id, struct json_object *obj));
 
 MTEV_HOOK_PROTO(mtev_cluster_read_extra_cluster_config,
                 (mtev_cluster_t *cluster, mtev_conf_section_t *conf), void *, closure,

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -36,6 +36,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <libxml/tree.h>
 #include <mtev_conf.h>
 
 #ifdef __cplusplus
@@ -351,6 +352,17 @@ MTEV_HOOK_PROTO(mtev_cluster_handle_node_update,
                 (void *closure, mtev_cluster_node_changes_t node_changes, mtev_cluster_node_t *updated_node, mtev_cluster_t *cluster,
                     struct timeval old_boot_time));
 
+MTEV_HOOK_PROTO(mtev_cluster_on_write_extra_cluster_config_cleanup,
+                (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
+
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config,
+                (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
+
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config,
+                (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
+                (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
 #ifdef __cplusplus
 }

--- a/src/mtev_cluster.h
+++ b/src/mtev_cluster.h
@@ -356,11 +356,11 @@ MTEV_HOOK_PROTO(mtev_cluster_on_write_extra_cluster_config_cleanup,
                 (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
-MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config,
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_cluster_config_xml,
                 (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 
-MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config,
+MTEV_HOOK_PROTO(mtev_cluster_write_extra_node_config_xml,
                 (mtev_cluster_t *cluster, xmlNodePtr node), void *, closure,
                 (void *closure, mtev_cluster_t *cluster, xmlNodePtr node));
 


### PR DESCRIPTION
Add hooks to `mtev_clustering` to allow applications that use this to read and write custom fields in the cluster and node XML fields. This allows users to set things relevant to them, but are not necessarily relevant to all clusters.