### PR TITLE
Add Extra Fields To Kafka Processing Config

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ## 2.7
 
+ * Update kafka configuration to allow setting extra fields and
+   the expected protocol.
+
 ### 2.7.7
 
  * Update kafka hook definitions to include individual fields.

--- a/src/modules/kafka.xml
+++ b/src/modules/kafka.xml
@@ -30,7 +30,11 @@
             <host>localhost</host>
             <port>9092</port>
             <topic>test_topic_one</topic>
-            <consumer_group>sample_consumer_group_id</consumer_group>
+	    <consumer_group>sample_consumer_group_id</consumer_group>
+            <protocol>prometheus</protocol>
+	    <override_custom_parameter_one>custom_value</override_custom_parameter_one>
+	    <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
+	    <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
           </mq>
         </network>
       </root>

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -70,6 +70,7 @@ static void mtev_rd_kafka_message_free(mtev_rd_kafka_message_t *msg)
 
 static mtev_rd_kafka_message_t *
   mtev_rd_kafka_message_alloc(rd_kafka_message_t *msg,
+                              const mtev_hash_table *extra_configs,
                               void (*free_func)(struct mtev_rd_kafka_message *))
 {
   mtev_rd_kafka_message_t *m =
@@ -83,6 +84,7 @@ static mtev_rd_kafka_message_t *
   m->payload_len = msg->len;
   m->offset = msg->offset;
   m->partition = msg->partition;
+  m->extra_configs = extra_configs;
   return m;
 }
 
@@ -308,7 +310,8 @@ public:
         conn->stats.msgs_in++;
         per_conn_cnt++;
         if (msg->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
-          mtev_rd_kafka_message_t *m = mtev_rd_kafka_message_alloc(msg, mtev_rd_kafka_message_free);
+          mtev_rd_kafka_message_t *m =
+            mtev_rd_kafka_message_alloc(msg, conn->extra_configs, mtev_rd_kafka_message_free);
           mtev_kafka_handle_message_dyn_hook_invoke(m);
           mtev_rd_kafka_message_deref(m);
         }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -46,6 +46,9 @@
 
 #define CONFIG_KAFKA_IN_MQ "//network//mq[@type='kafka']"
 
+static constexpr const char *VARIABLE_PARAMETER_PREFIX = "override_";
+static constexpr size_t VARIABLE_PARAMETER_PREFIX_LEN = strlen(VARIABLE_PARAMETER_PREFIX);
+
 static mtev_log_stream_t nlerr = nullptr;
 static mtev_log_stream_t nldeb = nullptr;
 
@@ -266,9 +269,10 @@ public:
         else if (!strcasecmp("protocol", iter.key.str)) {
           protocol_string = iter.value.str;
         }
-        else if (!strncasecmp(iter.key.str, "override_", strlen("override_"))) {
+        else if (!strncasecmp(iter.key.str, VARIABLE_PARAMETER_PREFIX,
+                              VARIABLE_PARAMETER_PREFIX_LEN)) {
           char *val_copy = strdup(iter.value.str);
-          const char *name = iter.key.str + strlen("override_");
+          const char *name = iter.key.str + VARIABLE_PARAMETER_PREFIX_LEN;
           if (strlen(name) == 0) {
             free(val_copy);
             continue;

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -55,6 +55,8 @@ typedef struct mtev_rd_kafka_message {
   size_t payload_len;
   int64_t offset;
   int32_t partition;
+  const char *protocol;
+  const mtev_hash_table *extra_configs;
   void (*free_fn)(struct mtev_rd_kafka_message *m);
 } mtev_rd_kafka_message_t;
 


### PR DESCRIPTION
Allow setting arbitrary fields in the config so users can set fields specific to their applications. Also added a "protocol" field for configuring the expected format of incoming data.