### PR TITLE
Allow Setting librdkafka Config Values In Kafka Module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,8 @@
 
 ## 2.7
 
+ * Allow setting arbitrary librdkafka configuration values on
+   connections in the kafka module.
  * Update kafka module to allow publishing as well as consuming.
 
 ### 2.7.8

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -51,7 +51,7 @@
 
 static constexpr const char *VARIABLE_PARAMETER_PREFIX = "override_";
 static constexpr size_t VARIABLE_PARAMETER_PREFIX_LEN = strlen(VARIABLE_PARAMETER_PREFIX);
-static constexpr const char *KAFKA_CONFIG_PARAMETER_PREFIX = "rdkafka_config_setting_";
+static constexpr const char *KAFKA_CONFIG_PARAMETER_PREFIX = "rdkafka_global_config_setting_";
 static constexpr size_t KAFKA_CONFIG_PARAMETER_PREFIX_LEN = strlen(KAFKA_CONFIG_PARAMETER_PREFIX);
 
 constexpr const char *bootstrap_str = "bootstrap.servers";

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -222,6 +222,8 @@ struct kafka_producer {
       rd_kafka_conf_destroy(rd_producer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);
+      mtev_hash_destroy(kafka_configs, free, free);
+      free(kafka_configs);
       throw std::runtime_error(error.c_str());
     }
     rd_kafka_conf_set_dr_msg_cb(rd_producer_conf, +[](rd_kafka_t *rk, const rd_kafka_message_t *rkmessage, void *closure) {
@@ -319,6 +321,8 @@ struct kafka_consumer {
       rd_kafka_conf_destroy(rd_consumer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);
+      mtev_hash_destroy(kafka_configs, free, free);
+      free(kafka_configs);
       throw std::runtime_error(error.c_str());
     }
     if (rd_kafka_conf_set(rd_consumer_conf, group_id_str, consumer_group.c_str(), error_string,
@@ -329,6 +333,8 @@ struct kafka_consumer {
       rd_kafka_conf_destroy(rd_consumer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);
+      mtev_hash_destroy(kafka_configs, free, free);
+      free(kafka_configs);
       throw std::runtime_error(error.c_str());
     }
 

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -152,11 +152,19 @@ static void set_kafka_config_values_from_hash(rd_kafka_conf_t *kafka_conf,
                                               mtev_hash_table *config_hash)
 {
   constexpr size_t error_string_size = 256;
+  constexpr const char *bootstrap_str = "bootstrap.servers";
+  constexpr size_t bootstrap_str_len = strlen(bootstrap_str);
   char error_string[error_string_size];
   mtev_hash_iter iter = MTEV_HASH_ITER_ZERO;
   while (mtev_hash_adv(config_hash, &iter)) {
     auto key = iter.key.str;
     auto value = iter.value.str;
+    if (!strncmp(key, bootstrap_str, bootstrap_str_len)) {
+      std::string error =
+        "kafka config error: field bootstrap.servers is not allowed. Use host and port settings";
+      mtevL(nlerr, "%s\n", error.c_str());
+      continue;
+    }
     if (rd_kafka_conf_set(kafka_conf, key, value, error_string,
       error_string_size) != RD_KAFKA_CONF_OK) {
       std::string error =

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -138,7 +138,7 @@ static kafka_common_fields set_common_connection_fields(mtev_hash_table *options
     ret.port = atoi(static_cast<char *>(vptr));
   }
   else {
-    ret.port = 9112;
+    ret.port = 9092;
   }
   if (mtev_hash_retrieve(options, "topic", strlen("topic"), &vptr)) {
     ret.topic = static_cast<char *>(vptr);

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -213,7 +213,7 @@ struct kafka_producer {
         mtevL(nlerr, "%s: %s\n", pair.first.c_str(), pair.second.c_str());
       }
       throw(std::runtime_error(std::string("Failed to configure producer for host " +
-        common_fields.broker_with_port + ", topic" + common_fields.topic + ": invalid configuration")));
+        common_fields.broker_with_port + ", topic " + common_fields.topic + ": invalid configuration")));
     }
     if (rd_kafka_conf_set(rd_producer_conf, bootstrap_str, common_fields.broker_with_port.c_str(),
                           error_string, error_string_size) != RD_KAFKA_CONF_OK) {
@@ -313,7 +313,7 @@ struct kafka_consumer {
         mtevL(nlerr, "%s: %s\n", pair.first.c_str(), pair.second.c_str());
       }
       throw(std::runtime_error(std::string("Failed to configure consumer for host " +
-        common_fields.broker_with_port + ", topic" + common_fields.topic + ": invalid configuration")));
+        common_fields.broker_with_port + ", topic " + common_fields.topic + ": invalid configuration")));
 
     }
     if (rd_kafka_conf_set(rd_consumer_conf, bootstrap_str, common_fields.broker_with_port.c_str(),
@@ -456,7 +456,7 @@ public:
             _consumers.push_back(std::move(consumer));
           }
           catch(const std::exception& e) {
-            mtevL(nlerr, "Failed to add consumer to list: %s... skipping\n", e.what());
+            mtevL(nlerr, "EXCEPTION: %s... skipping\n", e.what());
           }
           break;
         }
@@ -470,7 +470,7 @@ public:
             _producers.push_back(std::move(producer));
           }
           catch (const std::exception& e) {
-            mtevL(nlerr, "Failed to add producer to list: %s... skipping\n", e.what());
+            mtevL(nlerr, "EXCEPTION: %s... skipping\n", e.what());
           }
           break;
         }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -456,7 +456,7 @@ public:
             _consumers.push_back(std::move(consumer));
           }
           catch(const std::exception& e) {
-            // TODO
+            mtevL(nlerr, "Failed to add consumer to list: %s... skipping\n", e.what());
           }
           break;
         }
