### PR TITLE
Add Kafka Publishing Capability To Module

### DIFF
--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -1,64 +1,119 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-            {
-                "name": "(gdb) Opened busted test",
-                "type": "cppdbg",
-                "request": "launch",
-                "environment": [
-                    {"name":"_DYLD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
-                    {"name":"DYLD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
-                    {"name":"LD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
-                    {"name":"LD_PRELOAD","value":"${workspaceFolder}/src/libmtev.so"},
-                    {"name":"LUA_PATH","value":"/opt/circonus/share/lua/5.1/?.lua;/opt/circonus/share/lua/5.1/?/init.lua"}
-                ],
-                "program": "${workspaceFolder}/src/luamtev",
-                "args": [
-                    "-C",
-                    "'../src/modules/mtev_lua/?.so;{package.cpath}'",
-                    "-L",
-                    "'../src/modules/lua-support/?.lua;./?.lua;./lua-harness/?.lua;{package.path}'",
-                    "-M",
-                    "../src/modules/",
-                    "./mtevbusted-script",
-                    "-i",
-                    "lua-support/init.lua",              
-                    "-file",
-                    "${file}"
-                ],
-                "stopAtEntry": true,
-                "cwd": "${workspaceFolder}/test",
-                "externalConsole": false,
-                "MIMode": "gdb",
-                "setupCommands": [
-                    {
-                        "description": "Enable pretty-printing for gdb",
-                        "text": "-enable-pretty-printing",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "Ignore SIGPIPE",
-                        "text": "handle SIGPIPE nostop noprint pass",
-                        "ignoreFailures": true
-                    },
-                    {
-                        "description": "Set Non-Stop Mode On",
-                        "text": "set non-stop on",
-                        "ignoreFailures": false
-                    }
-                ],
-                "sourceFileMap": {
-                    "${workspaceFolder}": {
-                        "editorPath": "${workspaceFolder}",
-                        "useForBreakpoints": "true"
-                    }
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+        {
+            // Debug noitd on a busted test
+            "name": "(gdb) Opened noitd busted test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/src/noitd",
+            "args": [
+                "-D",
+                "-c",
+                "${fileDirname}/workspace/noit.conf"
+            ],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}/test/busted",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
                 },
-                "logging": {
-                    "engineLogging": true
+                {
+                    "description": "Ignore SIGPIPE",
+                    "text": "handle SIGPIPE nostop noprint pass",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Non-Stop Mode On",
+                    "text": "set non-stop on",
+                    "ignoreFailures": false
                 }
+            ],
+            "sourceFileMap": {
+                "${workspaceFolder}": {
+                    "editorPath": "${workspaceFolder}",
+                    "useForBreakpoints": "true"
+                }
+            },
+            "logging": {
+                "engineLogging": true
             }
-        ]
-    }
+        },
+        {
+            // Debug a shared lib used in lua ffi in a busted test`
+            "name": "(gdb) Opened lua ffi busted test",
+            "type": "cppdbg",
+            "request": "launch",
+            "environment": [
+                {"name":"ASAN_OPTIONS","value":"detect_leaks=0"},
+                {"name":"LD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
+// on Ubuntu 20.04, change these paths in following two lines to use 14 and 14.0.6
+                {"name":"ASAN_SYMBOLIZER_PATH","value":"/usr/bin/llvm-symbolizer-15"},
+                {"name":"LD_PRELOAD","value":"/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.so"},
+            ],
+            "program": "/opt/circonus/bin/luamtev",
+            "args": [
+                "-L",
+                "'+/opt/circonus/share/lua/5.1/?.lua;/opt/circonus/share/lua/5.1/?/init.lua'",
+                "/opt/circonus/bin/mtevbusted",
+                "-X",
+                "lua_debug=${fileDirname}",
+                "-file",
+                "${file}"
+            ],
+            "stopAtEntry": true,
+            "cwd": "${workspaceFolder}/test/busted",
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Ignore SIGPIPE",
+                    "text": "handle SIGPIPE nostop noprint pass",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Non-Stop Mode On",
+                    "text": "set non-stop on",
+                    "ignoreFailures": false
+                }
+            ],
+            "sourceFileMap": {
+                "${workspaceFolder}": {
+                    "editorPath": "${workspaceFolder}",
+                    "useForBreakpoints": "true"
+                },
+// Used to remap a libmtev packaging build to a home libmtev source folder 
+//                "/tmp/bld/libmtev-git": {
+//                    "editorPath": "~/libmtev",
+//                    "useForBreakpoints": "true"
+//                }
+            },
+            "logging": {
+                "engineLogging": true
+            }
+        },
+        {
+            // https://github.com/circonus/circonus-wiki/blob/master/Engineering/AdvancedDebugAndTest.md#lua-debugging
+            "name": "(lua) Opened busted test",
+            "type": "lua-local",
+            "request": "launch",
+            "program": {
+                "command": "./run-tests.sh"
+            },
+            "args": ["-file", "${file}", "-X", "lua_debug=${fileDirname}"],
+            "cwd": "${workspaceFolder}/test/busted",
+        },
+    ]
+}

