### PR TITLE
Silence Unused Parameter Warnings In Test Suite

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 ## 2.7
 
+ * Silence ununused parameter warnings in test suite
  * Fix compilation errors on calling openssl functions that occur on some compilers
 
 ### 2.7.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 ## 2.7
 
- * Silence ununused parameter warnings in test suite
+ * Silence unused parameter warnings in test suite
  * Fix compilation errors on calling openssl functions that occur on some compilers
 
 ### 2.7.0

--- a/test/async-pingpong/test.c
+++ b/test/async-pingpong/test.c
@@ -56,10 +56,18 @@ struct test_closure {
 };
 static int
 noop_asynch(eventer_t e, int mask, void *closure, struct timeval *now) {
+  (void)e;
+  (void)mask;
+  (void)closure;
+  (void)now;
+
   return 0;
 }
 static int
 doasynchstuff(eventer_t e, int mask, void *closure, struct timeval *now) {
+  (void)e;
+  (void)now;
+
   mtev_http_rest_closure_t *restc = closure;
   struct test_closure *cc = restc->closure;
 
@@ -90,6 +98,9 @@ doasynchstuff(eventer_t e, int mask, void *closure, struct timeval *now) {
 }
 static int
 test_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  (void)npats;
+  (void)pats;
+
   struct test_closure *cc = restc->closure;
   mtevL(mtev_debug, "-> test_complete()\n");
   mtev_http_response_ok(restc->http_ctx, "text/plain");
@@ -114,6 +125,9 @@ test_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
 }
 static int
 test(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  (void)npats;
+  (void)pats;
+
   mtevL(mtev_debug, "-> test()\n");
   restc->fastpath = test_complete;
 
@@ -131,6 +145,8 @@ test(mtev_http_rest_closure_t *restc, int npats, char **pats) {
 }
 
 static int mtev_conf_watch_and_journal_watchdog_cb(void *closure) {
+  (void)closure;
+
   return mtev_conf_write_log();
 }
 

--- a/test/dyn_buffer_test.c
+++ b/test/dyn_buffer_test.c
@@ -10,6 +10,9 @@ int chkmem(mtev_dyn_buffer_t *buff, size_t len, char exp) {
   return 1;
 }
 int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
   int a = 12345;
   int b = 54321;
   mtev_dyn_buffer_t buff;

--- a/test/flowreg/test.c
+++ b/test/flowreg/test.c
@@ -77,6 +77,9 @@ void add_jobs_loop(work_description_t *work_description)
 
 int test_job_cb(eventer_t e, int mask, void *v_work_description, struct timeval *now)
 {
+  (void)e;
+  (void)now;
+
   if (mask == EVENTER_ASYNCH_WORK) {
     work_description_t *work_description = (work_description_t *) v_work_description;
     unsigned int old_work_removed;
@@ -92,11 +95,20 @@ int test_job_cb(eventer_t e, int mask, void *v_work_description, struct timeval 
 
 int test_job_done(eventer_t e, int mask, void *v_work_description, struct timeval *now)
 {
+  (void)e;
+  (void)mask;
+  (void)v_work_description;
+  (void)now;
+
   return 0;
 }
 
 int test_poll(eventer_t e, int mask, void *v_work_description, struct timeval *now)
 {
+  (void)e;
+  (void)mask;
+  (void)now;
+
   work_description_t *work_description = (work_description_t *) v_work_description;
   unsigned int work_removed = ck_pr_load_uint(&work_description->work_removed);
   ck_pr_load_uint(&work_description->work_added);
@@ -111,6 +123,8 @@ int test_poll(eventer_t e, int mask, void *v_work_description, struct timeval *n
 }
 
 static int mtev_conf_watch_and_journal_watchdog_cb(void *closure) {
+  (void)closure;
+
   return mtev_conf_write_log();
 }
 

--- a/test/geturllz4f.c
+++ b/test/geturllz4f.c
@@ -4,6 +4,8 @@
 #include <curl/curl.h>
 
 static size_t print_data(void *buff, size_t s, size_t n, void *vd) {
+  (void)vd;
+
   return write(1, buff, s*n);
 }
 int main(int argc, char **argv) {

--- a/test/hll_test.c
+++ b/test/hll_test.c
@@ -14,6 +14,9 @@
 
 int main(int argc, char **argv) 
 {
+  (void)argc;
+  (void)argv;
+
   char s[PATH_MAX];
   srand(time(NULL));
 

--- a/test/intern_test.c
+++ b/test/intern_test.c
@@ -42,11 +42,16 @@ static void wl_intern_release_double(void *c, mtev_intern_t i) {
   mtev_intern_release_pool(*p, i);
 }
 static mtev_intern_t wl_strdup(void *c, const char *k, size_t l) {
+  (void)c;
+  (void)l;
+
   mtev_intern_t i;
   i.opaque1 = (uintptr_t)strdup(k);
   return i;
 }
 static void wl_free(void *c, mtev_intern_t i) {
+  (void)c;
+
   free((void *)i.opaque1);
 }
 

--- a/test/lfu_test.c
+++ b/test/lfu_test.c
@@ -26,6 +26,9 @@ noop_free(void *x)
 
 int main(int argc, char **argv) 
 {
+  (void)argc;
+  (void)argv;
+
   srand(time(NULL));
 
   struct data datas[10] = 

--- a/test/lru_test.c
+++ b/test/lru_test.c
@@ -26,6 +26,9 @@ noop_free(void *x)
 
 int main(int argc, char **argv) 
 {
+  (void)argc;
+  (void)argv;
+
   srand(time(NULL));
 
   struct data datas[10] = 

--- a/test/maybe_alloc_test.c
+++ b/test/maybe_alloc_test.c
@@ -9,6 +9,9 @@ int chkmem(const char *ptr, size_t len, char exp) {
   return 1;
 }
 int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
   int a = 12345;
   MTEV_MAYBE_DECL(char, buff, 1892);
   int b = 54321;

--- a/test/pool-shift-async/test.c
+++ b/test/pool-shift-async/test.c
@@ -41,6 +41,9 @@ parse_cli_args(int argc, char * const *argv) {
 
 static int
 doasynchstuff(eventer_t e, int mask, void *closure, struct timeval *now) {
+  (void)e;
+  (void)now;
+
   mtev_http_rest_closure_t *restc = closure;
   if(mask == EVENTER_ASYNCH_WORK) {
     mtevL(mtev_debug, "here asynch\n");
@@ -54,6 +57,9 @@ doasynchstuff(eventer_t e, int mask, void *closure, struct timeval *now) {
 }
 static int
 test_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  (void)npats;
+  (void)pats;
+
   mtevL(mtev_debug, "-> test_complete()\n");
   mtev_http_response_ok(restc->http_ctx, "text/plain");
   mtev_http_response_append_str(restc->http_ctx, "Hello world\n");
@@ -62,6 +68,9 @@ test_complete(mtev_http_rest_closure_t *restc, int npats, char **pats) {
 }
 static int
 test(mtev_http_rest_closure_t *restc, int npats, char **pats) {
+  (void)npats;
+  (void)pats;
+
   mtevL(mtev_debug, "-> test()\n");
   restc->fastpath = test_complete;
 
@@ -79,6 +88,8 @@ test(mtev_http_rest_closure_t *restc, int npats, char **pats) {
 }
 
 static int mtev_conf_watch_and_journal_watchdog_cb(void *closure) {
+  (void)closure;
+
   return mtev_conf_write_log();
 }
 

--- a/test/speculatelog_test.c
+++ b/test/speculatelog_test.c
@@ -4,6 +4,9 @@
 
 int main(int argc, char *argv[])
 {
+  (void)argc;
+  (void)argv;
+
   mtev_log_init_globals();
   mtev_log_stream_t *speculation = mtev_log_speculate(100, 65536);
   for (size_t index = 0; index < 100; index++)

--- a/test/subqueues/test.c
+++ b/test/subqueues/test.c
@@ -65,6 +65,9 @@ static void parse_cli_args(int argc, char *const *argv)
 
 static int
 toil(eventer_t e, int mask, void *c, struct timeval *now) {
+  (void)e;
+  (void)now;
+
   work_description_t *w = c;
   const char *type = "unknown";
   switch(mask) {
@@ -80,6 +83,8 @@ toil(eventer_t e, int mask, void *c, struct timeval *now) {
 }
 
 static int mtev_conf_watch_and_journal_watchdog_cb(void *closure) {
+  (void)closure;
+
   return mtev_conf_write_log();
 }
 

--- a/test/time_test.c
+++ b/test/time_test.c
@@ -16,6 +16,9 @@
 
 int main(int argc, char **argv) 
 {
+  (void)argc;
+  (void)argv;
+
   mtev_thread_init();
   mtev_time_start_tsc();
   mtev_hrtime_t start = mtev_sys_gethrtime();

--- a/test/uuid_test.c
+++ b/test/uuid_test.c
@@ -63,6 +63,9 @@ void parse_file(void)
 
 int main(int argc, char **argv) 
 {
+  (void)argc;
+  (void)argv;
+
   uuid_parse_fn = mtev_uuid_parse;
   for (int i = 0; i < 1000000/500; i++) {
     parse_file();


### PR DESCRIPTION
The test suite was throwing up a bunch of warnings about unused function parameters. Silence these - they're callback functions where the paramters are not needed in all circumstances.