### PR TITLE
In Kafka Module, manual_commit_asynch Defaults To True

### DIFF
--- a/src/modules/mtev_kafka.cpp
+++ b/src/modules/mtev_kafka.cpp
@@ -433,7 +433,7 @@ struct kafka_consumer {
       }
     }
     else {
-      manual_commit_asynch = false;
+      manual_commit_asynch = true;
     }
 
     constexpr size_t error_string_size = 256;


### PR DESCRIPTION
manual_commit_asynch should default to true to avoid getting hung up waiting on synchronous commits.