--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -1,119 +1,64 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
-  "configurations": [
-        {
-            // Debug noitd on a busted test
-            "name": "(gdb) Opened noitd busted test",
-            "type": "cppdbg",
-            "request": "launch",
-            "program": "${workspaceFolder}/src/noitd",
-            "args": [
-                "-D",
-                "-c",
-                "${fileDirname}/workspace/noit.conf"
-            ],
-            "stopAtEntry": true,
-            "cwd": "${workspaceFolder}/test/busted",
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+            {
+                "name": "(gdb) Opened busted test",
+                "type": "cppdbg",
+                "request": "launch",
+                "environment": [
+                    {"name":"_DYLD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
+                    {"name":"DYLD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
+                    {"name":"LD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
+                    {"name":"LD_PRELOAD","value":"${workspaceFolder}/src/libmtev.so"},
+                    {"name":"LUA_PATH","value":"/opt/circonus/share/lua/5.1/?.lua;/opt/circonus/share/lua/5.1/?/init.lua"}
+                ],
+                "program": "${workspaceFolder}/src/luamtev",
+                "args": [
+                    "-C",
+                    "'../src/modules/mtev_lua/?.so;{package.cpath}'",
+                    "-L",
+                    "'../src/modules/lua-support/?.lua;./?.lua;./lua-harness/?.lua;{package.path}'",
+                    "-M",
+                    "../src/modules/",
+                    "./mtevbusted-script",
+                    "-i",
+                    "lua-support/init.lua",              
+                    "-file",
+                    "${file}"
+                ],
+                "stopAtEntry": true,
+                "cwd": "${workspaceFolder}/test",
+                "externalConsole": false,
+                "MIMode": "gdb",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Ignore SIGPIPE",
+                        "text": "handle SIGPIPE nostop noprint pass",
+                        "ignoreFailures": true
+                    },
+                    {
+                        "description": "Set Non-Stop Mode On",
+                        "text": "set non-stop on",
+                        "ignoreFailures": false
+                    }
+                ],
+                "sourceFileMap": {
+                    "${workspaceFolder}": {
+                        "editorPath": "${workspaceFolder}",
+                        "useForBreakpoints": "true"
+                    }
                 },
-                {
-                    "description": "Ignore SIGPIPE",
-                    "text": "handle SIGPIPE nostop noprint pass",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Non-Stop Mode On",
-                    "text": "set non-stop on",
-                    "ignoreFailures": false
+                "logging": {
+                    "engineLogging": true
                 }
-            ],
-            "sourceFileMap": {
-                "${workspaceFolder}": {
-                    "editorPath": "${workspaceFolder}",
-                    "useForBreakpoints": "true"
-                }
-            },
-            "logging": {
-                "engineLogging": true
             }
-        },
-        {
-            // Debug a shared lib used in lua ffi in a busted test`
-            "name": "(gdb) Opened lua ffi busted test",
-            "type": "cppdbg",
-            "request": "launch",
-            "environment": [
-                {"name":"ASAN_OPTIONS","value":"detect_leaks=0"},
-                {"name":"LD_LIBRARY_PATH","value":"${workspaceFolder}/src"},
-// on Ubuntu 20.04, change these paths in following two lines to use 14 and 14.0.6
-                {"name":"ASAN_SYMBOLIZER_PATH","value":"/usr/bin/llvm-symbolizer-15"},
-                {"name":"LD_PRELOAD","value":"/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/libclang_rt.asan-x86_64.so"},
-            ],
-            "program": "/opt/circonus/bin/luamtev",
-            "args": [
-                "-L",
-                "'+/opt/circonus/share/lua/5.1/?.lua;/opt/circonus/share/lua/5.1/?/init.lua'",
-                "/opt/circonus/bin/mtevbusted",
-                "-X",
-                "lua_debug=${fileDirname}",
-                "-file",
-                "${file}"
-            ],
-            "stopAtEntry": true,
-            "cwd": "${workspaceFolder}/test/busted",
-            "externalConsole": false,
-            "MIMode": "gdb",
-            "setupCommands": [
-                {
-                    "description": "Enable pretty-printing for gdb",
-                    "text": "-enable-pretty-printing",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Ignore SIGPIPE",
-                    "text": "handle SIGPIPE nostop noprint pass",
-                    "ignoreFailures": true
-                },
-                {
-                    "description": "Set Non-Stop Mode On",
-                    "text": "set non-stop on",
-                    "ignoreFailures": false
-                }
-            ],
-            "sourceFileMap": {
-                "${workspaceFolder}": {
-                    "editorPath": "${workspaceFolder}",
-                    "useForBreakpoints": "true"
-                },
-// Used to remap a libmtev packaging build to a home libmtev source folder 
-//                "/tmp/bld/libmtev-git": {
-//                    "editorPath": "~/libmtev",
-//                    "useForBreakpoints": "true"
-//                }
-            },
-            "logging": {
-                "engineLogging": true
-            }
-        },
-        {
-            // https://github.com/circonus/circonus-wiki/blob/master/Engineering/AdvancedDebugAndTest.md#lua-debugging
-            "name": "(lua) Opened busted test",
-            "type": "lua-local",
-            "request": "launch",
-            "program": {
-                "command": "./run-tests.sh"
-            },
-            "args": ["-file", "${file}", "-X", "lua_debug=${fileDirname}"],
-            "cwd": "${workspaceFolder}/test/busted",
-        },
-    ]
-}
+        ]
+    }

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.7
 
