### PR TITLE
Fix mtev_dyn_buffer_add_vprintf Bug

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,16 +4,24 @@
 
 ## 2.6
 
+ * Added new function, `mtev_dyn_buffer_maybe_add_vprintf`, that will not try to
+   expand the buffer and will return how many more bytes are needed.
+ * Fix bug in `mtev_dyn_buffer_add_vprintf` where the va_list argument could be used
+   after being modified. This change involves making a copy of the argument list
+   every time, so it could impact performance; recomment using
+   `mtev_dyn_buffer_maybe_add_vprintf` and handling the buffer manually on failure
+   to avoid the extra copy if you plan on using it in a hot path.
+
 ## 2.6.0
 
-* Add various hooks into `mtev_clustering` to allow applications to use custom fields.
+ * Add various hooks into `mtev_clustering` to allow applications to use custom fields.
 
 ## 2.5
 
 ## 2.5.4
 
- * Fix issue in mtev_net_heartbeat where there would be attempts to use invalid messages
- * Improve logging in mtev_net_heartbeat
+ * Fix issue in `mtev_net_heartbeat` where there would be attempts to use invalid messages
+ * Improve logging in `mtev_net_heartbeat`
 
 ### 2.5.3
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
    expand the buffer and will return how many more bytes are needed.
  * Fix bug in `mtev_dyn_buffer_add_vprintf` where the va_list argument could be used
    after being modified. This change involves making a copy of the argument list
-   every time, so it could impact performance; recomment using
+   every time so it could impact performance; recommend using
    `mtev_dyn_buffer_maybe_add_vprintf` and handling the buffer manually on failure
    to avoid the extra copy if you plan on using it in a hot path.
 

--- a/src/utils/mtev_dyn_buffer.c
+++ b/src/utils/mtev_dyn_buffer.c
@@ -62,7 +62,9 @@ mtev_dyn_buffer_maybe_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va
   int available = mtev_dyn_buffer_size(buf) - mtev_dyn_buffer_used(buf);
   int needed = vsnprintf((char *)buf->pos, available, format, args);
   if (needed > (available - 1)) {
-    *(buf->pos) = 0;
+    if (available > 0) {
+      *(buf->pos) = 0;
+    }
     return needed + 1;
   }
   buf->pos += needed;

--- a/src/utils/mtev_dyn_buffer.c
+++ b/src/utils/mtev_dyn_buffer.c
@@ -56,6 +56,18 @@ mtev_dyn_buffer_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list 
   va_end(arg_copy);
 }
 
+inline int
+mtev_dyn_buffer_maybe_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list args) {
+  int available = mtev_dyn_buffer_size(buf) - mtev_dyn_buffer_used(buf);
+  int needed = vsnprintf((char *)buf->pos, available, format, args);
+  if (needed > (available - 1)) {
+    buf->pos = 0;
+    return needed + 1;
+  }
+  buf->pos += needed;
+  return 0;
+}
+
 inline void
 mtev_dyn_buffer_add_printf(mtev_dyn_buffer_t *buf, const char *format, ...)
 {

--- a/src/utils/mtev_dyn_buffer.h
+++ b/src/utils/mtev_dyn_buffer.h
@@ -86,7 +86,7 @@ API_EXPORT(void)
   mtev_dyn_buffer_add_json_string(mtev_dyn_buffer_t *buf, uint8_t *data, size_t len, int sol);
 
 /*! \fn void mtev_dyn_buffer_add_printf(mtev_dyn_buffer_t *buf, const char *format, ...)
-    \brief add data to the dyn_buffer using printf semantics.
+    \brief add data to the dyn_buffer using printf semantics
     \param buf the buffer to add to.
     \param format the printf style format string
     \param args printf arguments
@@ -100,19 +100,33 @@ API_EXPORT(void)
   mtev_dyn_buffer_add_printf(mtev_dyn_buffer_t *buf, const char *format, ...);
 
 
-/*! \fn void mtev_dyn_buffer_add_printf(mtev_dyn_buffer_t *buf, const char *format, ...)
-    \brief add data to the dyn_buffer using printf semantics.
+/*! \fn void mtev_dyn_buffer_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list arg)
+    \brief add data to the dyn_buffer using printf semantics and expand the buffer if necessary
     \param buf the buffer to add to.
     \param format the printf style format string
-    \param args printf arguments
+    \param arg the variadic printf arguments
     
     This does NUL terminate the format string but does not advance the write_pointer past
     the NUL.  Basically, the last mtev_dyn_buffer_add_printf will leave the resultant
     data NUL terminated.
-    
  */
 API_EXPORT(void)
   mtev_dyn_buffer_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list arg);