@@ -470,7 +470,7 @@ public:
             _producers.push_back(std::move(producer));
           }
           catch (const std::exception& e) {
-            // TODO
+            mtevL(nlerr, "Failed to add producer to list: %s... skipping\n", e.what());
           }
           break;
         }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -181,17 +181,6 @@ struct kafka_producer {
 
     rd_producer_conf = rd_kafka_conf_new();
     set_kafka_config_values_from_hash(rd_producer_conf, kafka_configs);
-    if (rd_kafka_conf_set(rd_producer_conf, "enable.idempotence", "true", error_string,
-                          error_string_size) != RD_KAFKA_CONF_OK) {
-      std::string error =
-        "kafka config error: error setting enable.idempotence field on producer for " +
-        common_fields.broker_with_port + ", topic " + common_fields.topic + ": kafka reported error |" +
-        error_string + "|";
-      rd_kafka_conf_destroy(rd_producer_conf);
-      mtev_hash_destroy(extra_configs, free, free);
-      free(extra_configs);
-      throw std::runtime_error(error.c_str());
-    }
     if (rd_kafka_conf_set(rd_producer_conf, "bootstrap.servers", common_fields.broker_with_port.c_str(),
                           error_string, error_string_size) != RD_KAFKA_CONF_OK) {
       std::string error =

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -460,7 +460,7 @@ public:
             _consumers.push_back(std::move(consumer));
           }
           catch(const std::exception& e) {
-            mtevL(nlerr, "EXCEPTION: %s... skipping\n", e.what());
+            mtevFatal(nlerr, "EXCEPTION: %s... aborting\n", e.what());
           }
           break;
         }
@@ -476,8 +476,8 @@ public:
               producer->common_fields.topic.c_str());
             _producers.push_back(std::move(producer));
           }
