### PR TITLE
Switch Timezone Test To Use America/New_York

### DIFF
--- a/test/lua-tests/timezone_spec.lua
+++ b/test/lua-tests/timezone_spec.lua
@@ -9,8 +9,8 @@ describe("test timezones", function()
     assert.are.equal(hour, uhour)
   end)
 
-  it("Can use US/Eastern", function()
-    local zi = mtev.timezone("US/Eastern")
+  it("Can use America/New_York", function()
+    local zi = mtev.timezone("America/New_York")
     assert.is_not_nil(zi)
     local month, hour, year, dst, zonename =
       zi:extract(1520197275, 'month', 'hour', 'year', 'dst', 'zonename') -- Sun Mar  4 21:01:15 2018 UTC 


### PR DESCRIPTION
US/Eastern is a symlink to America/New_York and is no longer support in some later tzinfo packages. Switch the test to explicitly check for America/New_York, which is.