### PR TITLE
Kafka Module Example Programs

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 ## 2.7
 
+ * Add example programs - `kafka_producer` and `kafka_consumer` -
+   to allow testing the kafka module.
+ * Add topic to kafka consumer hooks.
  * Allow setting arbitrary librdkafka configuration values on
    connections in the kafka module.
  * Update kafka module to allow publishing as well as consuming.

--- a/src/examples/.gitignore
+++ b/src/examples/.gitignore
@@ -5,6 +5,8 @@ websocket_server
 websocket_client
 echo_client
 echo_server
+kafka_producer
+kafka_consumer
 .mtev.console
 *.crt
 *.csr

--- a/src/examples/Makefile.in
+++ b/src/examples/Makefile.in
@@ -30,13 +30,17 @@ ACO_OBJS=	aco.o
 
 FQR_OBJS=	fq-router.o
 
+KAFKA_CONSUMER_OBJS= kafka_consumer.o
+
+KAFKA_PRODUCER_OBJS= kafka_producer.o
+
 WSC_OBJS=	websocket_client.o
 
 WSS_OBJS=	websocket_server.o
 
 EXTRA_TARGETS=@EXTRA_EXAMPLES@
 
-all:	testcerts echo_server echo_client example1 aco $(EXTRA_TARGETS)
+all:	testcerts echo_server echo_client example1 aco kafka_producer kafka_consumer $(EXTRA_TARGETS)
 
 .c.o:
 	@echo "- compiling $<"
@@ -61,6 +65,14 @@ aco:	$(ACO_OBJS)
 fq-router:	$(FQR_OBJS)
 	@echo "- linking $@"
 	$(Q)$(CC) -L.. $(LDFLAGS) @UNWINDLIB@ -o $@ $(FQR_OBJS) $(LIBS) -lmtev -lfq
+
+kafka_producer:	$(KAFKA_PRODUCER_OBJS)
+	@echo "- linking $@"
+	$(Q)$(CC) -L.. $(LDFLAGS) @UNWINDLIB@ -o $@ $(KAFKA_PRODUCER_OBJS) $(LIBS) -lmtev -lrdkafka
+
+kafka_consumer:	$(KAFKA_CONSUMER_OBJS)
+	@echo "- linking $@"
+	$(Q)$(CC) -L.. $(LDFLAGS) @UNWINDLIB@ -o $@ $(KAFKA_CONSUMER_OBJS) $(LIBS) -lmtev -lrdkafka
 
 websocket_client:	$(WSC_OBJS)
 	@echo "- linking $@"
@@ -97,7 +109,7 @@ test-server.crt:  test-server.csr test-ca.key test-ca.crt
 	openssl ca -batch -config demo-openssl.cnf -in test-server.csr -out test-server.crt -outdir . -keyfile test-ca.key -cert test-ca.crt -days 120
 
 clean:
-	rm -f *.o example1 websocket_server websocket_client fq-router echo_server echo_client aco
+	rm -f *.o example1 websocket_server websocket_client fq-router kafka_consumer kafka_producer echo_server echo_client aco
 	rm -rf demoCA
 	rm -f *.key *.crt *.csr *.pem
 

--- a/src/examples/Makefile.in
+++ b/src/examples/Makefile.in
@@ -40,7 +40,7 @@ WSS_OBJS=	websocket_server.o
 
 EXTRA_TARGETS=@EXTRA_EXAMPLES@
 
-all:	testcerts echo_server echo_client example1 aco kafka_producer kafka_consumer $(EXTRA_TARGETS)
+all:	testcerts echo_server echo_client example1 aco $(EXTRA_TARGETS)
 
 .c.o:
 	@echo "- compiling $<"

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -11,10 +11,9 @@
  *       copyright notice, this list of conditions and the following
  *       disclaimer in the documentation and/or other materials provided
  *       with the distribution.