+
+/*! \fn void mtev_dyn_buffer_maybe_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list arg)
+    \brief add data to the dyn_buffer using printf semantics if there's enough space
+    \param buf the buffer to add to.
+    \param format the printf style format string
+    \param arg the variadic printf arguments
+    \return 0 on success, the number of bytes the buffer needs to expand by on failure
+
+    This does NUL terminate the format string but does not advance the write_pointer past
+    the NUL.  Basically, the last mtev_dyn_buffer_add_printf will leave the resultant
+    data NUL terminated.
+    If the data could not be written, the pointer at `pos` will be set to NULL.
+ */
+API_EXPORT(int)
+  mtev_dyn_buffer_maybe_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list args);
 
 /*! \fn void mtev_dyn_buffer_ensure(mtev_dyn_buffer_t *buf, size_t len)
     \brief possibly grow the dyn_buffer so it can fit len bytes

--- a/src/utils/mtev_dyn_buffer.h
+++ b/src/utils/mtev_dyn_buffer.h
@@ -109,6 +109,11 @@ API_EXPORT(void)
     This does NUL terminate the format string but does not advance the write_pointer past
     the NUL.  Basically, the last mtev_dyn_buffer_add_printf will leave the resultant
     data NUL terminated.
+
+    Due to taking a va_list as an argument and possibly needing to use the list twice,
+    this function has to make a copy of the argument. In hot paths, this could have
+    performance impacts. It is recommended to use mtev_dyn_buffer_maybe_add_vprintf and
+    handle the buffer yourself if performance is a factor to avoid this copy.
  */
 API_EXPORT(void)
   mtev_dyn_buffer_add_vprintf(mtev_dyn_buffer_t *buf, const char *format, va_list arg);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -2137,7 +2137,7 @@ add_to_jsonf(int nelem, mtev_dyn_buffer_t *buff,
   va_start(args, fmt);
   int needed = mtev_dyn_buffer_maybe_add_vprintf(&scratch, fmt, args);
   if (needed) {
-    mtev_dyn_buffer_ensure(&scratch, needed); /* ensure we have space for the trailing NUL too */
+    mtev_dyn_buffer_ensure(&scratch, needed);
     va_end(args);
     va_start(args, fmt);
     mtevAssert(mtev_dyn_buffer_maybe_add_vprintf(&scratch, fmt, args) == 0);

--- a/src/utils/mtev_log.c
+++ b/src/utils/mtev_log.c
@@ -2135,7 +2135,13 @@ add_to_jsonf(int nelem, mtev_dyn_buffer_t *buff,
   mtev_dyn_buffer_init(&scratch);
   va_list args;
   va_start(args, fmt);
-  mtev_dyn_buffer_add_vprintf(&scratch, fmt, args);
+  int needed = mtev_dyn_buffer_maybe_add_vprintf(&scratch, fmt, args);
+  if (needed) {
+    mtev_dyn_buffer_ensure(&scratch, needed); /* ensure we have space for the trailing NUL too */
+    va_end(args);
+    va_start(args, fmt);
+    mtevAssert(mtev_dyn_buffer_maybe_add_vprintf(&scratch, fmt, args) == 0);
+  }
   va_end(args);
   int rv = add_to_json(nelem, buff, key, str, 
                        (const char *)mtev_dyn_buffer_data(&scratch));


### PR DESCRIPTION
There was a bug in `mtev_dyn_buffer_add_vprintf` where we could call `vsnprintf` with a `va_list` twice without a copy. This has undefined behavior, as the call to `vsnprintf` is destructive. Fixed it so that it does a copy now. However, that copy could have performance impacts, so also added a new function, `mtev_dyn_buffer_maybe_add_vprintf`, that will not try to increase the buffer size and requires the caller to handle it in order to avoid the extra copy.