-          catch (const std::exception& e) {
-            mtevL(nlerr, "EXCEPTION: %s... skipping\n", e.what());
+          catch(const std::exception& e) {
+            mtevFatal(nlerr, "EXCEPTION: %s... aborting\n", e.what());
           }
           break;
         }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -445,20 +445,30 @@ public:
       switch(conn_type) {
         case connection_type_e::CONSUMER:
         {
-          auto consumer =
-            std::make_unique<kafka_consumer>(entries,
-                                             std::move(kafka_configs),
-                                             std::move(extra_configs));
-          _consumers.push_back(std::move(consumer));
+          try {
+            auto consumer =
+              std::make_unique<kafka_consumer>(entries,
+                                              std::move(kafka_configs),
+                                              std::move(extra_configs));
+            _consumers.push_back(std::move(consumer));
+          }
+          catch(const std::exception& e) {
+            // TODO
+          }
           break;
         }
         case connection_type_e::PRODUCER:
         {
-          auto producer =
-            std::make_unique<kafka_producer>(entries,
-                                             std::move(kafka_configs),
-                                             std::move(extra_configs));
-          _producers.push_back(std::move(producer));
+          try {
+            auto producer =
+              std::make_unique<kafka_producer>(entries,
+                                              std::move(kafka_configs),
+                                              std::move(extra_configs));
+            _producers.push_back(std::move(producer));
+          }
+          catch (const std::exception& e) {
+            // TODO
+          }
           break;
         }
       }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -219,18 +219,7 @@ struct kafka_consumer {
     constexpr size_t error_string_size = 256;
     char error_string[error_string_size];
 
-    // Set consumer configuration stuff
     rd_consumer_conf = rd_kafka_conf_new();
-    if (rd_kafka_conf_set(rd_consumer_conf, "enable.idempotence", "true", error_string,
-                          error_string_size) != RD_KAFKA_CONF_OK) {
-      std::string error =
-        "kafka config error: error setting enable.idempotence field on consumer for " +
-        broker_with_port + ", topic " + topic + ": kafka reported error |" + error_string + "|";
-      rd_kafka_conf_destroy(rd_consumer_conf);
-      mtev_hash_destroy(extra_configs, free, free);
-      free(extra_configs);
-      throw std::runtime_error(error.c_str());
-    }
     if (rd_kafka_conf_set(rd_consumer_conf, "bootstrap.servers", broker_with_port.c_str(),
                           error_string, error_string_size) != RD_KAFKA_CONF_OK) {
       std::string error =

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -177,6 +177,9 @@ static std::unordered_map<std::string, std::string> set_kafka_config_values_from
       continue;
     }
   }
