### PR TITLE
Old SSL Version Fixes And Changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,12 +4,13 @@
 
 ## 2.7
 
-### 2.7.3
-
  * Fix bug where X509 OSCP errors were not being handled properly and could
    cause Lua overflow errors.
  * Fix bug where certificate dates would return errors if after the 32-bit
    apocalypse.
+
+### 2.7.3
+
  * Update `configure.ac` to look for `epoll.h` when checking for epoll.
 
 ### 2.7.2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@
 
 ### 2.7.3
 
+ * Fix bug where X509 OSCP errors were not being handled properly and could
+   cause Lua overflow errors.
+ * Fix bug where certificate dates would return errors if after the 32-bit
+   apocalypse.
  * Update `configure.ac` to look for `epoll.h` when checking for epoll.
 
 ### 2.7.2

--- a/src/eventer/eventer_SSL_fd_opset.c
+++ b/src/eventer/eventer_SSL_fd_opset.c
@@ -68,6 +68,13 @@
 #define DEFAULT_LAYER_STRING "tlsv1:all,!sslv2,!sslv3"
 #endif
 #endif
+#if OPENSSL_VERSION_NUMBER < _OPENSSL_VERSION_1_1_0
+#define _X509_GET_NOTBEFORE X509_get_notBefore
+#define _X509_GET_NOTAFTER X509_get_notAfter
+#else
+#define _X509_GET_NOTBEFORE X509_get0_notBefore
+#define _X509_GET_NOTAFTER X509_get0_notAfter
+#endif
 /* ERR_error_string(3): buf must be at least 120 bytes... */
 #define MIN_ERRSTR_LEN 120
 
@@ -246,10 +253,10 @@ eventer_ssl_verify_dates(eventer_ssl_ctx_t *ctx, int ok,
   if(!x509ctx) return X509_V_ERR_APPLICATION_VERIFICATION;
   const X509 *peer = X509_STORE_CTX_get_current_cert(x509ctx);
   time(&now);
-  const ASN1_TIME *t = X509_get0_notBefore(peer);
+  const ASN1_TIME *t = _X509_GET_NOTBEFORE(peer);
   ctx->start_time = OETS_ASN1_TIME_get(t, &err);
   if(X509_cmp_time(t, &now) > 0) return X509_V_ERR_CERT_NOT_YET_VALID;
-  t = X509_get0_notAfter(peer);
+  t = _X509_GET_NOTAFTER(peer);
   ctx->end_time = OETS_ASN1_TIME_get(t, &err);
   if(X509_cmp_time(t, &now) < 0) return X509_V_ERR_CERT_HAS_EXPIRED;
   return 0;


### PR DESCRIPTION
* Fix X509_get_notBefore and X509_get0_notAfter calls so they still work on pre-1.1.0 versions of OpenSSL
* Add Changelog