### PR TITLE
Include cstdint.h In mtev_json_object.h

### DIFF
--- a/src/json-lib/mtev_json_object.h
+++ b/src/json-lib/mtev_json_object.h
@@ -17,6 +17,8 @@
 extern "C" {
 #endif
 
+#include <stdint.h>
+
 #define JSON_OBJECT_DEF_HASH_ENTRIES 16
 
 #undef FALSE


### PR DESCRIPTION
mtev_json_object.h uses things like uint64_t, which require ctdint.h. Not including it here makes other files have to include it and makes include order matter.

Added the include directly to mtev_json_object.h to avoid this.