+  // We may want to display all of the extra parameters that were manually set at some point...
+  // this loops through and removes all of the ones that failed from the config so we have a clean
+  // picture of what was successfully set
   for (const auto& pair : errors) {
     mtev_hash_delete(config_hash, pair.first.c_str(), pair.first.size(), free, free);
   }

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -148,7 +148,7 @@ static kafka_common_fields set_common_connection_fields(mtev_hash_table *options
 }
 struct kafka_producer {
   kafka_producer(mtev_hash_table *config,
-    mtev_hash_table *extra_configs_in)
+    mtev_hash_table *&&extra_configs_in)
   {
     common_fields = set_common_connection_fields(config);
     extra_configs = extra_configs_in;
@@ -228,7 +228,7 @@ struct kafka_producer {
 
 struct kafka_consumer {
   kafka_consumer(mtev_hash_table *config,
-                 mtev_hash_table *extra_configs_in)
+                 mtev_hash_table *&&extra_configs_in)
   {
     common_fields = set_common_connection_fields(config);
     extra_configs = extra_configs_in;

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -151,6 +151,7 @@ struct kafka_producer {
     const std::string protocol_in,
     mtev_hash_table *extra_configs_in)
   {
+    common_fields = set_common_connection_fields(config);
     protocol = protocol_in;
     extra_configs = extra_configs_in;
 

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -61,6 +61,7 @@ constexpr size_t group_id_str_len = strlen(group_id_str);
 
 static mtev_log_stream_t nlerr = nullptr;
 static mtev_log_stream_t nldeb = nullptr;
+static mtev_log_stream_t nlnotice = nullptr;
 
 constexpr int32_t DEFAULT_POLL_TIMEOUT_MS = 10;
 constexpr int32_t DEFAULT_POLL_LIMIT = 10000;
@@ -453,6 +454,9 @@ public:
               std::make_unique<kafka_consumer>(entries,
                                               std::move(kafka_configs),
                                               std::move(extra_configs));
+            mtevL(nlnotice, "Added Kafka consumer: Host %s, Topic %s\n",
+              consumer->common_fields.broker_with_port.c_str(),
+              consumer->common_fields.topic.c_str());
             _consumers.push_back(std::move(consumer));
           }
           catch(const std::exception& e) {
@@ -467,6 +471,9 @@ public:
               std::make_unique<kafka_producer>(entries,
                                               std::move(kafka_configs),
                                               std::move(extra_configs));
+            mtevL(nlnotice, "Added Kafka producer: Host %s, Topic %s\n",
+              producer->common_fields.broker_with_port.c_str(),
+              producer->common_fields.topic.c_str());
             _producers.push_back(std::move(producer));
           }
           catch (const std::exception& e) {
@@ -702,6 +709,7 @@ static int kafka_driver_init(mtev_dso_generic_t *img)
 
   nlerr = mtev_log_stream_find("error/kafka");
   nldeb = mtev_log_stream_find("debug/kafka");
+  nlnotice = mtev_log_stream_find("notice/kafka");
   auto config = get_or_load_config(img);
   mtev_register_logops("kafka", &kafka_logio_ops);
 

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -212,13 +212,14 @@ struct kafka_producer {
       for (const auto& pair : config_errors) {
         mtevL(nlerr, "%s: %s\n", pair.first.c_str(), pair.second.c_str());
       }
+      throw(std::runtime_error(std::string("Failed to configure producer for host " +
+        common_fields.broker_with_port + ", topic" + common_fields.topic + ": invalid configuration")));
     }
     if (rd_kafka_conf_set(rd_producer_conf, bootstrap_str, common_fields.broker_with_port.c_str(),
                           error_string, error_string_size) != RD_KAFKA_CONF_OK) {
       std::string error =
-        "kafka config error: error setting bootstrap.servers field on producer for " +
-        common_fields.broker_with_port + ", topic " + common_fields.topic + ": kafka reported error |" +
-        error_string + "|";
+        "Failed to configure producer for host " + common_fields.broker_with_port + ", topic " +
+        common_fields.topic + ": error " + error_string;
       rd_kafka_conf_destroy(rd_producer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);
@@ -311,13 +312,15 @@ struct kafka_consumer {
       for (const auto& pair : config_errors) {
         mtevL(nlerr, "%s: %s\n", pair.first.c_str(), pair.second.c_str());
       }
+      throw(std::runtime_error(std::string("Failed to configure consumer for host " +
+        common_fields.broker_with_port + ", topic" + common_fields.topic + ": invalid configuration")));
+
     }
     if (rd_kafka_conf_set(rd_consumer_conf, bootstrap_str, common_fields.broker_with_port.c_str(),
                           error_string, error_string_size) != RD_KAFKA_CONF_OK) {
       std::string error =
-        "kafka config error: error setting bootstrap.servers field on consumer for " +
-        common_fields.broker_with_port + ", topic " + common_fields.topic + ": kafka reported error |" +
-        error_string + "|";
+        "Failed to configure consumer for host " + common_fields.broker_with_port + ", topic " +
+        common_fields.topic + ": error " + error_string;
       rd_kafka_conf_destroy(rd_consumer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);
@@ -327,9 +330,9 @@ struct kafka_consumer {
     }
     if (rd_kafka_conf_set(rd_consumer_conf, group_id_str, consumer_group.c_str(), error_string,
                           error_string_size) != RD_KAFKA_CONF_OK) {
-      std::string error = "kafka config error: error setting group.id field on consumer for " +
-        common_fields.broker_with_port + ", topic " + common_fields.topic + ": kafka reported error |" +
-        error_string + "|";
+      std::string error =
+        "Failed to configure consumer for host " + common_fields.broker_with_port + ", topic " +
+        common_fields.topic + ": error " + error_string;
       rd_kafka_conf_destroy(rd_consumer_conf);
       mtev_hash_destroy(extra_configs, free, free);
       free(extra_configs);

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -74,7 +74,9 @@
   * the XML element with `rdkafka_config_setting_`, then fill in the parameter you wish to set.
   * The official list of legal parameters from Confluent is available here:
   * https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
-  * Note that use of `bootstrap.servers` is not allowed. Use `host` and `port`.
+  * Use of the following fields are not allowed:
+  * `bootstrap.servers`: Use `host` and `port`.
+  * `group.id`: Use `consumer_group`.
   */
 
 #ifndef _MTEV_KAFKA_HPP

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -44,7 +44,7 @@
   *       <override_custom_parameter_one>custom_value</override_custom_parameter_one>
   *       <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
   *       <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
-  *       <rdkafka_config_setting_fetch.error.backoff.ms>500</rdkafka_config_setting_fetch.error.backoff.ms>
+  *       <rdkafka_global_config_setting_fetch.error.backoff.ms>500</rdkafka_global_config_setting_fetch.error.backoff.ms>
   *     </mq>
   *   </in>
   *   <out>
@@ -52,7 +52,7 @@
   *       <host>localhost</host>
   *       <port>9092</port>
   *       <topic>test_topic_two</topic>
-  *       <rdkafka_config_setting_enable.idempotence>true</rdkafka_config_setting_enable.idempotence>
+  *       <rdkafka_global_config_setting_enable.idempotence>true</rdkafka_global_config_setting_enable.idempotence>
   *     </mq>
   *   </out>
   * </network>
@@ -70,13 +70,15 @@
   * <override_*> allows setting arbitrary fields that can be read by the hooks
   * so that fields outside of this exact spec can be set and used. It's up to the hook to
   * handle these if specified.
-  * <rdkafka_config_setting_*> allows setting configuration parameters from rdkafka. Start
-  * the XML element with `rdkafka_config_setting_`, then fill in the parameter you wish to set.
+  * <rdkafka_global_config_setting_*> allows setting global configuration parameters from rdkafka. Start
+  * the XML element with `rdkafka_global_config_setting_`, then fill in the parameter you wish to set.
   * The official list of legal parameters from Confluent is available here:
   * https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
   * Use of the following fields are not allowed:
   * `bootstrap.servers`: Use `host` and `port`.
   * `group.id`: Use `consumer_group`.
+  *  At the moment, `Topic configuration properties` are not yet available. Only
+  *  `Global configuration properties` work.
   */
 
 #ifndef _MTEV_KAFKA_HPP

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -44,6 +44,7 @@
   *       <override_custom_parameter_one>custom_value</override_custom_parameter_one>
   *       <override_custom_parameter_two>another_custom_value</override_custom_parameter_two>
   *       <override_another_custom_parameter>yet_another_custom_value</override_another_custom_parameter>
+  *       <rdkafka_config_setting_fetch.error.backoff.ms>500</rdkafka_config_setting_fetch.error.backoff.ms>
   *     </mq>
   *   </in>
   *   <out>
@@ -51,6 +52,7 @@
   *       <host>localhost</host>
   *       <port>9092</port>
   *       <topic>test_topic_two</topic>
+  *       <rdkafka_config_setting_enable.idempotence>true</rdkafka_config_setting_enable.idempotence>
   *     </mq>
   *   </out>
   * </network>
@@ -65,9 +67,13 @@
   * <consumer_group> - The consumer group to use. Only for consumers.
   * <protocol>       - The format of the consumed messages. Only for consumers.
   *
-  * In addition, <override_*> allows setting arbitrary fields that can be read by the hooks
+  * <override_*> allows setting arbitrary fields that can be read by the hooks
   * so that fields outside of this exact spec can be set and used. It's up to the hook to
   * handle these if specified.
+  * <rdkafka_config_setting_*> allows setting configuration parameters from rdkafka. Start
+  * the XML element with `rdkafka_config_setting_`, then fill in the parameter you wish to set.
+  * The official list of legal parameters from Confluent is available here:
+  * https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
   */
 
 #ifndef _MTEV_KAFKA_HPP

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -74,6 +74,7 @@
   * the XML element with `rdkafka_config_setting_`, then fill in the parameter you wish to set.
   * The official list of legal parameters from Confluent is available here:
   * https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+  * Note that use of `bootstrap.servers` is not allowed. Use `host` and `port`.
   */
 
 #ifndef _MTEV_KAFKA_HPP


### PR DESCRIPTION
Add the ability for users to add arbitrary configuration fields defined for librdkafka so they can tweak the performance of the module as they see fit.