### PR TITLE
Fix Compile Error On OpenSSL Functions 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.7
 
+ * Fix compilation errors on calling openssl functions that occur on some compilers
+
 ### 2.7.0
 
  * Added new function, `mtev_dyn_buffer_maybe_add_vprintf`, that will not try to

--- a/src/mtev_net_heartbeat.c
+++ b/src/mtev_net_heartbeat.c
@@ -289,7 +289,7 @@ mtev_net_headerbeat_sendall(mtev_net_heartbeat_ctx *ctx, void *payload, int payl
 
 static int
 mtev_net_heartbeat_serialize_and_send(mtev_net_heartbeat_ctx *ctx) {
-  int i, len, blocksize, ivecsize, outlen1, outlen2, text_len;
+  int i, len, blocksize, ivecsize, text_len;
   EVP_CIPHER_CTX *evp_ctx = NULL;
   unsigned char cipher_buf_static[16000];
   unsigned char *ivec, *cipher_buf = cipher_buf_static, *text;
@@ -342,6 +342,7 @@ mtev_net_heartbeat_serialize_and_send(mtev_net_heartbeat_ctx *ctx) {
   memcpy(cipher_buf, payload, HDRLEN);
   text = (unsigned char *)payload + HDR_LENSIZE + HDR_IVSIZE;
   text_len = len - (HDR_LENSIZE + HDR_IVSIZE);
+  int outlen1 = 0, outlen2 = 0;
   if ((!EVP_EncryptUpdate(evp_ctx,cipher_buf+HDR_LENSIZE+HDR_IVSIZE,&outlen1,
                           text,text_len)) ||
       (!EVP_EncryptFinal(evp_ctx,cipher_buf+HDR_LENSIZE+HDR_IVSIZE+outlen1,


### PR DESCRIPTION
Some compilers complain that we're passing an uninitialized value to
openssl functions. These parameters are outparams, so it doesn't
actually matter, but initialize them to zero to make the compiler happy.