+ * Update kafka module to allow publishing as well as consuming.
+
 ### 2.7.8
 
  * Update kafka configuration to allow setting extra fields and

--- a/src/modules/kafka.xml
+++ b/src/modules/kafka.xml
@@ -39,9 +39,11 @@
             </mq>
           </in>
           <out>
-            <host>localhost</host>
-            <port>9092</port>
-            <topic>test_topic_two</topic>
+            <mq type="kafka">
+              <host>localhost</host>
+              <port>9092</port>
+              <topic>test_topic_two</topic>
+            </mq>
           </out>
         </network>
       </root>

--- a/src/modules/kafka.xml
+++ b/src/modules/kafka.xml
@@ -12,6 +12,10 @@
                required="optional"
                default="10000"
                allowed="\d+">Maximum number of messages to handle in a single callback.</parameter>
+    <parameter name="producer_poll_interval_ms"
+               required="optional"
+               default="10000"
+               allowed="\d+">Number of milliseconds to wait between polling producers.</parameter>
   </moduleconfig>
   <examples>
     <example>

--- a/src/modules/kafka.xml
+++ b/src/modules/kafka.xml
@@ -26,16 +26,23 @@
           </module>
         </modules>
         <network>
-          <mq type="kafka">
+          <in>
+            <mq type="kafka">
+              <host>localhost</host>
+              <port>9092</port>
+              <topic>test_topic_one</topic>
+              <consumer_group>sample_consumer_group_id</consumer_group>
+              <protocol>prometheus</protocol>
+              <override_custom_parameter_one>custom_value</override_custom_parameter_one>
+              <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
+              <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
+            </mq>
+          </in>
+          <out>
             <host>localhost</host>
             <port>9092</port>
             <topic>test_topic_one</topic>
-	    <consumer_group>sample_consumer_group_id</consumer_group>
-            <protocol>prometheus</protocol>
-	    <override_custom_parameter_one>custom_value</override_custom_parameter_one>
-	    <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
-	    <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
-          </mq>
+          </out>
         </network>
       </root>
     ]]></programlisting>

--- a/src/modules/kafka.xml
+++ b/src/modules/kafka.xml
@@ -41,7 +41,7 @@
           <out>
             <host>localhost</host>
             <port>9092</port>
-            <topic>test_topic_one</topic>
+            <topic>test_topic_two</topic>
           </out>
         </network>
       </root>

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -370,11 +370,11 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 }
 
 void