- *     * Neither the name OmniTI Computer Consulting, Inc. nor the names
- *       of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written
- *       permission.
+ *     * Neither the name Apica, Inc. nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -36,6 +35,7 @@
 #include "mtev_defines.h"
 #include "mtev_dso.h"
 #include "mtev_events_rest.h"
+#include "mtev_kafka.h"
 #include "mtev_listener.h"
 #include "mtev_log.h"
 #include "mtev_main.h"
@@ -70,6 +70,14 @@ static void parse_cli_args(int argc, char *const *argv)
   }
 }
 
+static mtev_hook_return_t
+handle_kafka_message(void *closure, mtev_rd_kafka_message_t *msg)
+{
+  (void)closure;
+  (void)msg;
+  return MTEV_HOOK_CONTINUE;
+}
+
 static int child_main(void)
 {
   if (mtev_conf_load(NULL) == -1) {
@@ -85,6 +93,8 @@ static int child_main(void)
   mtev_cluster_init();
   mtev_dso_init();
   mtev_dso_post_init();
+
+  mtev_kafka_handle_message_hook_register(APPNAME, handle_kafka_message, NULL);
 
   eventer_loop();
   return 0;

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -42,14 +42,25 @@ static int foreground = 1;
 
 static int usage(const char *prog)
 {
-  fprintf(stderr, "%s <-c conffile> [-D] [-d]\n\n", prog);
+  fprintf(stderr, "%s <-c conffile> [-d]\n\n", prog);
+  fprintf(stderr, "\t-c conffile\tthe configuration file to load\n");
+  fprintf(stderr, "\t-d\t\tturn on debugging\n");
   return 2;
 }
 
 static void parse_cli_args(int argc, char *const *argv)
 {
-  (void) argc;
-  (void) argv;
+  int c;
+  while ((c = getopt(argc, argv, "c:d")) != EOF) {
+    switch (c) {
+    case 'c':
+      config_file = optarg;
+      break;
+    case 'd':
+      debug = 1;
+      break;
+    }
+  }
 }
 
 static int child_main(void)

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -70,11 +70,10 @@ static void parse_cli_args(int argc, char *const *argv)
   }
 }
 
-static mtev_hook_return_t
-handle_kafka_message(void *closure, mtev_rd_kafka_message_t *msg)
+static mtev_hook_return_t handle_kafka_message(void *closure, mtev_rd_kafka_message_t *msg)
 {
-  (void)closure;
-  (void)msg;
+  (void) closure;
+  (void) msg;
   return MTEV_HOOK_CONTINUE;
 }
 

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -26,6 +26,9 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This application sets up a kafka consumer and logs anything that comes in
+ * on the configured topic. The consumer can be set up in kafka_consumer.conf.
  */
 
 #include <stdio.h>

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -73,7 +73,7 @@ static mtev_hook_return_t handle_kafka_message(void *closure, mtev_rd_kafka_mess
 {
   (void) closure;
   (void) msg;
-  mtevL(mtev_error, "Received message from kafka: %s\n", (char *)msg->payload);
+  mtevL(mtev_error, "Received message from kafka: %s\n", (char *) msg->payload);
   return MTEV_HOOK_CONTINUE;
 }
 

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, Apica, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name OmniTI Computer Consulting, Inc. nor the names
+ *       of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written
+ *       permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "mtev_defines.h"
+#include "mtev_main.h"
+#include "mtev_memory.h"
+
+#define APPNAME "kafka_consumer"
+static char *config_file = NULL;
+static int debug = 0;
+static int foreground = 1;
+
+static int usage(const char *prog)
+{
+  fprintf(stderr, "%s <-c conffile> [-D] [-d]\n\n", prog);
+  return 2;
+}
+
+static void parse_cli_args(int argc, char *const *argv)
+{
+  (void) argc;
+  (void) argv;
+}
+
+static int child_main(void)
+{
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  parse_cli_args(argc, argv);
+  if (!config_file) {
+    exit(usage(argv[0]));
+  }
+  mtev_memory_init();
+  mtev_main(APPNAME, config_file, debug, foreground, MTEV_LOCK_OP_LOCK, NULL, NULL, NULL,
+            child_main);
+  return 0;
+}

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -73,7 +73,11 @@ static mtev_hook_return_t handle_kafka_message(void *closure, mtev_rd_kafka_mess
 {
   (void) closure;
   (void) msg;
-  mtevL(mtev_error, "Received message from kafka: %s\n", (char *) msg->payload);
+  mtevL(mtev_error,
+        "Received message from kafka: %s\n"
+        "     Topic: %s\n"
+        "  Protocol: %s\n",
+        (char *) msg->payload, msg->topic, msg->protocol);
   return MTEV_HOOK_CONTINUE;
 }
 

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -31,7 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "mtev_capabilities_listener.h"
-#include "mtev_cluster.h"
 #include "mtev_defines.h"
 #include "mtev_dso.h"
 #include "mtev_events_rest.h"
@@ -74,6 +73,7 @@ static mtev_hook_return_t handle_kafka_message(void *closure, mtev_rd_kafka_mess
 {
   (void) closure;
   (void) msg;
+  mtevL(mtev_error, "Received message from kafka: %s\n", (char *)msg->payload);
   return MTEV_HOOK_CONTINUE;
 }
 
@@ -89,7 +89,6 @@ static int child_main(void)
   mtev_capabilities_listener_init();
   mtev_events_rest_init();
   mtev_listener_init(APPNAME);
-  mtev_cluster_init();
   mtev_dso_init();
   mtev_dso_post_init();
 

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -31,9 +31,16 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "mtev_capabilities_listener.h"
+#include "mtev_cluster.h"
 #include "mtev_defines.h"
+#include "mtev_dso.h"
+#include "mtev_events_rest.h"
+#include "mtev_listener.h"
+#include "mtev_log.h"
 #include "mtev_main.h"
 #include "mtev_memory.h"
+#include "mtev_rest.h"
 
 #define APPNAME "kafka_consumer"
 static char *config_file = NULL;
@@ -65,6 +72,21 @@ static void parse_cli_args(int argc, char *const *argv)
 
 static int child_main(void)
 {
+  if (mtev_conf_load(NULL) == -1) {
+    mtevL(mtev_error, "Cannot load config: '%s'\n", config_file);
+    exit(2);
+  }
+  eventer_init();
+  mtev_console_init(APPNAME);
+  mtev_http_rest_init();
+  mtev_capabilities_listener_init();
+  mtev_events_rest_init();
+  mtev_listener_init(APPNAME);
+  mtev_cluster_init();
+  mtev_dso_init();
+  mtev_dso_post_init();
+
+  eventer_loop();
   return 0;
 }
 

--- a/src/examples/kafka_consumer.c
+++ b/src/examples/kafka_consumer.c
@@ -74,7 +74,8 @@ static mtev_hook_return_t handle_kafka_message(void *closure, mtev_rd_kafka_mess
   (void) closure;
   (void) msg;
   mtevL(mtev_error,
-        "Received message from kafka: %s\n"
+        "Received message:\n"
+        "   Payload: %s\n"
         "     Topic: %s\n"
         "  Protocol: %s\n",
         (char *) msg->payload, msg->topic, msg->protocol);

--- a/src/examples/kafka_consumer.conf
+++ b/src/examples/kafka_consumer.conf
@@ -32,12 +32,6 @@
     </components>
   </logs>
   <listeners>
-    <sslconfig>
-      <optional_no_ca>false</optional_no_ca>
-      <certificate_file>/path/to/server.crt</certificate_file>
-      <key_file>/path/to/server.key</key_file>
-      <ca_chain>/path/to/ca.crt</ca_chain>
-    </sslconfig>
     <consoles type="mtev_console">
       <listener address="*" port="32322">
         <config>
@@ -45,19 +39,15 @@
         </config>
       </listener>
     </consoles>
-    <listener type="http_rest_api" address="*" port="8888" ssl="off">
-      <config>
-        <document_root>/path/to/docroot</document_root>
-      </config>
-    </listener>
+    <listener type="http_rest_api" address="*" port="8887" ssl="off"/>
   </listeners>
   <network>
     <in>
       <mq type="kafka">
         <host>localhost</host>
-	<port>9092</port>
-	<consumer_group>kafka_consumer_group_id</consumer_group>
-	<topic>libmtev_test_kafka_topic</topic>
+	      <port>9092</port>
+	      <consumer_group>kafka_consumer_group_id</consumer_group>
+	      <topic>libmtev_test_kafka_topic</topic>
       </mq>
     </in>
     <out>

--- a/src/examples/kafka_consumer.conf
+++ b/src/examples/kafka_consumer.conf
@@ -45,9 +45,9 @@
     <in>
       <mq type="kafka">
         <host>localhost</host>
-	      <port>9092</port>
-	      <consumer_group>kafka_consumer_group_id</consumer_group>
-	      <topic>libmtev_test_kafka_topic</topic>
+        <port>9092</port>
+        <consumer_group>kafka_consumer_group_id</consumer_group>
+        <topic>libmtev_test_kafka_topic</topic>
       </mq>
     </in>
     <out>

--- a/src/examples/kafka_consumer.conf
+++ b/src/examples/kafka_consumer.conf
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<kafka_consumer lockfile="/var/tmp/kafka_consumer.lock">
+  <eventer>
+    <config>
+      <concurrency>4</concurrency>
+      <default_queue_threads>10</default_queue_threads>
+      <default_ca_chain>/etc/default-ca-chain.crt</default_ca_chain>
+    </config>
+  </eventer>
+  <modules directory="../modules">
+    <generic image="kafka" name="kafka" />
+  </modules>
+  <logs>
+    <log name="internal" type="memory" path="10000,100000"/>
+    <log name="logfile" type="file" path="/var/tmp/kafka_consumer.log"/>
+    <console_output>
+      <outlet name="stderr"/>
+      <outlet name="internal"/>
+      <outlet name="logfile"/>
+      <log name="error" disabled="false"/>
+      <log name="debug" disabled="true"/>
+    </console_output>
+    <components>
+      <error>
+        <outlet name="error"/>
+        <log name="error/example"/>
+      </error>
+      <debug>
+        <outlet name="debug"/>
+        <log name="debug/example"/>
+      </debug>
+    </components>
+  </logs>
+  <listeners>
+    <sslconfig>
+      <optional_no_ca>false</optional_no_ca>
+      <certificate_file>/path/to/server.crt</certificate_file>
+      <key_file>/path/to/server.key</key_file>
+      <ca_chain>/path/to/ca.crt</ca_chain>
+    </sslconfig>
+    <consoles type="mtev_console">
+      <listener address="*" port="32322">
+        <config>
+          <line_protocol>telnet</line_protocol>
+        </config>
+      </listener>
+    </consoles>
+    <listener type="http_rest_api" address="*" port="8888" ssl="off">
+      <config>
+        <document_root>/path/to/docroot</document_root>
+      </config>
+    </listener>
+  </listeners>
+  <network>
+    <in>
+      <mq type="kafka">
+        <host>localhost</host>
+	<port>9092</port>
+	<consumer_group>kafka_consumer_group_id</consumer_group>
+	<topic>libmtev_test_kafka_topic</topic>
+      </mq>
+    </in>
+    <out>
+    </out>
+  </network>
+</kafka_consumer>

--- a/src/examples/kafka_consumer.conf
+++ b/src/examples/kafka_consumer.conf
@@ -53,4 +53,9 @@
     <out>
     </out>
   </network>
+  <rest>
+    <acl>
+      <rule type="allow" />
+    </acl>
+  </rest>
 </kafka_consumer>

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -42,14 +42,25 @@ static int foreground = 1;
 
 static int usage(const char *prog)
 {
-  fprintf(stderr, "%s <-c conffile> [-D] [-d]\n\n", prog);
+  fprintf(stderr, "%s <-c conffile> [-d]\n\n", prog);
+  fprintf(stderr, "\t-c conffile\tthe configuration file to load\n");
+  fprintf(stderr, "\t-d\t\tturn on debugging\n");
   return 2;
 }
 
 static void parse_cli_args(int argc, char *const *argv)
 {
-  (void) argc;
-  (void) argv;
+  int c;
+  while ((c = getopt(argc, argv, "c:d")) != EOF) {
+    switch (c) {
+    case 'c':
+      config_file = optarg;
+      break;
+    case 'd':
+      debug = 1;
+      break;
+    }
+  }
 }
 
 static int child_main(void)

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Apica, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name OmniTI Computer Consulting, Inc. nor the names
+ *       of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written
+ *       permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "mtev_defines.h"
+#include "mtev_main.h"
+#include "mtev_memory.h"
+
+#define APPNAME "kafka_producer"
+static char *config_file = NULL;
+static int debug = 0;
+static int foreground = 1;
+
+static int usage(const char *prog)
+{
+  fprintf(stderr, "%s <-c conffile> [-D] [-d]\n\n", prog);
+  return 2;
+}
+
+static void parse_cli_args(int argc, char *const *argv)
+{
+  (void) argc;
+  (void) argv;
+}
+
+static int child_main(void)
+{
+  return 0;
+}
+
+int main(int argc, char **argv)
+{
+  parse_cli_args(argc, argv);
+  if (!config_file) {
+    exit(usage(argv[0]));
+  }
+  mtev_memory_init();
+  mtev_main(APPNAME, config_file, debug, foreground, MTEV_LOCK_OP_LOCK, NULL, NULL, NULL,
+            child_main);
+}

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -31,7 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "mtev_capabilities_listener.h"
-#include "mtev_cluster.h"
 #include "mtev_defines.h"
 #include "mtev_dso.h"
 #include "mtev_events_rest.h"
@@ -100,11 +99,10 @@ static int child_main(void)
   mtev_capabilities_listener_init();
   mtev_events_rest_init();
   mtev_listener_init(APPNAME);
-  mtev_cluster_init();
   mtev_dso_init();
   mtev_dso_post_init();
 
-  mtev_http_rest_register("POST", "/", "^(.*)$", handle_post_data);
+  mtev_http_rest_register("POST", "/", "^data$", handle_post_data);
 
   eventer_loop();
   return 0;

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -31,9 +31,16 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include "mtev_capabilities_listener.h"
+#include "mtev_cluster.h"
 #include "mtev_defines.h"
+#include "mtev_dso.h"
+#include "mtev_events_rest.h"
+#include "mtev_listener.h"
+#include "mtev_log.h"
 #include "mtev_main.h"
 #include "mtev_memory.h"
+#include "mtev_rest.h"
 
 #define APPNAME "kafka_producer"
 static char *config_file = NULL;
@@ -65,6 +72,21 @@ static void parse_cli_args(int argc, char *const *argv)
 
 static int child_main(void)
 {
+  if (mtev_conf_load(NULL) == -1) {
+    mtevL(mtev_error, "Cannot load config: '%s'\n", config_file);
+    exit(2);
+  }
+  eventer_init();
+  mtev_console_init(APPNAME);
+  mtev_http_rest_init();
+  mtev_capabilities_listener_init();
+  mtev_events_rest_init();
+  mtev_listener_init(APPNAME);
+  mtev_cluster_init();
+  mtev_dso_init();
+  mtev_dso_post_init();
+
+  eventer_loop();
   return 0;
 }
 

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -11,10 +11,9 @@
  *       copyright notice, this list of conditions and the following
  *       disclaimer in the documentation and/or other materials provided
  *       with the distribution.
- *     * Neither the name OmniTI Computer Consulting, Inc. nor the names
- *       of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written
- *       permission.
+ *     * Neither the name Apica, Inc. nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -26,6 +26,10 @@
  * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This application sets up a kafka producer, sets up a REST endpoint, and
+ * sends anything posted to that endpoint to all configured producers.
+ * Producers can be set up in kafka_producer.conf.
  */
 
 #include <stdio.h>

--- a/src/examples/kafka_producer.c
+++ b/src/examples/kafka_producer.c
@@ -102,7 +102,7 @@ static int child_main(void)
   mtev_dso_init();
   mtev_dso_post_init();
 
-  mtev_http_rest_register("POST", "/", "^data$", handle_post_data);
+  mtev_http_rest_register("POST", "/", "^(.*)$", handle_post_data);
 
   eventer_loop();
   return 0;

--- a/src/examples/kafka_producer.conf
+++ b/src/examples/kafka_producer.conf
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf8" standalone="yes"?>
-<kafka_producer lockfile="/var/tmp/kafka_consumer.lock">
+<kafka_producer lockfile="/var/tmp/kafka_producer.lock">
   <eventer>
     <config>
       <concurrency>4</concurrency>
@@ -12,7 +12,7 @@
   </modules>
   <logs>
     <log name="internal" type="memory" path="10000,100000"/>
-    <log name="logfile" type="file" path="/var/tmp/kafka_consumer.log"/>
+    <log name="logfile" type="file" path="/var/tmp/kafka_producer.log"/>
     <console_output>
       <outlet name="stderr"/>
       <outlet name="internal"/>

--- a/src/examples/kafka_producer.conf
+++ b/src/examples/kafka_producer.conf
@@ -47,8 +47,8 @@
     <out>
       <mq type="kafka">
         <host>localhost</host>
-	      <port>9092</port>
-	      <topic>libmtev_test_kafka_topic</topic>
+        <port>9092</port>
+        <topic>libmtev_test_kafka_topic</topic>
       </mq>
     </out>
     <out>

--- a/src/examples/kafka_producer.conf
+++ b/src/examples/kafka_producer.conf
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf8" standalone="yes"?>
+<kafka_producer lockfile="/var/tmp/kafka_consumer.lock">
+  <eventer>
+    <config>
+      <concurrency>4</concurrency>
+      <default_queue_threads>10</default_queue_threads>
+      <default_ca_chain>/etc/default-ca-chain.crt</default_ca_chain>
+    </config>
+  </eventer>
+  <modules directory="../modules">
+    <generic image="kafka" name="kafka" />
+  </modules>
+  <logs>
+    <log name="internal" type="memory" path="10000,100000"/>
+    <log name="logfile" type="file" path="/var/tmp/kafka_consumer.log"/>
+    <console_output>
+      <outlet name="stderr"/>
+      <outlet name="internal"/>
+      <outlet name="logfile"/>
+      <log name="error" disabled="false"/>
+      <log name="debug" disabled="true"/>
+    </console_output>
+    <components>
+      <error>
+        <outlet name="error"/>
+        <log name="error/example"/>
+      </error>
+      <debug>
+        <outlet name="debug"/>
+        <log name="debug/example"/>
+      </debug>
+    </components>
+  </logs>
+  <listeners>
+    <sslconfig>
+      <optional_no_ca>false</optional_no_ca>
+      <certificate_file>/path/to/server.crt</certificate_file>
+      <key_file>/path/to/server.key</key_file>
+      <ca_chain>/path/to/ca.crt</ca_chain>
+    </sslconfig>
+    <consoles type="mtev_console">
+      <listener address="*" port="32322">
+        <config>
+          <line_protocol>telnet</line_protocol>
+        </config>
+      </listener>
+    </consoles>
+    <listener type="http_rest_api" address="*" port="8888" ssl="off">
+      <config>
+        <document_root>/path/to/docroot</document_root>
+      </config>
+    </listener>
+  </listeners>
+  <network>
+    <in>
+    </in>
+    <out>
+      <mq type="kafka">
+        <host>localhost</host>
+	<port>9092</port>
+	<topic>libmtev_test_kafka_topic</topic>
+      </mq>
+    </out>
+    <out>
+    </out>
+  </network>
+</kafka_producer>

--- a/src/examples/kafka_producer.conf
+++ b/src/examples/kafka_producer.conf
@@ -54,4 +54,9 @@
     <out>
     </out>
   </network>
+  <rest>
+    <acl>
+      <rule type="allow" />
+    </acl>
+  </rest>
 </kafka_producer>

--- a/src/examples/kafka_producer.conf
+++ b/src/examples/kafka_producer.conf
@@ -32,24 +32,14 @@
     </components>
   </logs>
   <listeners>
-    <sslconfig>
-      <optional_no_ca>false</optional_no_ca>
-      <certificate_file>/path/to/server.crt</certificate_file>
-      <key_file>/path/to/server.key</key_file>
-      <ca_chain>/path/to/ca.crt</ca_chain>
-    </sslconfig>
     <consoles type="mtev_console">
-      <listener address="*" port="32322">
+      <listener address="*" port="32323">
         <config>
           <line_protocol>telnet</line_protocol>
         </config>
       </listener>
     </consoles>
-    <listener type="http_rest_api" address="*" port="8888" ssl="off">
-      <config>
-        <document_root>/path/to/docroot</document_root>
-      </config>
-    </listener>
+    <listener type="http_rest_api" address="*" port="8888" ssl="off"/>
   </listeners>
   <network>
     <in>
@@ -57,8 +47,8 @@
     <out>
       <mq type="kafka">
         <host>localhost</host>
-	<port>9092</port>
-	<topic>libmtev_test_kafka_topic</topic>
+	      <port>9092</port>
+	      <topic>libmtev_test_kafka_topic</topic>
       </mq>
     </out>
     <out>

--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -93,6 +93,7 @@ static void mtev_rd_kafka_message_free(mtev_rd_kafka_message_t *msg)
 static mtev_rd_kafka_message_t *
   mtev_rd_kafka_message_alloc(rd_kafka_message_t *msg,
                               const char *protocol,
+                              const char *topic,
                               const mtev_hash_table *extra_configs,
                               void (*free_func)(struct mtev_rd_kafka_message *))
 {
@@ -108,6 +109,7 @@ static mtev_rd_kafka_message_t *
   m->offset = msg->offset;
   m->partition = msg->partition;
   m->protocol = protocol;
+  m->topic = topic;
   m->extra_configs = extra_configs;
   return m;
 }
@@ -648,7 +650,8 @@ public:
         per_conn_cnt++;
         if (msg->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
           mtev_rd_kafka_message_t *m = mtev_rd_kafka_message_alloc(
-            msg, consumer->protocol.c_str(), consumer->extra_configs, mtev_rd_kafka_message_free);
+            msg, consumer->protocol.c_str(), consumer->common_fields.topic.c_str(),
+            consumer->extra_configs, mtev_rd_kafka_message_free);
           mtev_kafka_handle_message_dyn_hook_invoke(m);
           mtev_rd_kafka_message_deref(m);
         }

--- a/src/modules/mtev_kafka.h
+++ b/src/modules/mtev_kafka.h
@@ -110,6 +110,7 @@ typedef struct mtev_rd_kafka_message {
   int64_t offset;
   int32_t partition;
   const char *protocol;
+  const char *topic;
   const mtev_hash_table *extra_configs;
   void (*free_fn)(struct mtev_rd_kafka_message *m);
 } mtev_rd_kafka_message_t;


### PR DESCRIPTION
Add a kafka_producer and kafka_consumer test program that allows setting up both a consumer and producer and using them to send and receive messages.

Added topic to consumer hook to make it clear where messages came from.