-mtev_kafka_send_function(void *payload, size_t payload_len) {
+mtev_kafka_send_function(const void *payload, size_t payload_len) {
 }
 
 void
-mtev_kafka_send_data_function(void *payload, size_t payload_len) {
+mtev_kafka_send_data_function(const void *payload, size_t payload_len) {
   mtev_kafka_send_function(payload, payload_len);
 }
 
@@ -388,6 +388,7 @@ static int
   kafka_logio_write(mtev_log_stream_t ls, const struct timeval *whence, const void *buf, size_t len)
 {
   // TODO: Need a write function
+  mtev_kafka_send_data(buf, len);
   return -1;
 }
 

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -370,11 +370,11 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 }
 
 void
-mtev_amqp_send_function() {
+mtev_kafka_send_function() {
 }
 
 void
-mtev_amqp_send_data_function() {
+mtev_kafka_send_data_function() {
 }
 
 static int kafka_logio_open(mtev_log_stream_t ls)

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -93,12 +93,18 @@ static mtev_rd_kafka_message_t *
   return m;
 }
 
-struct kafka_stats_t {
-  kafka_stats_t() : msgs_in{0}, msgs_out{0}, errors{0} {}
-  ~kafka_stats_t() = default;
+struct kafka_producer_stats_t {
+  kafka_producer_stats_t() : msgs_out{0}, errors{0} {}
+  ~kafka_producer_stats_t() = default;
+
+  uint64_t msgs_out;
+  uint64_t errors;
+};
+struct kafka_consumer_stats_t {
+  kafka_consumer_stats_t() : msgs_in{0}, errors{0} {}
+  ~kafka_consumer_stats_t() = default;
 
   uint64_t msgs_in;
-  uint64_t msgs_out;
   uint64_t errors;
 };
 struct kafka_producer {
@@ -164,6 +170,7 @@ struct kafka_producer {
   rd_kafka_t *rd_producer;
   rd_kafka_topic_conf_t *rd_topic_producer_conf;
   rd_kafka_topic_t *rd_topic_producer;
+  kafka_producer_stats_t stats;
 };
 
 struct kafka_consumer {
@@ -239,9 +246,9 @@ struct kafka_consumer {
     nc_printf(ncct,
               "== %s:%d ==\n"
               "  topic: %s\n  consumer_group: %s\n"
-              "  (s) msgs tx: %zu\n  (s) msgs rx: %zu\n  (s) msgs tx errors: %zu\n",
+              "  (s) msgs tx: %zu\n  (s) msgs tx errors: %zu\n",
               host.c_str(), port, topic.c_str(), consumer_group.c_str(), stats.msgs_in,
-              stats.msgs_out, stats.errors);
+              stats.errors);
   }
 
   std::string host;
@@ -254,7 +261,7 @@ struct kafka_consumer {
   rd_kafka_conf_t *rd_consumer_conf;
   rd_kafka_t *rd_consumer;
   rd_kafka_topic_partition_list_t *rd_consumer_topics;
-  kafka_stats_t stats;
+  kafka_consumer_stats_t stats;
 };
 
 class kafka_module_config {

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -405,6 +405,15 @@ public:
   }
   int show_console(const mtev_console_closure_t &ncct)
   {
+    if (_producers.size()) {
+      nc_printf(ncct, "Producers:\n");
+    }
+    for (const auto &producer : _producers) {
+      producer->write_to_console(ncct);
+    }
+    if (_consumers.size()) {
+      nc_printf(ncct, "Consumers:\n");
+    }
     for (const auto &consumer : _consumers) {
       consumer->write_to_console(ncct);
     }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -469,15 +469,10 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 // runtime resolution will fail
 extern "C" {
 void
-mtev_kafka_send_function(const void *payload, size_t payload_len) {
+mtev_kafka_broadcast_function(const void *payload, size_t payload_len) {
   if (the_conf) {
     the_conf->publish_to_producers(payload, payload_len, -1);
   }
-}
-
-void
-mtev_kafka_send_data_function(const void *payload, size_t payload_len) {
-  mtev_kafka_send_function(payload, payload_len);
 }
 }
 
@@ -490,7 +485,7 @@ static int kafka_logio_open(mtev_log_stream_t ls)
 static int
   kafka_logio_write(mtev_log_stream_t ls, const struct timeval *whence, const void *buf, size_t len)
 {
-  mtev_kafka_send_data(buf, len);
+  mtev_kafka_broadcast(buf, len);
   return -1;
 }
 

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -369,6 +369,14 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
   return the_conf;
 }
 
+void
+mtev_amqp_send_function() {
+}
+
+void
+mtev_amqp_send_data_function() {
+}
+
 static int kafka_logio_open(mtev_log_stream_t ls)
 {
   (void) ls;

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -396,9 +396,6 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 
 void
 mtev_kafka_send_function(const void *payload, size_t payload_len) {
-  if (the_conf) {
-    the_conf->publish_to_producers(payload, payload_len, -1);
-  }
 }
 
 void

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -105,7 +105,6 @@ struct kafka_producer {
   kafka_producer(const std::string &host_in,
     const int32_t port_in,
     const std::string &topic_in,
-    const std::string consumer_group_in,
     const std::string protocol_in,
     mtev_hash_table *extra_configs_in)
   {
@@ -113,7 +112,6 @@ struct kafka_producer {
     port = port_in;
     topic = topic_in;
     broker_with_port = host + ":" + std::to_string(port);
-    consumer_group = consumer_group_in;
     protocol = protocol_in;
     extra_configs = extra_configs_in;
 
@@ -160,7 +158,6 @@ struct kafka_producer {
   int32_t port;
   std::string broker_with_port;
   std::string topic;
-  std::string consumer_group;
   std::string protocol;
   mtev_hash_table *extra_configs;
   rd_kafka_conf_t *rd_producer_conf;

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -166,6 +166,7 @@ struct kafka_producer {
     nc_printf(ncct,
               "== %s:%d ==\n"
               "  mq type: kafka\n"
+              "  connection type: producer\n"
               "  topic: %s\n"
               "  (s) msgs out: %zu\n  (s) errors: %zu\n",
               host.c_str(), port, topic.c_str(), stats.msgs_out,
@@ -257,6 +258,7 @@ struct kafka_consumer {
     nc_printf(ncct,
               "== %s:%d ==\n"
               "  mq type: kafka\n"
+              "  connection type: consumer\n"
               "  topic: %s\n"
               "  consumer_group: %s\n"
               "  (s) msgs in: %zu\n  (s) errors: %zu\n",

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -394,6 +394,10 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
   return the_conf;
 }
 
+// These functions are invoked by the write hooks..... need to be in
+// an extern "C" block so their names don't get mangled, otherwise the
+// runtime resolution will fail
+extern "C" {
 void
 mtev_kafka_send_function(const void *payload, size_t payload_len) {
   if (the_conf) {
@@ -404,6 +408,7 @@ mtev_kafka_send_function(const void *payload, size_t payload_len) {
 void
 mtev_kafka_send_data_function(const void *payload, size_t payload_len) {
   mtev_kafka_send_function(payload, payload_len);
+}
 }
 
 static int kafka_logio_open(mtev_log_stream_t ls)

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -349,10 +349,17 @@ public:
   void publish_to_producers(const void *payload, size_t payload_len, int connection_id_broadcast_if_negative)
   {
     int count = 0;
+    int sent = 0;
     for (const auto &conn : _conns) {
       if (connection_id_broadcast_if_negative < 0 || count == connection_id_broadcast_if_negative) {
-        rd_kafka_produce(conn->rd_topic_producer, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_COPY,
-          const_cast<void *>(payload), payload_len, nullptr, 0, nullptr);
+        if (rd_kafka_produce(conn->rd_topic_producer, RD_KAFKA_PARTITION_UA, RD_KAFKA_MSG_F_COPY,
+          const_cast<void *>(payload), payload_len, nullptr, 0, nullptr) == 0) {
+          sent++;
+        }
+        else {
+          mtevL(nlerr, "%s: Error producing message: %s\n", __func__, rd_kafka_err2str(rd_kafka_last_error()));
+
+        }
       }
       count++;
     }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -387,7 +387,6 @@ static int kafka_logio_open(mtev_log_stream_t ls)
 static int
   kafka_logio_write(mtev_log_stream_t ls, const struct timeval *whence, const void *buf, size_t len)
 {
-  // TODO: Need a write function
   mtev_kafka_send_data(buf, len);
   return -1;
 }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -279,6 +279,12 @@ public:
     : _poll_timeout{std::chrono::milliseconds{DEFAULT_POLL_TIMEOUT_MS}}, _poll_limit{
                                                                            DEFAULT_POLL_LIMIT}
   {
+    enum class connection_type_e {CONSUMER, PRODUCER};
+    constexpr auto set_common_fields = [&](connection_type_e conn_type,
+                                           mtev_conf_section_t *mqs,
+                                           int section_id) -> bool {
+      return true;
+    };
     int number_of_conns = 0;
     mtev_conf_section_t *mqs =
       mtev_conf_get_sections_read(MTEV_CONF_ROOT, CONFIG_KAFKA_IN_MQ, &number_of_conns);

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -370,11 +370,12 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 }
 
 void
-mtev_kafka_send_function() {
+mtev_kafka_send_function(void *payload, size_t payload_len) {
 }
 
 void
-mtev_kafka_send_data_function() {
+mtev_kafka_send_data_function(void *payload, size_t payload_len) {
+  mtev_kafka_send_function(payload, payload_len);
 }
 
 static int kafka_logio_open(mtev_log_stream_t ls)

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -396,6 +396,9 @@ static kafka_module_config *get_or_load_config(mtev_dso_generic_t *self)
 
 void
 mtev_kafka_send_function(const void *payload, size_t payload_len) {
+  if (the_conf) {
+    the_conf->publish_to_producers(payload, payload_len, -1);
+  }
 }
 
 void

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -160,6 +160,15 @@ struct kafka_producer {
     mtev_hash_destroy(extra_configs, free, free);
     free(extra_configs);
   }
+  void write_to_console(const mtev_console_closure_t &ncct)
+  {
+    nc_printf(ncct,
+              "== %s:%d ==\n"
+              "  topic: %s\n\n"
+              "  (s) msgs rx: %zu\n  (s) msgs tx errors: %zu\n",
+              host.c_str(), port, topic.c_str(), stats.msgs_out,
+              stats.errors);
+  }
   std::string host;
   int32_t port;
   std::string broker_with_port;

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -44,8 +44,8 @@
 #include <string>
 #include <vector>
 
-#define CONFIG_KAFKA_CONSUMER_IN_MQ "//network/in/mq[@type='kafka']"
-#define CONFIG_KAFKA_PRODUCER_IN_MQ "//network/out/mq[@type='kafka']"
+#define CONFIG_KAFKA_MQ_CONSUMER "//network/in/mq[@type='kafka']"
+#define CONFIG_KAFKA_MQ_PRODUCER "//network/out/mq[@type='kafka']"
 
 static constexpr const char *VARIABLE_PARAMETER_PREFIX = "override_";
 static constexpr size_t VARIABLE_PARAMETER_PREFIX_LEN = strlen(VARIABLE_PARAMETER_PREFIX);
@@ -359,7 +359,7 @@ public:
 
     int number_of_conns = 0;
     mtev_conf_section_t *mqs =
-      mtev_conf_get_sections_read(MTEV_CONF_ROOT, CONFIG_KAFKA_CONSUMER_IN_MQ, &number_of_conns);
+      mtev_conf_get_sections_read(MTEV_CONF_ROOT, CONFIG_KAFKA_MQ_CONSUMER, &number_of_conns);
 
     if (number_of_conns > 0) {
       for (int section_id = 0; section_id < number_of_conns; section_id++) {
@@ -370,7 +370,7 @@ public:
 
     number_of_conns = 0;
     mqs =
-      mtev_conf_get_sections_read(MTEV_CONF_ROOT, CONFIG_KAFKA_PRODUCER_IN_MQ, &number_of_conns);
+      mtev_conf_get_sections_read(MTEV_CONF_ROOT, CONFIG_KAFKA_MQ_PRODUCER, &number_of_conns);
 
     if (number_of_conns > 0) {
       for (int section_id = 0; section_id < number_of_conns; section_id++) {

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -76,12 +76,9 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
   }
 }
 
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void,
+MTEV_RUNTIME_RESOLVE(mtev_kafka_broadcast, mtev_kafka_broadcast_function, void,
   (const void *payload, size_t payload_len), (payload, payload_len))
-MTEV_RUNTIME_AVAIL(mtev_kafka_send, mtev_kafka_send_function)
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void,
-  (const void *payload, size_t payload_len), (payload, payload_len))
-MTEV_RUNTIME_AVAIL(mtev_kafka_send_data, mtev_kafka_send_data_function)
+MTEV_RUNTIME_AVAIL(mtev_kafka_broadcast, mtev_kafka_broadcast_function)
 
 MTEV_HOOK_PROTO(mtev_kafka_handle_message_dyn,
                 (mtev_rd_kafka_message_t * msg),

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -76,7 +76,6 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
   }
 }
 
-// TODO: Need write hooks
 MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void,
   (const void *payload, size_t payload_len), (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_send, mtev_kafka_send_function)

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -77,6 +77,10 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
 }
 
 // TODO: Need write hooks
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void, (), ())
+MTEV_RUNTIME_AVAIL(mtev_kafka_send, mtev_kafka_send_function)
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void, (), ())
+MTEV_RUNTIME_AVAIL(mtev_kafka_send_data, mtev_kafka_send_data_function)
 
 MTEV_HOOK_PROTO(mtev_kafka_handle_message_dyn,
                 (mtev_rd_kafka_message_t * msg),

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -77,11 +77,11 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
 }
 
 // TODO: Need write hooks
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void, (void *payload, size_t payload_len),
-  (payload, payload_len))
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void,
+  (const void *payload, size_t payload_len), (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_send, mtev_kafka_send_function)
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void, (void *payload, size_t payload_len), 
-  (payload, payload_len))
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void,
+  (const void *payload, size_t payload_len), (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_send_data, mtev_kafka_send_data_function)
 
 MTEV_HOOK_PROTO(mtev_kafka_handle_message_dyn,

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -29,6 +29,47 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+ /*
+  * The Kafka module is used to handle both consuming from and publishing to
+  * kafka instances. All consumers and producers must be configured separately.
+  * The configuration will look like this:
+  * <network>
+  *   <in>
+  *     <mq type="kafka">
+  *       <host>localhost</host>
+  *       <port>9092</port>
+  *       <topic>test_topic_one</topic>
+  *       <consumer_group>sample_consumer_group_id</consumer_group>
+  *       <protocol>prometheus</protocol>
+  *       <override_custom_parameter_one>custom_value</override_custom_parameter_one>
+  *       <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
+  *       <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
+  *     </mq>
+  *   </in>
+  *   <out>
+  *     <mq type="kafka">
+  *       <host>localhost</host>
+  *       <port>9092</port>
+  *       <topic>test_topic_two</topic>
+  *     </mq>
+  *   </out>
+  * </network>
+  *
+  * The <in> stanza will contain all consumers. The <out> standza will contain all producers. Multiple
+  * mq stanzas can be defined for each.
+  *
+  * The individual fields for each config are:
+  * <host>           - The host to connect to.
+  * <port>           - The port to connect to.
+  * <topic>          - The topic to interact with
+  * <consumer_group> - The consumer group to use. Only for consumers.
+  * <protocol>       - The format of the consumed messages. Only for consumers.
+  *
+  * In addition, <override_*> allows setting arbitrary fields that can be read by the hooks
+  * so that fields outside of this exact spec can be set and used. It's up to the hook to
+  * handle these if specified.
+  */
+
 #ifndef _MTEV_KAFKA_HPP
 #define _MTEV_KAFKA_HPP
 

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -77,9 +77,11 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
 }
 
 // TODO: Need write hooks
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void, (), ())
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send, mtev_kafka_send_function, void, (void *payload, size_t payload_len),
+  (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_send, mtev_kafka_send_function)
-MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void, (), ())
+MTEV_RUNTIME_RESOLVE(mtev_kafka_send_data, mtev_kafka_send_data_function, void, (void *payload, size_t payload_len), 
+  (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_send_data, mtev_kafka_send_data_function)
 
 MTEV_HOOK_PROTO(mtev_kafka_handle_message_dyn,

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -76,6 +76,11 @@ static inline void mtev_rd_kafka_message_deref(mtev_rd_kafka_message_t *msg)
   }
 }
 
+/*! \fn void mtev_kafka_broadcast(const void *payload, size_t payload_len)
+    \brief Publish a Kafka message to all conifigurd Kafka publishers.
+    \param payload The payload to publish.
+    \param payload_len The size of the payload.
+ */
 MTEV_RUNTIME_RESOLVE(mtev_kafka_broadcast, mtev_kafka_broadcast_function, void,
   (const void *payload, size_t payload_len), (payload, payload_len))
 MTEV_RUNTIME_AVAIL(mtev_kafka_broadcast, mtev_kafka_broadcast_function)


### PR DESCRIPTION
Add the ability to publish kafka messages to the kafka module. Added details about how this works to the mtev_kafka.hpp header file with examples.

As of now, this will only publish to all configured publishers. Eventual plan is to add more fine-grained sending.